### PR TITLE
fix(backend): construct OpenAI client lazily so the app boots without a key

### DIFF
--- a/backend/backend/app/services/openai_provider.py
+++ b/backend/backend/app/services/openai_provider.py
@@ -1,7 +1,7 @@
 """OpenAI-backed AI form provider using function-calling tools."""
 
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from openai import AsyncOpenAI
 
@@ -102,9 +102,20 @@ class OpenAIFormProvider(AIFormProvider):
     """Generates forms using OpenAI chat completions with function calling."""
 
     def __init__(self, unsplash_service: UnsplashService) -> None:
-        self._client = AsyncOpenAI(api_key=settings.open_ai.API_KEY)
+        # Construct the client lazily (see `client`) so the app can boot
+        # without an OpenAI key; only actually generating a form needs one.
+        self._client: Optional[AsyncOpenAI] = None
         self._model = settings.open_ai.MODAL
         self._unsplash = unsplash_service
+
+    @property
+    def client(self) -> AsyncOpenAI:
+        # `openai` >= 2.44 raises at construction when the API key is missing,
+        # so building the client eagerly in __init__ would crash startup for
+        # anyone not using AI form generation. Defer it to first use.
+        if self._client is None:
+            self._client = AsyncOpenAI(api_key=settings.open_ai.API_KEY)
+        return self._client
 
     async def generate_form(self, prompt: str) -> Dict[str, Any]:
         messages = [
@@ -114,7 +125,7 @@ class OpenAIFormProvider(AIFormProvider):
 
         # Agentic tool-call loop — runs until the model emits a plain message.
         while True:
-            response = await self._client.chat.completions.create(
+            response = await self.client.chat.completions.create(
                 model=self._model,
                 messages=messages,
                 tools=OPENAI_TOOLS,


### PR DESCRIPTION
## Problem

The Dependabot `python-minor-and-patch` group (#522) bumps `openai` `>=2.21` → `>=2.44`. In `openai` **2.44**, `AsyncOpenAI(api_key=...)` **raises `OpenAIError: Missing credentials` at construction** when the key is empty. The previously pinned version constructed lazily.

`OpenAIFormProvider.__init__` built the client eagerly, and it's a container **singleton created at app startup** — so with the bump, the backend (and the **entire pytest suite**) fails to boot whenever `OPENAI_API_KEY` isn't set. That's why **#522's backend tests fail with 129 errors**, and it would also crash local/prod startup for anyone not using AI form generation.

## Fix

Defer client construction to first use via a `client` property. Restores the pre-bump behaviour: the app boots without a key; only actually generating a form needs valid credentials.

```python
@property
def client(self) -> AsyncOpenAI:
    if self._client is None:
        self._client = AsyncOpenAI(api_key=settings.open_ai.API_KEY)
    return self._client
```

## Verification

Ran the **full backend suite against `openai==2.44.0`** (the version #522 resolves) with a fresh `mongo:7` and **no `OPENAI_API_KEY`**:

```
129 passed, 147 warnings in ~106s
```

Without this fix, the same setup yields 129 errors (`Missing credentials`).

## Why this instead of a dummy CI key

A dummy `OPENAI_API_KEY` in CI would only mask the problem in tests and leave the **startup-crash regression** in place for contributors/prod running without a key. This fix addresses the root cause and needs no CI env change.

## Follow-up

Once merged, the Dependabot group update **#522** can be rebased and will go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)