### PR TITLE
Fix/api_environment_var

### DIFF
--- a/webapp/src/app/[workspace_name]/forms/[form_id]/layout.tsx
+++ b/webapp/src/app/[workspace_name]/forms/[form_id]/layout.tsx
@@ -45,7 +45,7 @@ export default function Layout({ children, params }: { children: React.ReactNode
 }
 
 async function FormWrapper({ workspaceName, formId, children }: { workspaceName: string; formId: string; children: React.ReactNode }) {
-    const workspaceResponse = await fetch(process.env.INTERNAL_DOCKER_API_ENDPOINT_HOST + '/workspaces?workspace_name=' + workspaceName, { next: { revalidate: 300 } });
+    const workspaceResponse = await fetch(environments.INTERNAL_DOCKER_API_ENDPOINT_HOST + '/workspaces?workspace_name=' + workspaceName, { next: { revalidate: 300 } });
     const workspace = await workspaceResponse.json();
 
     const config = {


### PR DESCRIPTION
**Bug Issue**
FormWrapper function was trying to access INTERNAL_DOCKER_API_ENDPOINT environment variable directly which was not set and thus making it undefined. This caused fetch error in development. This unset variable was handled in environments.tsx file but was not being used in this function.

**Fix**
Replaced process.env. with INTERNAL_DOCKER_API_ENDPOINT from environment's file.