### PR TITLE
fix(webapp): upgrade react-data-table-component to v8 (clears React 19 DOM-prop console errors)

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -92,7 +92,7 @@
     "react-cookie": "^8.0.1",
     "react-country-dropdown": "^1.1.0",
     "react-csv": "^2.2.2",
-    "react-data-table-component": "^7.5.3",
+    "react-data-table-component": "^8.4.2",
     "react-day-picker": "8.10.1",
     "react-dom": "19.2.4",
     "react-ga4": "^1.4.1",

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -3613,7 +3613,7 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@^4.2.2, deepmerge@^4.3.1:
+deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
@@ -7674,12 +7674,10 @@ react-csv@^2.2.2:
   resolved "https://registry.yarnpkg.com/react-csv/-/react-csv-2.2.2.tgz#5bbf0d72a846412221a14880f294da9d6def9bfb"
   integrity sha512-RG5hOcZKZFigIGE8LxIEV/OgS1vigFQT4EkaHeKgyuCbUAu9Nbd/1RYq++bJcJJ9VOqO/n9TZRADsXNDR4VEpw==
 
-react-data-table-component@^7.5.3:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/react-data-table-component/-/react-data-table-component-7.7.1.tgz#103ede17c515f114a36c4054a4d1e8636fc28917"
-  integrity sha512-F1qciUONe0EiItxd+LZg9K7UXxvilSQH8WvUoSnPnAVZ/PK2x4Djr3nzkuCqCIfiMuU3imI+8gI7nYRIW2Kfxw==
-  dependencies:
-    deepmerge "^4.3.1"
+react-data-table-component@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/react-data-table-component/-/react-data-table-component-8.4.2.tgz#d090ee2dc49a5dbf0e6a862f183411acfb48df26"
+  integrity sha512-hLX+0/TeNUoPRv+Sz2hl9Oj0kLyZJwOBaqCDl6X/MaPlZUDpGfKDZ6KW/s89x33kHPUsh1jjN6YkiHs3MlYAFA==
 
 react-day-picker@8.10.1:
   version "8.10.1"


### PR DESCRIPTION
## Problem

On any page with a data table (reported on **members/collaborators**), the console showed 3 React 19 errors:

```
React does not recognize the `minWidth` prop on a DOM element ...
React does not recognize the `allowOverflow` prop on a DOM element ...
Received `true` for a non-boolean attribute `button` ...
```

Root cause: `react-data-table-component@7.7.1` forwards its own **column-config props** (`allowOverflow`, `button`, `minWidth` — set in [members-table.tsx](webapp/src/components/settings/members-table.tsx) / [invitations-table.tsx](webapp/src/components/settings/invitations-table.tsx)) onto DOM nodes under React 19 + styled-components v6, instead of consuming them internally. Library incompatibility, not a bug in the column defs.

## Fix

Upgrade RDT **7.7.1 → 8.4.2** (peer `react >=18`), which forwards props correctly. Our API usage is minimal and unchanged across the major — every consumer only does `import DataTable from 'react-data-table-component'`; no `createTheme`/`defaultThemes` (the APIs that changed in v8) are used — so **no code changes were needed**.

## Verification

- **Warnings gone:** restarted the dev server on v8, reloaded members/collaborators → **console clean** (0 errors).
- **Renders correctly:** collaborators table still shows Member / Joined Date / Role + the action column.
- **No compile breakage:** `tsc --noEmit` clean across all **8** components that use `DataTable` (members, invitations, responses, tabular-responses, select-group, workspace-groups, workspace-responders, workspace-domain-status).
- `yarn install --frozen-lockfile` clean.

## Note

I verified the members/collaborators table in-browser and type-checked the rest. The other tables (responses, responders, groups) use the same minimal, stable API, so they should be unaffected — worth a quick click-through on those when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)