### PR TITLE
fix(webapp): invalid nested <button> in the form-published modal

### DIFF
--- a/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
+++ b/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useToast } from '@app/shadcn/components/ui/use-toast';
 
-import { Button } from '@app/shadcn/components/ui/button';
+import { Button, buttonVariants } from '@app/shadcn/components/ui/button';
 import { selectAuth } from '@app/store/auth/slice';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
@@ -51,19 +51,25 @@ export default function FormPublishedModal(props: any) {
                     <span className="h5-new">What’s Next?</span>
                     <span className="p4-new break-words text-center">
                         Add your custom domain, add integration or change form privacy,{' '}
-                        <button data-umami-event={'PublishModal Goto Settings Link'} data-umami-event-email={authState.email}>
-                            <a href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms/${standardForm.formId}?view=FormLinks`} className="text-blue-500">
-                                Go to form settings
-                            </a>
-                        </button>
+                        <a
+                            data-umami-event={'PublishModal Goto Settings Link'}
+                            data-umami-event-email={authState.email}
+                            href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms/${standardForm.formId}?view=FormLinks`}
+                            className="text-blue-500"
+                        >
+                            Go to form settings
+                        </a>
                     </span>
                 </div>
                 <div className="mb-5 mt-5">
-                    <button data-umami-event={'PublishModal Goto Dashboard Link'} data-umami-event-email={authState.email}>
-                        <a href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms`}>
-                            <Button size="medium">Done! Go to dashboard</Button>
-                        </a>
-                    </button>
+                    <a
+                        data-umami-event={'PublishModal Goto Dashboard Link'}
+                        data-umami-event-email={authState.email}
+                        href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms`}
+                        className={buttonVariants({ size: 'medium', className: 'cursor-pointer' })}
+                    >
+                        Done! Go to dashboard
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Problem

Publishing a form logged a React DOM-nesting error in the console (publish itself succeeds — `POST /publish` returns `200`):

```
In HTML, <button> cannot be a descendant of <button>. This will cause a hydration error.
<button> cannot contain a nested <button>.
```

**Root cause** — [form-publised-modal.tsx](webapp/src/views/molecules/dialogs/form-publised-modal.tsx): the success modal wrapped its two links in a `<button>` solely to carry `data-umami-event` analytics attributes:
- **"Done! Go to dashboard"**: `<button> › <a> › <Button>` — and `<Button>` renders a `<button>`, so `<button>` nested inside `<button>` (the reported error).
- **"Go to form settings"**: `<button> › <a>` — also invalid interactive-content nesting.

## Fix

Remove the wrapper `<button>`s and put the `data-umami-event` / `data-umami-event-email` attributes directly on the anchors. The dashboard action keeps its button appearance by applying `buttonVariants({ size: 'medium', ... })` to the `<a>` (the `Button` component has no `asChild`, so styling the anchor is the clean way to avoid a nested button element).

No behavior change: both remain real links with their original `href`s and analytics attributes.

## Verification (in-browser)

- Clicked **Publish** → `POST /publish` `200`, success modal opens, **console clean** (was 2 errors).
- Modal renders identically: "Done! Go to dashboard" is still the blue primary button (now a styled `<a>`), "Go to form settings" is the blue link.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)