### PR TITLE
FIxed User OTP Signup - Roles Bug

### DIFF
--- a/auth/.env.example
+++ b/auth/.env.example
@@ -27,6 +27,8 @@ GOOGLE_REVOKE_CREDENTIALS_URL=https://oauth2.googleapis.com/revoke
 GOOGLE_API_VERSION=v2
 GOOGLE_API_SERVICE_NAME=drive
 GOOGLE_SCOPES="openid https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/drive.metadata.readonly https://www.googleapis.com/auth/forms.body.readonly https://www.googleapis.com/auth/forms.responses.readonly"
+OAUTHLIB_INSECURE_TRANSPORT=1
+OAUTHLIB_RELAX_TOKEN_SCOPE=1
 
 #Typeform
 TYPEFORM_CLIENT_ID=

--- a/auth/auth/app/schemas/user.py
+++ b/auth/auth/app/schemas/user.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from beanie import Indexed
 from common.configs.mongo_document import MongoDocument
 from common.enums.plan import Plans
+from common.enums.roles import Roles
 
 from auth.app.services.database_service import entity
 
@@ -14,7 +15,7 @@ class UserDocument(MongoDocument):
     last_name: Optional[str]
     profile_image: Optional[str]
     email: Indexed(str, unique=True)
-    roles: Optional[List[str]]
+    roles: Optional[List[str]] = []
     otp_code: Optional[str]
     otp_expiry: Optional[int]
     otp_code_for: Optional[str]

--- a/auth/auth/app/schemas/user.py
+++ b/auth/auth/app/schemas/user.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from beanie import Indexed
 from common.configs.mongo_document import MongoDocument
 from common.enums.plan import Plans
-from common.enums.roles import Roles
+
 
 from auth.app.services.database_service import entity
 


### PR DESCRIPTION
The OTP signup assigned default user role as null . The null value blocked user role assignment and the signup/validation process . Assigning default user role as an empty array fixed the bug.

The Google Oauth sign up was missing oauthlib insecure transport and oauth relax token scope which was causing proxy error in local dev environment. Added them to auth/.env.example
