### PR TITLE
Fix forms-listing 503 and React 19 form-rendering crash

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -873,16 +873,16 @@ wheels = [
 
 [[package]]
 name = "fastapi-pagination"
-version = "0.15.10"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/36/4314836683bec1b33195bbaf2d74e1515cfcbb7e7ef5431ef515b864a5d0/fastapi_pagination-0.15.10.tar.gz", hash = "sha256:0ba7d4f795059a91a9e89358af129f2114876452c1defaf198ea8e3419e9a3cd", size = 575160, upload-time = "2026-02-08T13:13:40.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/79/826b79dd718b0d9a91f21c3cfed365e5ecf44bc31419615c4cebeebb9ada/fastapi_pagination-0.15.15.tar.gz", hash = "sha256:d6e9e4bc4d6e20709dcabc11b16056cd5cd184c995ee214b0190f6b81426fa0c", size = 614873, upload-time = "2026-06-16T17:25:44.055Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/95/cce73569317fdba138c315b980c39c6a035baa0ea5867d12276f1d312cff/fastapi_pagination-0.15.10-py3-none-any.whl", hash = "sha256:d50071ebc93b519391f16ff6c3ba9e3603bd659963fe6774ba2f4d5037e17fd8", size = 60798, upload-time = "2026-02-08T13:13:41.972Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/2e794ea498515afdadf2891f89aaed404de3ed619dd9cbf1ca637f17df19/fastapi_pagination-0.15.15-py3-none-any.whl", hash = "sha256:dc828d7cd15614c650c284bd2c3a98a8a2d9ce340508be3970dc8986908a02aa", size = 65864, upload-time = "2026-06-16T17:25:42.734Z" },
 ]
 
 [[package]]

--- a/webapp/src/components/hocs/field-input-wrapper.tsx
+++ b/webapp/src/components/hocs/field-input-wrapper.tsx
@@ -29,10 +29,11 @@ const FieldInputWrapper = ({ id, slide, value, onChange, type = 'text', style, i
     }, [value]);
 
     const Component: typeof OptionInput | typeof FieldInput = isOptionsInput ? OptionInput : FieldInput;
+    const { theme } = useFormState();
 
     return (
         <>
-            <Component id={id} type={type} value={inputVal} style={style} onChange={(e: any) => setInputVal(e.target.value)} {...props} />
+            <Component id={id} type={type} value={inputVal} style={style} $formTheme={theme} onChange={(e: any) => setInputVal(e.target.value)} {...props} />
         </>
     );
 };
@@ -40,10 +41,11 @@ const FieldInputWrapper = ({ id, slide, value, onChange, type = 'text', style, i
 const OptionInput = styled(Input)<{
     $slide?: StandardFormFieldDto;
     $formTheme?: IThemeState;
-}>(({}) => {
-    const { theme } = useFormState();
-    const tertiaryColor = theme?.tertiary;
-    const secondaryColor = theme?.secondary;
+}>(({ $formTheme }) => {
+    // See note in text-area-field.tsx: theme is passed as a prop, not read via a
+    // hook inside the styled interpolation (avoids "Rendered fewer hooks").
+    const tertiaryColor = $formTheme?.tertiary;
+    const secondaryColor = $formTheme?.secondary;
     return {
         background: 'inherit',
         borderColor: tertiaryColor,

--- a/webapp/src/shadcn/components/ui/input.tsx
+++ b/webapp/src/shadcn/components/ui/input.tsx
@@ -10,7 +10,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
     textColor?: string;
 }
 
-const ShadCNInput = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+const ShadCNInput = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, value, ...props }, ref) => {
     const { theme } = useFormState();
 
     return (
@@ -21,6 +21,8 @@ const ShadCNInput = React.forwardRef<HTMLInputElement, InputProps>(({ className,
             type={type}
             className={cn(`w-full border-0 border-b-[1px] px-0 py-2 text-[28px] disabled:cursor-not-allowed disabled:opacity-50 lg:text-[32px]`, className)}
             ref={ref}
+            // Coerce null -> '' so a controlled input never receives a null value.
+            value={value === null ? '' : value}
             {...props}
         />
     );
@@ -43,10 +45,11 @@ AppInput.displayName = 'AppInput';
 const FieldInput = styled(ShadCNInput)<{
     $slide?: StandardFormFieldDto;
     $formTheme?: IThemeState;
-}>(({ }) => {
-    const { theme } = useFormState();
-    const themeColor = theme?.tertiary;
-    const secondaryColor = theme?.secondary;
+}>(({ $formTheme }) => {
+    // Theme comes in as a prop; calling useFormState() inside a styled-components
+    // interpolation yields an inconsistent hook count under React 19.
+    const themeColor = $formTheme?.tertiary;
+    const secondaryColor = $formTheme?.secondary;
     return {
         background: 'inherit',
         borderColor: themeColor,

--- a/webapp/src/shadcn/components/ui/scroll-area.tsx
+++ b/webapp/src/shadcn/components/ui/scroll-area.tsx
@@ -10,12 +10,12 @@ type ExtendedScrollbarProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
     thumbBg?: string; // or whatever type thumbBg should be
 };
 
-const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & ExtendedScrollbarProps>(({ className, children, asChild, id, ...props }, ref) => (
+const ScrollArea = React.forwardRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>, React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & ExtendedScrollbarProps>(({ className, children, asChild, id, thumbBg, ...props }, ref) => (
     <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
         <ScrollAreaPrimitive.Viewport style={{ display: 'block !important' }} asChild={asChild} id={id} className="!block h-full w-full rounded-[inherit]">
             {children}
         </ScrollAreaPrimitive.Viewport>
-        <ScrollBar thumbBg={props.thumbBg} />
+        <ScrollBar thumbBg={thumbBg} />
         <ScrollAreaPrimitive.Corner />
     </ScrollAreaPrimitive.Root>
 ));

--- a/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
@@ -3,7 +3,7 @@ import 'react-phone-input-2/lib/style.css';
 import styled from 'styled-components';
 
 import { StandardFormFieldDto } from '@app/models/dtos/form';
-import { useFormState } from '@app/store/jotai/form';
+import { IThemeState, useFormState } from '@app/store/jotai/form';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
 import { getPlaceholderValueForField } from '@app/utils/form-utils';
@@ -13,10 +13,10 @@ import { useAppSelector } from '@app/store/hooks';
 import { scrollToDivById } from '@app/utils/scroll-utils';
 import QuestionWrapper from './question-wrapper';
 
-const CustomPhoneInputField = styled(PhoneInput)(() => {
-    const { theme } = useFormState();
-    const tertiaryColor = theme?.tertiary;
-    const accentColor = theme?.accent;
+const CustomPhoneInputField = styled(PhoneInput)<{ $formTheme?: IThemeState }>(({ $formTheme }) => {
+    // Theme is passed as a prop; a hook inside the styled interpolation breaks
+    // the hook count under React 19 ("Rendered fewer hooks").
+    const accentColor = $formTheme?.accent;
 
     return {
         '.selected-flag': {
@@ -48,6 +48,7 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                 }}
             >
                 <CustomPhoneInputField
+                    $formTheme={theme}
                     value={(formResponse.answers && formResponse.answers[field.id]?.phone_number) || ''}
                     onChange={(e) => handleChange(e)}
                     country={'np'}

--- a/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
@@ -16,10 +16,12 @@ import QuestionWrapper from './question-wrapper';
 const StyledAutoSizeTextArea = styled(AutosizeTextarea)<{
     $slide?: StandardFormFieldDto;
     $formTheme?: IThemeState;
-}>(({ }) => {
-    const { theme } = useFormState();
-    const themeColor = theme?.tertiary;
-    const secondaryColor = theme?.secondary;
+}>(({ $formTheme }) => {
+    // Theme is passed as a prop; calling the useFormState() hook inside a
+    // styled-components interpolation produces an inconsistent hook count under
+    // React 19 ("Rendered fewer hooks than expected").
+    const themeColor = $formTheme?.tertiary;
+    const secondaryColor = $formTheme?.secondary;
     return {
         background: 'inherit',
         borderColor: themeColor,
@@ -39,6 +41,7 @@ export default function TextAreaField({ field }: { field: StandardFormFieldDto }
 
     const form: StandardFormDto = useAppSelector(selectForm);
     const { currentSlide } = useResponderState();
+    const { theme } = useFormState();
 
     const [debouncedInputValue] = useDebounceValue(inputVal, 300);
 
@@ -59,6 +62,7 @@ export default function TextAreaField({ field }: { field: StandardFormFieldDto }
                 }}
             >
                 <StyledAutoSizeTextArea
+                    $formTheme={theme}
                     rows={1}
                     value={inputVal}
                     onChange={(e) => setInputVal(e.target.value)}

--- a/webapp/src/views/organism/form-builder/fields/matrix.tsx
+++ b/webapp/src/views/organism/form-builder/fields/matrix.tsx
@@ -180,6 +180,7 @@ function MatrixFieldComponent({ field, disabled }: IMatrixFieldProps) {
 
 const MatrixHeaderInput = ({ value, onChange, disabled, placeholder }: { value: string; onChange?: (value: string) => void; disabled?: boolean; placeholder?: string }) => {
     const [inputVal, setInputVal] = useState(value);
+    const { theme } = useFormState();
 
     const [debouncedInputValue] = useDebounceValue(inputVal, 300);
     useEffect(() => {
@@ -192,6 +193,7 @@ const MatrixHeaderInput = ({ value, onChange, disabled, placeholder }: { value: 
 
     return (
         <StyledMatrixHeaderInput
+            $theme={theme}
             className={cn('ring-none focus:ring-none items-center border-none bg-transparent text-center text-sm outline-none focus:!border-none focus:outline-none focus-visible:outline-none active:outline-none', disabled && 'pointer-events-none')}
             placeholder={placeholder || 'Header'}
             value={inputVal}
@@ -201,10 +203,10 @@ const MatrixHeaderInput = ({ value, onChange, disabled, placeholder }: { value: 
         />
     );
 };
-const StyledMatrixHeaderInput = styled(AppInput)<{ $theme?: IThemeState }>(() => {
-    const { theme } = useFormState();
-    const themeColor = theme?.tertiary;
-    const secondaryColor = theme?.secondary;
+const StyledMatrixHeaderInput = styled(AppInput)<{ $theme?: IThemeState }>(({ $theme }) => {
+    // Theme via prop; avoid calling useFormState() inside the styled interpolation.
+    const themeColor = $theme?.tertiary;
+    const secondaryColor = $theme?.secondary;
     return {
         resize: 'none',
         overflow: 'auto',


### PR DESCRIPTION
Follow-up to #502 (Dependabot fixes). Two issues found while verifying the app after that upgrade — the security PR merged before these landed.

## 1. Forms listing (and every paginated screen) returned 503
Bumping starlette (0.52→1.3.1) / fastapi (→0.139) in #502 broke `fastapi-pagination 0.15.10`: `add_pagination`'s per-request `ContextVar` was no longer propagated to endpoints, so paginated routes threw `UninitializedConfigurationError` and 503'd. The forms dashboard showed "2/100" (from the non-paginated stats call) but an empty list.

**Fix:** bump `fastapi-pagination` to 0.15.15. Verified: the forms dashboard and all paginated screens (responders, deletion requests, members) now return 200 and render their data.

## 2. Form preview / responder fill crashed on long-text fields
`Rendered fewer hooks than expected` crashed the preview and public fill-form for any form with a long-text field. Several field components call the `useFormState()` hook **inside a styled-components interpolation**; styled v6 can memoize and skip that interpolation on a re-render, changing the hook count. Fixed by passing the theme as a `$`-transient prop instead, in: `text-area-field`, `input` (FieldInput), `field-input-wrapper` (OptionInput), `phone-number-field`, `matrix`.

Also, two DOM-prop console errors in shared components: `scroll-area` leaked `thumbBg` to the DOM (now destructured out), and `input` now coerces a `null` value to `''`.

## Verification
Full click-through of the dashboard: **103 backend requests, all 200**; form preview renders; `yarn build` compiles/type-checks cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)