### PR TITLE
fix(webapp): address UI/UX audit P0 & P1 findings

### DIFF
--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -190,12 +190,12 @@
       "TITLE": "Import your first form"
     },
     "EMPTY_DELETION_REQUEST": {
-      "DESCRIPTION": "You will be able to see deletion request once responders requests for deletion.",
-      "TITLE": "No deletion request yet"
+      "DESCRIPTION": "Deletion requests appear here once responders ask you to delete their responses.",
+      "TITLE": "No deletion requests yet"
     },
     "EMPTY_RESPONSE": {
-      "DESCRIPTION": "You will be able to see the form responders once responder responses ",
-      "TITLE": "No responder yet"
+      "DESCRIPTION": "Responders appear here once people start submitting your forms.",
+      "TITLE": "No responders yet"
     },
     "EMPTY_DELETION_RESPONSE.TITLE": "No responses to show",
     "FORM_TYPE": "Form type",
@@ -229,7 +229,7 @@
       "DESCRIPTION": "Collaborators can import forms, delete forms, see responses and delete response.",
       "FORM_LINK": {
         "TITLE": "Form Link",
-        "DESCRIPTION": "Create personalized form links that align with their branding or specific requirements."
+        "DESCRIPTION": "Create personalized form links that align with your branding or specific requirements."
       },
       "CUSTOMIZE_FORM_LINK": {
         "TITLE": "Custom Domain Form Link",
@@ -280,7 +280,7 @@
     "SEARCH_BY_EMAIL": "Search by Email",
     "SETTINGS": {
       "DEFAULT": {
-        "DESCRIPTION": "Effortlessly customize form links and manage their forms effectively.",
+        "DESCRIPTION": "Effortlessly customize your form links and manage your forms.",
         "COLLECT_EMAILS": {
           "TITLE": "Collect Emails",
           "DESCRIPTION": "When you enable this setting, the users needs to verify their identity before they can submit their response."
@@ -312,7 +312,7 @@
         "ADD_OR_REMOVE": "Add or Remove Group"
       },
       "LINKS": {
-        "DESCRIPTION": "Create personalized form links that align with their branding or specific requirements. A link slug is a brief, descriptive part of a URL that identifies web page content.",
+        "DESCRIPTION": "Create personalized form links that align with your branding or specific requirements. A link slug is a brief, descriptive part of a URL that identifies web page content.",
         "CHANGE_SLUG": "Customize Link",
         "CUSTOM_DOMAIN_LINK": "Custom Domain Link",
         "DEFAULT_LINK": "Default Link",

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
@@ -3,7 +3,7 @@
 import cn from 'classnames';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Divider from '@Components/common/divider';
@@ -135,6 +135,21 @@ export default function FormDashboardLayoutClient({
         router.push(`/${workspace?.workspaceName}/dashboard/forms`);
     };
 
+    const formTitle = form?.title?.trim() || 'Untitled form';
+
+    // Keep the active tab visible: the tab bar scrolls horizontally when it
+    // overflows, so center the current tab within its scroll container on
+    // navigation (querying the container avoids relying on <Link> ref forwarding).
+    const tabsContainerRef = useRef<HTMLDivElement | null>(null);
+    useEffect(() => {
+        // Defer to the next frame so tab widths are final before scrolling.
+        const id = requestAnimationFrame(() => {
+            const active = tabsContainerRef.current?.querySelector<HTMLElement>('[data-tab-active="true"]');
+            active?.scrollIntoView({ inline: 'nearest', block: 'nearest' });
+        });
+        return () => cancelAnimationFrame(id);
+    }, [pathname, tabMenu.length]);
+
 
     if (pathname.endsWith("/edit")) {
         return (
@@ -156,9 +171,16 @@ export default function FormDashboardLayoutClient({
                 <div className="mt-6 flex flex-col gap-1 sm:mt-12">
                     <FormPageLayer className="px-4 md:px-10 lg:px-28">
                         <div className="flex justify-between">
-                            <div className="flex flex-row items-center gap-1 cursor-pointer" onClick={handleBackClick}>
-                                {isMobile && <ChevronRight className="h-6 w-6 rotate-180 p-[2px]" />}
-                                {isMobile ? <h1 className="hp3-new">{form?.title}</h1> : <h1 className="h2-new text-pink">{form?.title}</h1>}
+                            <div className="flex flex-col gap-1">
+                                <button
+                                    type="button"
+                                    onClick={handleBackClick}
+                                    className="text-black-600 hover:text-black-800 flex w-fit items-center gap-1 text-sm"
+                                >
+                                    <ChevronRight className="h-4 w-4 rotate-180" />
+                                    Forms
+                                </button>
+                                {isMobile ? <h1 className="hp3-new">{formTitle}</h1> : <h1 className="h2-new text-pink">{formTitle}</h1>}
                             </div>
                             <div className="hidden gap-4 lg:flex">
                                 {form?.settings?.provider === 'self' && form?.builderVersion === 'v2' && (
@@ -235,11 +257,11 @@ export default function FormDashboardLayoutClient({
                         <Divider className="mt-6 hidden md:flex" />
                     </FormPageLayer>
                     <div className="md:px-10 lg:px-28 pt-4">
-                        <div className="flex space-x-1 border-b border-gray-200 overflow-x-auto">
+                        <div ref={tabsContainerRef} className="flex space-x-1 border-b border-gray-200 overflow-x-auto">
                             {tabMenu.map((tab) => {
                                 const isActive = pathname?.includes(`/${tab.path}`);
                                 return (
-                                    <Link key={tab.path} href={`/${params.workspace_name}/dashboard/forms/${params.form_id}/${tab.path}`} className={cn(
+                                    <Link key={tab.path} data-tab-active={isActive} href={`/${params.workspace_name}/dashboard/forms/${params.form_id}/${tab.path}`} className={cn(
                                         'flex items-center gap-2 px-4 py-2 text-sm font-medium cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap',
                                         isActive
                                             ? 'border-b-2 border-black-900 text-black-900 bg-gray-100 rounded-t'

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
@@ -112,6 +112,9 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
         if (matchingNavList.length > 0) {
             return matchingNavList[matchingNavList.length - 1]?.name;
         }
+        // Routes not represented in the sidebar nav still need a correct title.
+        if (pathname.includes('/dashboard/templates')) return 'Templates';
+        if (pathname.includes('/dashboard/account-settings')) return 'Account Settings';
         return 'My Workspace';
     };
 

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/account-settings/_components/account-settings-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/account-settings/_components/account-settings-client.tsx
@@ -22,14 +22,17 @@ export default function AccountSettingsClient() {
 
     const { openBottomSheetModal } = useBottomSheetModal();
 
+    const hasName = !!(authStatus.firstName || authStatus.lastName);
+    const displayName = getFullNameFromUser(authStatus);
+
     return (
         <div className="my-4">
             <h4 className="h4">{t(profileMenu.accountSettings)}</h4>
             <div className="mt-[30px] flex gap-4 mb-10">
-                <AuthAccountProfileImage size={80} image={authStatus.profileImage} name={authStatus.firstName ?? 'Anonymous'} />
+                <AuthAccountProfileImage size={80} image={authStatus.profileImage} name={displayName} />
                 <div className="flex flex-col gap-2 justify-center">
-                    <p className="h4 !leading-none">{getFullNameFromUser(authStatus)}</p>
-                    <p className="body4 text-black-700 !leading-none">{authStatus.email}</p>
+                    <p className="h4 !leading-none">{displayName}</p>
+                    {hasName && <p className="body4 text-black-700 !leading-none">{authStatus.email}</p>}
                 </div>
             </div>
             <div className="flex flex-col gap-6">

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/templates/_components/templates-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/templates/_components/templates-client.tsx
@@ -5,6 +5,7 @@ import { selectAuth } from '@app/store/auth/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { useGetTemplatesQuery } from '@app/store/template/api';
 import { selectWorkspace } from '@app/store/workspaces/slice';
+import { LayoutTemplate } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 export default function TemplatesClient({ predefined_templates }: { predefined_templates: any[] }) {
@@ -12,28 +13,34 @@ export default function TemplatesClient({ predefined_templates }: { predefined_t
     const workspace = useAppSelector(selectWorkspace);
     const auth = useAppSelector(selectAuth);
 
-    console.log('predefined_templates', predefined_templates);
+    const isAdmin = auth?.roles?.includes('ADMIN');
+    const predefined = isAdmin && Array.isArray(predefined_templates) ? [...predefined_templates] : [];
 
-    let p = [...(predefined_templates || [])];
-    const { data: v2Forms } = useGetTemplatesQuery(
+    const { data: v2Forms, isLoading } = useGetTemplatesQuery(
         { workspace_id: workspace?.id, v2: true },
         { skip: !workspace?.id }
     );
+    const v2 = isAdmin && Array.isArray(v2Forms) ? v2Forms : [];
+
+    const isEmpty = predefined.length === 0 && v2.length === 0;
 
     return (
         <>
-            {predefined_templates && Array.isArray(predefined_templates) && predefined_templates.length > 0 && (
-                <TemplateSection
-                    title={t('TEMPLATE.DEFAULT')}
-                    templates={auth?.roles?.includes('ADMIN') ? p : []}
-                    className="h-[400px]"
-                />
+            {predefined.length > 0 && (
+                <TemplateSection title={t('TEMPLATE.DEFAULT')} templates={predefined} className="h-[400px]" />
             )}
-            {auth?.roles?.includes('ADMIN') && (
-                <TemplateSection
-                    title={t('TEMPLATE.YOUR_WORKSPACE') + ' v2'}
-                    templates={v2Forms}
-                />
+            {v2.length > 0 && (
+                <TemplateSection title={t('TEMPLATE.YOUR_WORKSPACE') + ' v2'} templates={v2} />
+            )}
+            {isEmpty && !isLoading && (
+                <div className="flex min-h-[320px] w-full flex-col items-center justify-center gap-3 text-center">
+                    <LayoutTemplate className="text-black-500 h-10 w-10" strokeWidth={1.5} />
+                    <div className="h5-new text-black-800">No templates yet</div>
+                    <p className="body4 text-black-600 max-w-[360px]">
+                        Ready-made form templates will appear here. In the meantime, start from scratch or import an
+                        existing form.
+                    </p>
+                </div>
             )}
         </>
     );

--- a/webapp/src/components/analytics/analytics.tsx
+++ b/webapp/src/components/analytics/analytics.tsx
@@ -6,6 +6,7 @@ import { useFormAnalyticsData } from '@app/store/analytics/analytics-hooks';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import EmptyResponseIcon from '@Components/icons/expty-response-icon';
+import { AlertTriangle } from 'lucide-react';
 import { useEffect, useState, type JSX } from 'react';
 
 export default function FormAnalytics() {
@@ -226,7 +227,7 @@ export default function FormAnalytics() {
         return (
             <>
                 <TimeRangeSelector onRangeSelect={handleRangeSelect} selectedRange={range} />
-                <EmptyDataResponseComponent title="No data yet" detail="There was an error while fetching the data" />
+                <AnalyticsErrorComponent onRetry={() => window.location.reload()} />
             </>
         );
     }
@@ -263,6 +264,25 @@ const EmptyDataResponseComponent = ({ title, detail }: { title: JSX.Element | st
                 <EmptyResponseIcon />
                 <span className="p3-new text-black">{title}</span>
                 <span className="p4-new text-black-600">{detail}</span>
+            </div>
+        </div>
+    );
+};
+
+const AnalyticsErrorComponent = ({ onRetry }: { onRetry: () => void }) => {
+    return (
+        <div className="flex min-h-[300px] w-full items-center justify-center">
+            <div className="mb-28 flex max-w-[360px] flex-col items-center gap-3 text-center">
+                <AlertTriangle className="h-9 w-9 text-amber-500" strokeWidth={1.5} />
+                <span className="p3-new text-black">Couldn&apos;t load analytics</span>
+                <span className="p4-new text-black-600">Something went wrong fetching this data. Check your connection and try again.</span>
+                <button
+                    type="button"
+                    onClick={onRetry}
+                    className="text-brand-500 border-brand-500 mt-1 rounded-lg border px-4 py-2 text-sm font-medium hover:bg-blue-50"
+                >
+                    Try again
+                </button>
             </div>
         </div>
     );

--- a/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
+++ b/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
@@ -62,6 +62,15 @@ const AddWorkspaceDomainForm = () => {
     return (
         <div className="mt-4 flex flex-col  gap-2">
             <span className="text-black-700 text-xs">You can use your own domain name to have a custom URL for your published forms. Consider using a subdomain, such as : forms.yourdomain.com</span>
+            {!workspace.isPro && (
+                <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-[#FFD79A] bg-[#FFF7EA] px-3 py-2 text-xs text-[#8A5A00]">
+                    <span className="rounded bg-[#FFB020] px-1.5 py-0.5 text-[10px] font-semibold text-white">PRO</span>
+                    <span>Custom domains are a Pro feature.</span>
+                    <button type="button" onClick={() => openModal('UPGRADE_TO_PRO')} className="font-semibold text-[#8A5A00] underline underline-offset-2">
+                        Upgrade to connect your domain
+                    </button>
+                </div>
+            )}
             <div className="text-black-800 mt-4 text-xs font-medium">Enter a domain you own</div>
             <form
                 onSubmit={(event) => {

--- a/webapp/src/components/dashboard/form-settings.tsx
+++ b/webapp/src/components/dashboard/form-settings.tsx
@@ -334,7 +334,7 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
                                     <div className="h5-new !text-black-800">Require Verified Identity</div>
                                     <Divider className={'my-2 w-full'} />
                                     <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4 flex-1">If this is enabled the user needs to verify his email identity before filling this form</div>
+                                        <div className="body4 !text-black-700 w-3/4 flex-1">When enabled, respondents must verify their email before they can fill out this form.</div>
                                         {/*<div className="body4 !text-black-700 w-3/4">{t('FORM_PAGE.SETTINGS.DEFAULT.COLLECT_EMAILS.DESCRIPTION')}</div>*/}
                                         <Switch
                                             data-umami-event="Require Verified Identity Switch"
@@ -356,7 +356,7 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
                                     <div className="h5-new !text-black-800">Show Submission Number</div>
                                     <Divider className={'my-2 w-full'} />
                                     <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4">When this is enabled the responder will br shown a submission ID which the user can use to view his response and also request for deletion of his response</div>
+                                        <div className="body4 !text-black-700 w-3/4">When enabled, respondents get a submission ID they can use to view their response and request its deletion.</div>
                                         <Switch
                                             data-umami-event="Show Submission Number Switch"
                                             data-umami-event-email={auth.email}

--- a/webapp/src/components/form/integrations.tsx
+++ b/webapp/src/components/form/integrations.tsx
@@ -159,7 +159,7 @@ export default function FormIntegrations() {
             )}
             {Array.isArray(data) && data.length == 0 && (
                 <div>
-                    <EmptyFormsView description="No Integrations Found" />
+                    <EmptyFormsView description="No integrations available yet — once you connect one, it will appear here." />
                 </div>
             )}
         </div>

--- a/webapp/src/components/sidebar/sidebar-layout.tsx
+++ b/webapp/src/components/sidebar/sidebar-layout.tsx
@@ -118,6 +118,10 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
         if (matchingNavList.length > 0) {
             return matchingNavList[matchingNavList.length - 1]?.name;
         }
+        // Routes that aren't represented in the sidebar nav still need a correct
+        // title instead of the generic "My Workspace" fallback.
+        if (pathname?.includes('/dashboard/templates')) return 'Templates';
+        if (pathname?.includes('/dashboard/account-settings')) return 'Account Settings';
         return 'My Workspace';
     };
 


### PR DESCRIPTION
Addresses every **P0** and **P1** from the screen-by-screen UI/UX audit. All changes are UI-level, type-check clean, and verified live in the browser.

## P0 — orientation & broken states
| # | Fix |
|---|---|
| 1 | **Form identity** — form-detail header now shows the title with an **"Untitled form"** fallback (was blank) + a visible **"‹ Forms" breadcrumb/back** link. |
| 2 | **Form-detail chrome** — the tab bar **auto-scrolls the active tab into view** so it's never clipped (verified on "Form Link" / "Analytics"). |
| 3 | **Templates** — real **"No templates yet"** empty state instead of a blank screen; removed a stray `console.log`. |
| 4 | **Analytics** — a genuine **error state** ("Couldn't load analytics" + **Try again**) distinct from empty, replacing the contradictory "No data yet / there was an error". |

## P1 — trust & completeness
| # | Fix |
|---|---|
| 5 | **Copy/voice pass** — fixed the "will **br** shown" typo, the cut-off responders empty-state sentence, and the deletion-request grammar; degendered "his" → "their"; unified "their branding/forms" → "your". |
| 6 | **Page titles** — top bar shows **"Templates"** / **"Account Settings"** instead of the generic "My Workspace". |
| 7 | **Identity** — avatar initial now derives from the display name (matches the sidebar; **"S"** not "A"); email no longer prints twice when no name is set. |
| 8 | **Account Settings** — identity display fixed (it already had Delete Account). |
| 9 | **Integrations** — empty state reworded to be clearer and less of a dead end. |
| 10 | **Custom Domain** — explicit **PRO banner** for free users (the submit-time upgrade gate already existed). |

## Verification
- Walked each affected screen in the browser: form-detail (title + breadcrumb + tab scroll), Templates, Analytics, Account Settings, Settings, Custom Domain.
- `tsc --noEmit` clean.

## Out of scope (need backend — follow-ups)
- **Fuller Account Settings**: editable profile fields, notifications, and billing/subscription management.
- **Live Integrations catalog**: a "connect" catalog needs the integrations list/endpoints; this PR only improves the empty-state copy.

Files: `common.json` (copy), form-detail layout, side-nav layout title, account-settings, templates, analytics, custom-domain form, form-settings, integrations, sidebar-layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)