### PR TITLE
Speed up backend test suite (~137s → ~5s)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,4 +57,8 @@ build-backend = "hatchling.build"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+# Share a single session-scoped event loop so the session-scoped app/DB fixtures
+# (see tests/conftest.py) stay valid across every test.
+asyncio_default_fixture_loop_scope = "session"
+asyncio_default_test_loop_scope = "session"
 testpaths = ["tests"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import httpx
 import pymongo
 import pytest
+import pytest_asyncio
 from common.models.form_import import FormImportResponse
 from common.models.standard_form import StandardForm, StandardFormResponse
 from dotenv import load_dotenv
@@ -47,10 +48,16 @@ def _drop_test_db() -> None:
     sync_client.close()
 
 
-@pytest.fixture()
-async def client():
-    # Everything runs in pytest-asyncio's event loop so AsyncMongoClient is
-    # never passed between event loops (avoids the "different event loop" error).
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def _initialized_app():
+    """Initialise the app (and Beanie) exactly once for the whole test session.
+
+    Re-running the ASGI lifespan per test was the dominant cost of the suite:
+    `init_beanie` recreates indexes for every collection on each call. Everything
+    shares one session-scoped event loop (see the asyncio settings in
+    pyproject.toml) so the AsyncMongoClient created here stays valid for all
+    tests — the reason this was previously done per-test.
+    """
     original_uri = settings.mongo_settings.URI
     original_db = settings.mongo_settings.DB
     settings.mongo_settings.URI = TEST_MONGO_URI
@@ -60,19 +67,34 @@ async def client():
     _drop_test_db()
 
     app = get_application(is_test_mode=True)
-    # Manually run the ASGI lifespan in the current (pytest) event loop.
-    # This creates the AsyncMongoClient and initialises beanie here, so all
-    # fixtures that do DB work share the same event loop.
     async with lifespan(app):
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app), base_url="http://test"
-        ) as ac:
-            yield ac
+        yield app
 
     _drop_test_db()
     settings.mongo_settings.URI = original_uri
     settings.mongo_settings.DB = original_db
     container.database_client.reset_override()
+
+
+@pytest_asyncio.fixture(autouse=True, loop_scope="session")
+async def _clean_db(_initialized_app):
+    """Reset data before each test without re-initialising Beanie.
+
+    Clearing documents (rather than dropping the database) keeps the indexes and
+    collections created by the one-time init, so per-test setup stays cheap.
+    """
+    db = container.database_client()[TEST_MONGO_DB]
+    for name in await db.list_collection_names():
+        await db[name].delete_many({})
+    yield
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def client(_initialized_app):
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_initialized_app), base_url="http://test"
+    ) as ac:
+        yield ac
 
 
 @pytest.fixture()


### PR DESCRIPTION
Optimizes the backend test infrastructure so the suite runs in **~5 seconds instead of ~137**, with no change to what's tested (129 passing).

## Why it was slow

The `client` fixture was **function-scoped** and re-ran the entire ASGI lifespan on **every test**. The dominant cost was `init_beanie(...)`, which recreates the indexes for all 13+ collections each time it runs — so that happened 129 times. Each test also dropped the whole test database twice (setup + teardown). Profiling showed **~0.85 s of fixture *setup* per test**, with the test bodies themselves taking near-zero.

A compounding bug: `init_db()` does `document_models.extend([...])` on a module-global list and ran once per test, so the model list accumulated duplicates and Beanie got slower on each successive test. (Harmless in production, where `init_db` runs once.)

## The change

Initialise the app + Beanie **once per session**, and isolate tests by clearing data rather than reinitialising:

- **`_initialized_app`** (session-scoped): runs the app lifespan a single time.
- **`_clean_db`** (autouse, per-test): `delete_many({})` on each collection — clears data while keeping the one-time indexes/collections.
- **`client`**: now just the httpx client; no lifespan re-run.
- **`pyproject.toml`**: `asyncio_default_fixture_loop_scope` / `asyncio_default_test_loop_scope = "session"` so the session-scoped `AsyncMongoClient` stays on one event loop across all tests (the reason init used to be per-test).

No production code changed — only `tests/conftest.py` and the pytest config.

## Verification

Against a `mongo:7` service identical to CI:
- **129 passed in ~5 s** (down from ~137 s)
- Stable across repeated runs **and randomized order** (`pytest-randomly`), so there's no order dependence from the shared session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)