### PR TITLE
fix(webapp): stop the form editor auto-saving on load

### DIFF
--- a/webapp/src/views/molecules/form-builder/audo-save-form.tsx
+++ b/webapp/src/views/molecules/form-builder/audo-save-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 import { useDebounceValue } from 'usehooks-ts';
 
@@ -33,9 +33,21 @@ export default function AutoSaveForm({ formId }: { formId: string }) {
     );
     const [debouncedForm] = useDebounceValue(combinedFormState, 1000);
 
-    const saveForm = async () => {
+    // Serialized snapshot of the last state we consider "saved", plus the time
+    // the editor mounted. Together these stop the editor from auto-saving while
+    // it hydrates the loaded form on open: opening a form populates the builder
+    // state from the loaded data (across a couple of renders, since form state
+    // and fields are separate atoms), which must not be mistaken for user edits.
+    const lastSavedBodyRef = useRef<string | null>(null);
+    const mountedAtRef = useRef<number>(Date.now());
+    // Window during which state changes are treated as hydration, not edits.
+    // Comfortably covers the 1s debounce plus a settle; user edits after this
+    // (or a later edit) still save.
+    const HYDRATION_WINDOW_MS = 2500;
+
+    const saveForm = async (serializedForm: string) => {
         const formData = new FormData();
-        formData.append('form_body', JSON.stringify(debouncedForm));
+        formData.append('form_body', serializedForm);
         const requestData: any = {
             formId: formId,
             workspaceId: workspace.id,
@@ -48,9 +60,22 @@ export default function AutoSaveForm({ formId }: { formId: string }) {
     };
 
     useEffect(() => {
-        if (debouncedForm.fields.length > 0) {
-            workspace.id && saveForm();
+        if (!workspace?.id || debouncedForm.fields.length === 0) return;
+
+        const body = JSON.stringify(debouncedForm);
+
+        // While the loaded form is still hydrating, keep the baseline in sync
+        // instead of saving, so opening a form never triggers a write.
+        if (Date.now() - mountedAtRef.current < HYDRATION_WINDOW_MS) {
+            lastSavedBodyRef.current = body;
+            return;
         }
+
+        // Past hydration: save only when the content actually changed.
+        if (body === lastSavedBodyRef.current) return;
+
+        lastSavedBodyRef.current = body;
+        saveForm(body);
     }, [debouncedForm, workspace?.id]);
 
     return <></>;


### PR DESCRIPTION
## Problem

Opening the form builder (`/dashboard/forms/{id}/edit`) fired **3 redundant `PATCH /forms/{id}` auto-saves** on load, before the user edited anything.

**Root cause** — [audo-save-form.tsx](webapp/src/views/molecules/form-builder/audo-save-form.tsx): the auto-save effect watches the debounced form state and PATCHes on every change. On open, that state is **hydrated** from the loaded form — and because form state and fields live in separate jotai atoms that settle across renders (and `workspace.id` loads async), the effect fires several times during hydration, mistaking it for user edits and re-saving the just-loaded data.

## Fix

Only auto-save genuine post-load edits:
- **Hydration window:** for a short window after mount, keep the "last saved" baseline in sync with the settling state instead of writing — so opening a form never triggers a save.
- **Dirty check:** after that, save only when the serialized form body actually differs from the last saved one (also dedupes repeated identical saves / any re-render loop).

No API or data-shape changes; purely a guard around when the existing save runs.

## Verification (in-browser, against local backend)

- **Open form → 0 PATCH** (was 3), confirmed ~5s after load (past the debounce).
- **Edit a field** (changed the welcome "Button" label) → **exactly 1 PATCH** after the 1s debounce, `200`.
- Restored the test edit; form left unchanged.
- `tsc --noEmit` clean.

## Note on the window heuristic

Hydration completes within ~1–1.5s (1s debounce + settle); the window is set to 2.5s for headroom. The only edge is a user's *first and only* edit landing within that window of page load — it would be captured as baseline and persist on their next edit. That's a rare, low-impact trade vs. saving on every open. A fully event-driven "dirty on user input" signal would remove even that, but there's no central edit event today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)