### PR TITLE
docs: update CHANGELOG Unreleased for recent UI/UX fixes and merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,27 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 - Rewrote `README.md` for a public audience.
 - Sped up the backend test suite (~137s → ~5s) via session-scoped app/DB init.
 - Aligned toolchain versions (Node via `.nvmrc`, Python for CI, `.editorconfig`).
+- UI/UX: form titles are now shown across the app (forms list and form-detail
+  header) with an "Untitled form" fallback, plus a "Forms" breadcrumb, and the
+  form tab bar keeps the active tab in view.
+- UI/UX: corrected page titles and empty/error states (Templates, Analytics,
+  Integrations, Responders, Deletion Requests) and did a copy pass for typos,
+  grammar, and consistent, inclusive second-person wording.
+- UI/UX: Account Settings derives the avatar and name consistently and no
+  longer prints the email twice; Custom Domain shows an explicit Pro upgrade
+  prompt on free plans.
+- Batched routine dependency updates across all services (npm + uv + GitHub
+  Actions) and moved CI actions to Node-24 majors.
 
 ### Fixed
 
 - React 19 form-rendering crash and DOM-prop console errors in the webapp.
+- React 19 DOM-prop warnings from data tables (`react-data-table-component` v8).
+- Form editor no longer auto-saves on load — only on real user edits.
+- Invalid nested `<button>` in the form-published modal.
+- Analytics now distinguishes a genuine load error (with a retry) from an
+  empty state.
+- Backend boots without an `OPENAI_API_KEY` (OpenAI client is created lazily).
 - Forms listing/pagination failure (fastapi-pagination under Starlette 1.x).
 - Login "Failed to send OTP" flow (route, API host, and cookie-domain issues).
 - Numerous Dependabot security advisories across all services.


### PR DESCRIPTION
The `CHANGELOG.md` `[Unreleased]` section had drifted — the recent fixes and the UI/UX audit work (merged in #540) weren't recorded, even though `CONTRIBUTING.md` asks for a changelog entry per PR. This brings it current.

### Added to `[Unreleased]`

**Changed**
- Form titles surfaced across the app (list + form-detail header) with an "Untitled form" fallback, a "Forms" breadcrumb, and an auto-scrolling tab bar.
- Corrected page titles and empty/error states (Templates, Analytics, Integrations, Responders, Deletion Requests); copy pass for typos, grammar, and consistent second-person wording.
- Account Settings avatar/name/email consistency; Custom Domain Pro upgrade prompt on free plans.
- Batched dependency updates and Node-24 CI action majors.

**Fixed**
- React 19 DOM-prop warnings from data tables (`react-data-table-component` v8).
- Form editor no longer auto-saves on load.
- Invalid nested `<button>` in the form-published modal.
- Analytics distinguishes a load error (with retry) from an empty state.
- Backend boots without an `OPENAI_API_KEY` (lazy OpenAI client).

Docs-only; no code changes.

> Follow-up idea (not in this PR): a lightweight CI check that fails PRs touching `webapp/`/`backend/` without a `CHANGELOG.md` change, with a `skip-changelog` label escape hatch — so this doesn't drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)