### PR TITLE
Frontend unit test suite: logic engine, builder store, responder contracts

### DIFF
--- a/webapp/src/store/jotai/field-selectors.test.tsx
+++ b/webapp/src/store/jotai/field-selectors.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { Comparison, LogicalOperator } from '@app/models/types/form-builder-shared';
+import useFormFieldsAtom from './field-selectors';
+
+/**
+ * Each renderHook gets a fresh Jotai <Provider>, so module-level atoms are
+ * isolated between tests.
+ */
+const setup = () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => <Provider>{children}</Provider>;
+    return renderHook(() => useFormFieldsAtom(), { wrapper });
+};
+
+const q = (id: string, index: number, type: string = FieldTypes.SHORT_TEXT): StandardFormFieldDto => ({ id, index, type });
+
+const twoPageForm = (): StandardFormFieldDto[] => [
+    {
+        id: 'slide-1',
+        index: 0,
+        type: FieldTypes.SLIDE,
+        properties: {
+            fields: [q('q1', 0)],
+            jumps: [{ operator: LogicalOperator.AND, conditions: [{ fieldId: 'q1', fieldType: FieldTypes.SHORT_TEXT, comparison: Comparison.IS_EQUAL, value: 'skip' }], target: 'slide-2' }]
+        }
+    },
+    { id: 'slide-2', index: 1, type: FieldTypes.SLIDE, properties: { fields: [q('q2', 0)] } }
+];
+
+describe('initFormFields — undo baseline', () => {
+    it('seeds fields and starts history with nothing to undo', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        expect(result.current.formFields).toHaveLength(2);
+        expect(result.current.canUndo).toBe(false);
+        expect(result.current.canRedo).toBe(false);
+    });
+
+    it('undo can never reach past the loaded form (data-loss guard)', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.deleteSlide(1));
+        act(() => result.current.undo());
+        expect(result.current.formFields).toHaveLength(2);
+        expect(result.current.canUndo).toBe(false);
+        // a further undo is a no-op, not a blank form
+        act(() => result.current.undo());
+        expect(result.current.formFields).toHaveLength(2);
+    });
+});
+
+describe('undo / redo', () => {
+    it('round-trips a structural change', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.deleteSlide(1));
+        expect(result.current.formFields).toHaveLength(1);
+        expect(result.current.canUndo).toBe(true);
+
+        act(() => result.current.undo());
+        expect(result.current.formFields).toHaveLength(2);
+        expect(result.current.formFields[1].id).toBe('slide-2');
+        expect(result.current.canRedo).toBe(true);
+
+        act(() => result.current.redo());
+        expect(result.current.formFields).toHaveLength(1);
+        expect(result.current.canRedo).toBe(false);
+    });
+
+    it('a new change truncates the redo future', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.deleteSlide(1));
+        act(() => result.current.undo());
+        act(() => result.current.updateSlidePosition(0, { x: 10, y: 20 }));
+        expect(result.current.canRedo).toBe(false);
+    });
+
+    it('identical consecutive commits are deduped (no wasted undo steps)', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.setFormFields([...result.current.formFields]));
+        expect(result.current.canUndo).toBe(false);
+    });
+
+    it('undone state is a deep copy — later mutations cannot corrupt history', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.updateSlidePosition(0, { x: 1, y: 1 }));
+        act(() => result.current.updateSlidePosition(0, { x: 2, y: 2 }));
+        act(() => result.current.undo());
+        expect(result.current.formFields[0].properties?.position).toEqual({ x: 1, y: 1 });
+        act(() => result.current.undo());
+        expect(result.current.formFields[0].properties?.position).toBeUndefined();
+    });
+});
+
+describe('slide mutations', () => {
+    it('addSlide appends and reindexes', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.addSlide({ id: 'slide-3', index: 2, type: FieldTypes.SLIDE, properties: { fields: [] } }, 2));
+        expect(result.current.formFields).toHaveLength(3);
+        expect(result.current.formFields.map((s) => s.index)).toEqual([0, 1, 2]);
+    });
+
+    it('deleteSlide removes, reindexes, and prunes conditions referencing its fields', () => {
+        const { result } = setup();
+        // slide-2 has a jump conditioned on q1 (slide-1's field); deleting slide-1 must prune it
+        const form: StandardFormFieldDto[] = [
+            { id: 'slide-1', index: 0, type: FieldTypes.SLIDE, properties: { fields: [q('q1', 0)] } },
+            {
+                id: 'slide-2',
+                index: 1,
+                type: FieldTypes.SLIDE,
+                properties: {
+                    fields: [q('q2', 0)],
+                    jumps: [{ operator: LogicalOperator.AND, conditions: [{ fieldId: 'q1', fieldType: FieldTypes.SHORT_TEXT, comparison: Comparison.IS_NOT_EMPTY, value: '' }], target: 'slide-1' }]
+                }
+            }
+        ];
+        act(() => result.current.initFormFields(form));
+        act(() => result.current.deleteSlide(0));
+        expect(result.current.formFields).toHaveLength(1);
+        expect(result.current.formFields[0].index).toBe(0);
+        // the jump conditioned on the deleted q1 is swept
+        expect(result.current.formFields[0].properties?.jumps).toBeUndefined();
+    });
+
+    it('duplicateSlide deep-copies with fresh ids and no inherited canvas position', () => {
+        const { result } = setup();
+        const form = twoPageForm();
+        form[0].properties!.position = { x: 100, y: 200 };
+        act(() => result.current.initFormFields(form));
+        let newId: string | undefined;
+        act(() => {
+            newId = result.current.duplicateSlide(0);
+        });
+        expect(result.current.formFields).toHaveLength(3);
+        const copy = result.current.formFields[1];
+        expect(copy.id).toBe(newId);
+        expect(copy.id).not.toBe('slide-1');
+        expect(copy.properties?.fields?.[0].id).not.toBe('q1');
+        expect(copy.properties?.position).toBeUndefined();
+        expect(result.current.formFields.map((s) => s.index)).toEqual([0, 1, 2]);
+        // the original keeps its identity
+        expect(result.current.formFields[0].id).toBe('slide-1');
+    });
+});
+
+describe('field mutations', () => {
+    it('deleteField removes, reindexes, and prunes logic referencing it', () => {
+        const { result } = setup();
+        const form: StandardFormFieldDto[] = [
+            {
+                id: 'slide-1',
+                index: 0,
+                type: FieldTypes.SLIDE,
+                properties: {
+                    fields: [
+                        q('q1', 0),
+                        { ...q('q2', 1), properties: { logic: { action: 'SHOW', operator: LogicalOperator.AND, conditions: [{ fieldId: 'q1', fieldType: FieldTypes.SHORT_TEXT, comparison: Comparison.IS_NOT_EMPTY, value: '' }] } } }
+                    ]
+                }
+            }
+        ];
+        act(() => result.current.initFormFields(form));
+        act(() => result.current.deleteField(0, 0)); // delete q1
+        const fields = result.current.formFields[0].properties!.fields!;
+        expect(fields).toHaveLength(1);
+        expect(fields[0].id).toBe('q2');
+        expect(fields[0].index).toBe(0);
+        // q2's visibility rule referenced the deleted q1 → swept
+        expect(fields[0].properties?.logic).toBeUndefined();
+    });
+
+    it('updateFieldConditionalLogic sets and clears a rule (fieldIndex first, slideIndex second)', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        const rule = { action: 'SHOW' as const, operator: LogicalOperator.AND, conditions: [{ fieldId: 'q1', fieldType: FieldTypes.SHORT_TEXT, comparison: Comparison.IS_EQUAL, value: 'x' }] };
+        act(() => result.current.updateFieldConditionalLogic(0, 1, rule));
+        expect(result.current.formFields[1].properties?.fields?.[0].properties?.logic).toEqual(rule);
+        act(() => result.current.updateFieldConditionalLogic(0, 1, undefined));
+        expect(result.current.formFields[1].properties?.fields?.[0].properties?.logic).toBeUndefined();
+    });
+});
+
+describe('flow-view mutations', () => {
+    it('updateSlideJumps sets and clears jump rules', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        const jumps = [{ operator: LogicalOperator.AND, conditions: [{ fieldId: 'q1', fieldType: FieldTypes.SHORT_TEXT, comparison: Comparison.IS_EQUAL, value: 'y' }], target: '__SUBMIT__' }];
+        act(() => result.current.updateSlideJumps(1, jumps));
+        expect(result.current.formFields[1].properties?.jumps).toEqual(jumps);
+        act(() => result.current.updateSlideJumps(1, undefined));
+        expect(result.current.formFields[1].properties?.jumps).toBeUndefined();
+    });
+
+    it('updateSlidePosition and clearSlidePositions manage the canvas layout', () => {
+        const { result } = setup();
+        act(() => result.current.initFormFields(twoPageForm()));
+        act(() => result.current.updateSlidePosition(0, { x: 42, y: 7 }));
+        act(() => result.current.updateSlidePosition(1, { x: 1, y: 2 }));
+        expect(result.current.formFields[0].properties?.position).toEqual({ x: 42, y: 7 });
+        act(() => result.current.clearSlidePositions());
+        expect(result.current.formFields[0].properties?.position).toBeUndefined();
+        expect(result.current.formFields[1].properties?.position).toBeUndefined();
+    });
+});

--- a/webapp/src/store/jotai/responder-form-response.test.tsx
+++ b/webapp/src/store/jotai/responder-form-response.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, expect, it } from 'vitest';
+
+import { useFormResponse } from './responder-form-response';
+
+const setup = () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => <Provider>{children}</Provider>;
+    return renderHook(() => useFormResponse(), { wrapper });
+};
+
+/**
+ * The answer shapes below are load-bearing: the conditional-logic evaluator
+ * (getComparableAnswerValue) and the submit payload both read these exact slots.
+ */
+describe('answer setters produce the shapes the evaluator reads', () => {
+    it('text answers', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldTextAnswer('f1', 'hello'));
+        expect(result.current.formResponse.answers.f1).toEqual({ type: 'text', text: 'hello' });
+    });
+
+    it('boolean (Yes/No) answers', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldBooleanAnswer('f1', true));
+        expect(result.current.formResponse.answers.f1).toMatchObject({ boolean: true });
+    });
+
+    it('single-choice answers store choice.value', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldChoiceAnswer('f1', 'Red'));
+        expect(result.current.formResponse.answers.f1).toEqual({ type: 'choice', choice: { value: 'Red' } });
+    });
+
+    it('multi-select answers store choices.values', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldChoicesAnswer('f1', ['Red', 'Blue']));
+        expect(result.current.formResponse.answers.f1.choices?.values).toEqual(['Red', 'Blue']);
+    });
+
+    it('number answers', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldNumberAnswer('f1', 42));
+        expect(result.current.formResponse.answers.f1).toMatchObject({ number: 42 });
+    });
+
+    it('answers accumulate per field id without clobbering others', () => {
+        const { result } = setup();
+        act(() => result.current.addFieldTextAnswer('f1', 'a'));
+        act(() => result.current.addFieldTextAnswer('f2', 'b'));
+        act(() => result.current.addFieldTextAnswer('f1', 'c')); // overwrite same field
+        expect(result.current.formResponse.answers.f1.text).toBe('c');
+        expect(result.current.formResponse.answers.f2.text).toBe('b');
+    });
+});
+
+describe('validation state', () => {
+    it('setInvalidFields stores per-field invalidations for QuestionWrapper', () => {
+        const { result } = setup();
+        act(() => result.current.setInvalidFields({ f1: [0] } as any));
+        expect(result.current.formResponse.invalidFields?.f1).toBeDefined();
+    });
+});

--- a/webapp/src/store/jotai/responder-form-state.test.tsx
+++ b/webapp/src/store/jotai/responder-form-state.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { act, renderHook } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// useResponderState reads the redux form only for nextField bounds — stub it.
+vi.mock('@app/store/hooks', () => ({
+    useAppSelector: () => ({ fields: [{ id: 's1', properties: { fields: [{ id: 'a' }, { id: 'b' }] } }, { id: 's2' }, { id: 's3' }] })
+}));
+
+import { useResponderState } from './responder-form-state';
+
+const setup = () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => <Provider>{children}</Provider>;
+    return renderHook(() => useResponderState(), { wrapper });
+};
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+const settle = () => act(() => void vi.advanceTimersByTime(600));
+
+describe('responder navigation history (jump-aware Back)', () => {
+    it('starts on the welcome pseudo-slide with empty history', () => {
+        const { result } = setup();
+        expect(result.current.currentSlide).toBe(-1);
+        expect(result.current.responderState.history).toEqual([]);
+    });
+
+    it('nextSlide advances linearly and records where it came from', () => {
+        const { result } = setup();
+        act(() => result.current.nextSlide());
+        settle();
+        expect(result.current.currentSlide).toBe(0);
+        expect(result.current.responderState.history).toEqual([-1]);
+    });
+
+    it('goToSlide jumps anywhere and Back retraces the jump, not index-1', () => {
+        const { result } = setup();
+        act(() => result.current.nextSlide()); // welcome -> 0
+        settle();
+        act(() => result.current.goToSlide(2)); // jump 0 -> 2 (skipping 1)
+        settle();
+        expect(result.current.currentSlide).toBe(2);
+        expect(result.current.responderState.history).toEqual([-1, 0]);
+
+        act(() => result.current.previousSlide()); // back retraces to 0, not 1
+        settle();
+        expect(result.current.currentSlide).toBe(0);
+        expect(result.current.responderState.history).toEqual([-1]);
+
+        act(() => result.current.previousSlide());
+        settle();
+        expect(result.current.currentSlide).toBe(-1);
+        expect(result.current.responderState.history).toEqual([]);
+    });
+
+    it('previousSlide falls back to index-1 when history is empty', () => {
+        const { result } = setup();
+        act(() => result.current.setResponderState({ ...result.current.responderState, currentSlide: 2, history: [] }));
+        act(() => result.current.previousSlide());
+        settle();
+        expect(result.current.currentSlide).toBe(1);
+    });
+
+    it('returning to the welcome page clears history', () => {
+        const { result } = setup();
+        act(() => result.current.nextSlide());
+        settle();
+        act(() => result.current.setCurrentSlideToWelcomePage());
+        expect(result.current.currentSlide).toBe(-1);
+        expect(result.current.responderState.history).toEqual([]);
+    });
+
+    it('thank-you page is the -2 sentinel', () => {
+        const { result } = setup();
+        act(() => result.current.setCurrentSlideToThankyouPage());
+        expect(result.current.currentSlide).toBe(-2);
+    });
+
+    it('resetResponderState restores the initial state', () => {
+        const { result } = setup();
+        act(() => result.current.goToSlide(2));
+        settle();
+        act(() => result.current.resetResponderState());
+        expect(result.current.currentSlide).toBe(-1);
+        expect(result.current.responderState.history).toEqual([]);
+    });
+});

--- a/webapp/src/utils/conditional-logic.test.ts
+++ b/webapp/src/utils/conditional-logic.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { Comparison, JUMP_TARGET_SUBMIT, LogicalOperator } from '@app/models/types/form-builder-shared';
+import {
+    areConditionsMet,
+    computeFlowTraffic,
+    evaluateConditions,
+    fieldHasLogic,
+    getComparableAnswerValue,
+    getHiddenFieldIds,
+    isFieldHiddenByLogic,
+    isJumpTargetValid,
+    pruneOrphanedConditions,
+    resolveJumpTargetId,
+    slideHasLogic
+} from './conditional-logic';
+
+/* ------------------------------ test helpers ----------------------------- */
+
+const cond = (fieldId: string, comparison: Comparison, value: any = '', fieldType: string = FieldTypes.SHORT_TEXT) => ({ fieldId, fieldType, comparison, value });
+
+const field = (id: string, type: string = FieldTypes.SHORT_TEXT, logic?: any): StandardFormFieldDto => ({ id, index: 0, type, properties: logic ? { logic } : {} });
+
+const slide = (id: string, fields: StandardFormFieldDto[] = [], jumps?: any[]): StandardFormFieldDto =>
+    ({ id, index: 0, type: FieldTypes.SLIDE, properties: { fields, ...(jumps ? { jumps } : {}) } }) as StandardFormFieldDto;
+
+const textAnswer = (text: string) => ({ type: 'text', text });
+
+/* --------------------------- getComparableAnswerValue -------------------- */
+
+describe('getComparableAnswerValue', () => {
+    it('maps each field type to its answer slot', () => {
+        expect(getComparableAnswerValue({ text: 'hi' }, FieldTypes.SHORT_TEXT)).toBe('hi');
+        expect(getComparableAnswerValue({ text: 'hi' }, FieldTypes.LONG_TEXT)).toBe('hi');
+        expect(getComparableAnswerValue({ email: 'a@b.c' }, FieldTypes.EMAIL)).toBe('a@b.c');
+        expect(getComparableAnswerValue({ url: 'https://x' }, FieldTypes.LINK)).toBe('https://x');
+        expect(getComparableAnswerValue({ number: 7 }, FieldTypes.NUMBER)).toBe(7);
+        expect(getComparableAnswerValue({ number: 3 }, FieldTypes.RATING)).toBe(3);
+        expect(getComparableAnswerValue({ number: 9 }, FieldTypes.LINEAR_RATING)).toBe(9);
+        expect(getComparableAnswerValue({ date: '2026-01-01' }, FieldTypes.DATE)).toBe('2026-01-01');
+        expect(getComparableAnswerValue({ phoneNumber: '123' }, FieldTypes.PHONE_NUMBER)).toBe('123');
+        expect(getComparableAnswerValue({ phone_number: '456' }, FieldTypes.PHONE_NUMBER)).toBe('456');
+    });
+
+    it('maps Yes/No booleans to the literal strings the builder offers', () => {
+        expect(getComparableAnswerValue({ boolean: true }, FieldTypes.YES_NO)).toBe('Yes');
+        expect(getComparableAnswerValue({ boolean: false }, FieldTypes.YES_NO)).toBe('No');
+        expect(getComparableAnswerValue({}, FieldTypes.YES_NO)).toBeUndefined();
+    });
+
+    it('prefers multi-select values over single choice for choice fields', () => {
+        expect(getComparableAnswerValue({ choice: { value: 'A' } }, FieldTypes.MULTIPLE_CHOICE)).toBe('A');
+        expect(getComparableAnswerValue({ choices: { values: ['A', 'B'] } }, FieldTypes.MULTIPLE_CHOICE)).toEqual(['A', 'B']);
+        expect(getComparableAnswerValue({ choice: { value: 'X' } }, FieldTypes.DROP_DOWN)).toBe('X');
+    });
+
+    it('returns undefined for a missing answer', () => {
+        expect(getComparableAnswerValue(undefined, FieldTypes.SHORT_TEXT)).toBeUndefined();
+        expect(getComparableAnswerValue(null, FieldTypes.NUMBER)).toBeUndefined();
+    });
+});
+
+/* ------------------------------ comparisons ------------------------------ */
+
+describe('evaluateConditions — comparison operators', () => {
+    const answers = { q: textAnswer('Hello World') };
+    const one = (comparison: Comparison, value: any, a: Record<string, any> = answers, fieldType: string = FieldTypes.SHORT_TEXT) =>
+        evaluateConditions(LogicalOperator.AND, [cond('q', comparison, value, fieldType)], a);
+
+    it('IS_EQUAL / IS_NOT_EQUAL compare as strings', () => {
+        expect(one(Comparison.IS_EQUAL, 'Hello World')).toBe(true);
+        expect(one(Comparison.IS_EQUAL, 'hello world')).toBe(false); // equality is case-sensitive
+        expect(one(Comparison.IS_NOT_EQUAL, 'nope')).toBe(true);
+        expect(one(Comparison.IS_NOT_EQUAL, 'Hello World')).toBe(false);
+    });
+
+    it('IS_EQUAL against a multi-select answer checks membership', () => {
+        const a = { q: { choices: { values: ['Red', 'Blue'] } } };
+        expect(one(Comparison.IS_EQUAL, 'Red', a, FieldTypes.MULTIPLE_CHOICE)).toBe(true);
+        expect(one(Comparison.IS_EQUAL, 'Green', a, FieldTypes.MULTIPLE_CHOICE)).toBe(false);
+        expect(one(Comparison.IS_NOT_EQUAL, 'Green', a, FieldTypes.MULTIPLE_CHOICE)).toBe(true);
+    });
+
+    it('CONTAINS / DOES_NOT_CONTAIN are case-insensitive on strings', () => {
+        expect(one(Comparison.CONTAINS, 'hello')).toBe(true);
+        expect(one(Comparison.CONTAINS, 'WORLD')).toBe(true);
+        expect(one(Comparison.CONTAINS, 'xyz')).toBe(false);
+        expect(one(Comparison.DOES_NOT_CONTAIN, 'xyz')).toBe(true);
+    });
+
+    it('CONTAINS on multi-select answers checks membership', () => {
+        const a = { q: { choices: { values: ['Red', 'Blue'] } } };
+        expect(one(Comparison.CONTAINS, 'Blue', a, FieldTypes.MULTIPLE_CHOICE)).toBe(true);
+        expect(one(Comparison.DOES_NOT_CONTAIN, 'Green', a, FieldTypes.MULTIPLE_CHOICE)).toBe(true);
+    });
+
+    it('numeric comparisons', () => {
+        const a = { q: { number: 10 } };
+        expect(one(Comparison.GREATER_THAN, 5, a, FieldTypes.NUMBER)).toBe(true);
+        expect(one(Comparison.GREATER_THAN, 10, a, FieldTypes.NUMBER)).toBe(false);
+        expect(one(Comparison.GREATER_THAN_EQUAL, 10, a, FieldTypes.NUMBER)).toBe(true);
+        expect(one(Comparison.LESS_THAN, 11, a, FieldTypes.NUMBER)).toBe(true);
+        expect(one(Comparison.LESS_THAN_EQUAL, 9, a, FieldTypes.NUMBER)).toBe(false);
+    });
+
+    it('STARTS_WITH / ENDS_WITH are case-insensitive', () => {
+        expect(one(Comparison.STARTS_WITH, 'hello')).toBe(true);
+        expect(one(Comparison.ENDS_WITH, 'WORLD')).toBe(true);
+        expect(one(Comparison.STARTS_WITH, 'World')).toBe(false);
+    });
+
+    it('IS_EMPTY / IS_NOT_EMPTY treat missing, empty string and empty array as empty', () => {
+        expect(one(Comparison.IS_EMPTY, '', {})).toBe(true);
+        expect(one(Comparison.IS_EMPTY, '', { q: textAnswer('') })).toBe(true);
+        expect(one(Comparison.IS_EMPTY, '', { q: { choices: { values: [] } } }, FieldTypes.MULTIPLE_CHOICE)).toBe(true);
+        expect(one(Comparison.IS_NOT_EMPTY, '', answers)).toBe(true);
+        expect(one(Comparison.IS_NOT_EMPTY, '', {})).toBe(false);
+    });
+});
+
+describe('evaluateConditions — folding', () => {
+    const answers = { a: textAnswer('x'), b: textAnswer('y') };
+
+    it('AND requires every condition', () => {
+        expect(evaluateConditions(LogicalOperator.AND, [cond('a', Comparison.IS_EQUAL, 'x'), cond('b', Comparison.IS_EQUAL, 'y')], answers)).toBe(true);
+        expect(evaluateConditions(LogicalOperator.AND, [cond('a', Comparison.IS_EQUAL, 'x'), cond('b', Comparison.IS_EQUAL, 'nope')], answers)).toBe(false);
+    });
+
+    it('OR requires any condition', () => {
+        expect(evaluateConditions(LogicalOperator.OR, [cond('a', Comparison.IS_EQUAL, 'nope'), cond('b', Comparison.IS_EQUAL, 'y')], answers)).toBe(true);
+        expect(evaluateConditions(LogicalOperator.OR, [cond('a', Comparison.IS_EQUAL, 'nope'), cond('b', Comparison.IS_EQUAL, 'nope')], answers)).toBe(false);
+    });
+
+    it('empty or incomplete condition sets never match', () => {
+        expect(evaluateConditions(LogicalOperator.AND, [], answers)).toBe(false);
+        expect(evaluateConditions(LogicalOperator.AND, undefined, answers)).toBe(false);
+        // a condition without a fieldId is not evaluatable
+        expect(evaluateConditions(LogicalOperator.AND, [cond('', Comparison.IS_EQUAL, 'x')], answers)).toBe(false);
+    });
+});
+
+/* --------------------------- field visibility ---------------------------- */
+
+describe('field visibility (SHOW / HIDE)', () => {
+    const show = { action: 'SHOW', operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_EQUAL, 'yes')] };
+    const hide = { ...show, action: 'HIDE' };
+
+    it('SHOW hides the field until conditions match', () => {
+        expect(isFieldHiddenByLogic(field('f', FieldTypes.SHORT_TEXT, show), {})).toBe(true);
+        expect(isFieldHiddenByLogic(field('f', FieldTypes.SHORT_TEXT, show), { q: textAnswer('yes') })).toBe(false);
+    });
+
+    it('HIDE shows the field until conditions match', () => {
+        expect(isFieldHiddenByLogic(field('f', FieldTypes.SHORT_TEXT, hide), {})).toBe(false);
+        expect(isFieldHiddenByLogic(field('f', FieldTypes.SHORT_TEXT, hide), { q: textAnswer('yes') })).toBe(true);
+    });
+
+    it('fields without a usable rule are always visible', () => {
+        expect(isFieldHiddenByLogic(field('f'), {})).toBe(false);
+        expect(isFieldHiddenByLogic(field('f', FieldTypes.SHORT_TEXT, { action: 'SHOW', operator: 'AND', conditions: [] }), {})).toBe(false);
+    });
+
+    it('getHiddenFieldIds collects only hidden fields', () => {
+        const fields = [field('a', FieldTypes.SHORT_TEXT, show), field('b')];
+        expect([...getHiddenFieldIds(fields, {})]).toEqual(['a']);
+        expect([...getHiddenFieldIds(fields, { q: textAnswer('yes') })]).toEqual([]);
+    });
+
+    it('areConditionsMet mirrors evaluateConditions', () => {
+        expect(areConditionsMet(show as any, { q: textAnswer('yes') })).toBe(true);
+        expect(areConditionsMet(show as any, {})).toBe(false);
+    });
+});
+
+/* ------------------------------- page jumps ------------------------------ */
+
+describe('resolveJumpTargetId', () => {
+    const s1 = slide('s1', [field('q')], [
+        { operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_EQUAL, 'a')], target: 's2' },
+        { operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_EQUAL, 'b')], target: JUMP_TARGET_SUBMIT }
+    ]);
+
+    it('returns null with no jumps or no match', () => {
+        expect(resolveJumpTargetId(slide('x'), {})).toBeNull();
+        expect(resolveJumpTargetId(s1, { q: textAnswer('zzz') })).toBeNull();
+    });
+
+    it('first matching rule wins, in order', () => {
+        expect(resolveJumpTargetId(s1, { q: textAnswer('a') })).toBe('s2');
+        expect(resolveJumpTargetId(s1, { q: textAnswer('b') })).toBe(JUMP_TARGET_SUBMIT);
+        const both = slide('s', [], [
+            { operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_NOT_EMPTY)], target: 'first' },
+            { operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_NOT_EMPTY)], target: 'second' }
+        ]);
+        expect(resolveJumpTargetId(both, { q: textAnswer('x') })).toBe('first');
+    });
+
+    it('rules with empty conditions are skipped', () => {
+        const s = slide('s', [], [{ operator: LogicalOperator.AND, conditions: [], target: 's2' }]);
+        expect(resolveJumpTargetId(s, { q: textAnswer('a') })).toBeNull();
+    });
+});
+
+describe('isJumpTargetValid', () => {
+    const ids = new Set(['s1', 's2']);
+    it('accepts existing slides and the submit sentinel', () => {
+        expect(isJumpTargetValid('s1', ids)).toBe(true);
+        expect(isJumpTargetValid(JUMP_TARGET_SUBMIT, ids)).toBe(true);
+    });
+    it('rejects deleted pages and empty targets', () => {
+        expect(isJumpTargetValid('deleted', ids)).toBe(false);
+        expect(isJumpTargetValid(undefined, ids)).toBe(false);
+        expect(isJumpTargetValid('', ids)).toBe(false);
+    });
+});
+
+/* ----------------------------- badge helpers ----------------------------- */
+
+describe('fieldHasLogic / slideHasLogic', () => {
+    const rule = { action: 'SHOW', operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_NOT_EMPTY)] };
+
+    it('detects field visibility rules', () => {
+        expect(fieldHasLogic(field('f', FieldTypes.SHORT_TEXT, rule))).toBe(true);
+        expect(fieldHasLogic(field('f'))).toBe(false);
+        expect(fieldHasLogic(undefined)).toBe(false);
+    });
+
+    it('detects slide logic via jumps or field rules', () => {
+        expect(slideHasLogic(slide('s', [], [{ operator: 'AND', conditions: [cond('q', Comparison.IS_EQUAL, 'x')], target: 't' }]))).toBe(true);
+        expect(slideHasLogic(slide('s', [field('f', FieldTypes.SHORT_TEXT, rule)]))).toBe(true);
+        expect(slideHasLogic(slide('s', [field('f')]))).toBe(false);
+        // a jump with zero conditions is not usable logic
+        expect(slideHasLogic(slide('s', [], [{ operator: 'AND', conditions: [], target: 't' }]))).toBe(false);
+    });
+});
+
+/* --------------------------- orphaned-rule prune ------------------------- */
+
+describe('pruneOrphanedConditions', () => {
+    it('drops conditions pointing at deleted fields, and rules left empty', () => {
+        const slides = [
+            slide('s1', [field('alive')], [
+                { operator: LogicalOperator.AND, conditions: [cond('alive', Comparison.IS_NOT_EMPTY), cond('ghost', Comparison.IS_EQUAL, 'x')], target: 's2' },
+                { operator: LogicalOperator.AND, conditions: [cond('ghost', Comparison.IS_EQUAL, 'x')], target: 's2' }
+            ]),
+            slide('s2', [])
+        ];
+        pruneOrphanedConditions(slides);
+        const jumps = slides[0].properties!.jumps as any[];
+        expect(jumps).toHaveLength(1); // ghost-only rule removed entirely
+        expect(jumps[0].conditions).toHaveLength(1);
+        expect(jumps[0].conditions[0].fieldId).toBe('alive');
+    });
+
+    it('cleans field-visibility logic the same way', () => {
+        const target = field('t', FieldTypes.SHORT_TEXT, { action: 'SHOW', operator: 'AND', conditions: [cond('ghost', Comparison.IS_EQUAL, 'x')] });
+        const slides = [slide('s1', [target])];
+        pruneOrphanedConditions(slides);
+        expect(slides[0].properties!.fields![0].properties!.logic).toBeUndefined();
+    });
+
+    it('keeps jump targets pointing at deleted pages (surfaced as broken, not rewritten)', () => {
+        const slides = [slide('s1', [field('q')], [{ operator: LogicalOperator.AND, conditions: [cond('q', Comparison.IS_NOT_EMPTY)], target: 'deleted-page' }])];
+        pruneOrphanedConditions(slides);
+        expect((slides[0].properties!.jumps as any[])[0].target).toBe('deleted-page');
+    });
+});
+
+/* ------------------------------ flow traffic ----------------------------- */
+
+describe('computeFlowTraffic', () => {
+    const q = 'q1';
+    const pages = [
+        slide('p1', [field(q)], [{ operator: LogicalOperator.AND, conditions: [cond(q, Comparison.IS_EQUAL, 'skip')], target: JUMP_TARGET_SUBMIT }]),
+        slide('p2', []),
+        slide('p3', [])
+    ];
+
+    it('counts a purely linear response through every page', () => {
+        const t = computeFlowTraffic(pages, [{ [q]: textAnswer('hello') }]);
+        expect(t.total).toBe(1);
+        expect(t.nodeVisits.get('p1')).toBe(1);
+        expect(t.nodeVisits.get('p2')).toBe(1);
+        expect(t.nodeVisits.get('p3')).toBe(1);
+        expect(t.nextTraversals.get('__welcome__')).toBe(1);
+        expect(t.nextTraversals.get('p1')).toBe(1);
+        expect(t.jumpTraversals.size).toBe(0);
+    });
+
+    it('counts a jump-to-submit response only on the pages it saw', () => {
+        const t = computeFlowTraffic(pages, [{ [q]: textAnswer('skip') }]);
+        expect(t.nodeVisits.get('p1')).toBe(1);
+        expect(t.nodeVisits.get('p2')).toBeUndefined();
+        expect(t.jumpTraversals.get('p1:0')).toBe(1);
+        expect(t.nextTraversals.get('p1')).toBeUndefined();
+    });
+
+    it('aggregates mixed traffic (the shipped verification scenario)', () => {
+        const answers = [{ [q]: textAnswer('skip') }, { [q]: textAnswer('skip') }, { [q]: textAnswer('a') }, { [q]: textAnswer('b') }, { [q]: textAnswer('c') }, { [q]: textAnswer('d') }];
+        const t = computeFlowTraffic(pages, answers);
+        expect(t.total).toBe(6);
+        expect(t.nodeVisits.get('p1')).toBe(6);
+        expect(t.nodeVisits.get('p2')).toBe(4);
+        expect(t.jumpTraversals.get('p1:0')).toBe(2);
+        expect(t.nextTraversals.get('p1')).toBe(4);
+    });
+
+    it('jumps to a mid-form page resume the linear flow from there', () => {
+        const withMidJump = [
+            slide('a', [field(q)], [{ operator: LogicalOperator.AND, conditions: [cond(q, Comparison.IS_EQUAL, 'go')], target: 'c' }]),
+            slide('b', []),
+            slide('c', [])
+        ];
+        const t = computeFlowTraffic(withMidJump, [{ [q]: textAnswer('go') }]);
+        expect(t.nodeVisits.get('a')).toBe(1);
+        expect(t.nodeVisits.get('b')).toBeUndefined();
+        expect(t.nodeVisits.get('c')).toBe(1);
+        expect(t.jumpTraversals.get('a:0')).toBe(1);
+    });
+
+    it('broken jump targets fall back to the linear path', () => {
+        const broken = [slide('a', [field(q)], [{ operator: LogicalOperator.AND, conditions: [cond(q, Comparison.IS_NOT_EMPTY)], target: 'deleted' }]), slide('b', [])];
+        const t = computeFlowTraffic(broken, [{ [q]: textAnswer('x') }]);
+        expect(t.nodeVisits.get('b')).toBe(1);
+        expect(t.jumpTraversals.size).toBe(0);
+    });
+
+    it('terminates on cyclic rules (hop cap)', () => {
+        const loop = [
+            slide('a', [field(q)], [{ operator: LogicalOperator.AND, conditions: [cond(q, Comparison.IS_NOT_EMPTY)], target: 'b' }]),
+            slide('b', [], [{ operator: LogicalOperator.AND, conditions: [cond(q, Comparison.IS_NOT_EMPTY)], target: 'a' }])
+        ];
+        const t = computeFlowTraffic(loop, [{ [q]: textAnswer('x') }]);
+        const totalVisits = (t.nodeVisits.get('a') ?? 0) + (t.nodeVisits.get('b') ?? 0);
+        expect(totalVisits).toBeGreaterThan(0);
+        expect(totalVisits).toBeLessThanOrEqual(loop.length * 2 + 2); // capped, no infinite loop
+    });
+
+    it('handles zero submissions', () => {
+        const t = computeFlowTraffic(pages, []);
+        expect(t.total).toBe(0);
+        expect(t.nodeVisits.size).toBe(0);
+    });
+});

--- a/webapp/src/utils/object-utils.test.ts
+++ b/webapp/src/utils/object-utils.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { deepCopy } from './object-utils';
+
+describe('deepCopy', () => {
+    it('arrays stay arrays (the `{...array}` editor-crash class)', () => {
+        const copy = deepCopy([{ id: 'a' }, { id: 'b' }]);
+        expect(Array.isArray(copy)).toBe(true);
+        expect(typeof (copy as any).some).toBe('function');
+        expect(copy).toHaveLength(2);
+    });
+
+    it('nested structures are fully detached from the source', () => {
+        const src = { slides: [{ id: 's1', properties: { fields: [{ id: 'q1' }] } }] };
+        const copy = deepCopy(src);
+        copy.slides[0].properties.fields[0].id = 'mutated';
+        expect(src.slides[0].properties.fields[0].id).toBe('q1');
+    });
+
+    it('primitives and null pass through', () => {
+        expect(deepCopy(5)).toBe(5);
+        expect(deepCopy('x')).toBe('x');
+        expect(deepCopy(null)).toBeNull();
+    });
+});

--- a/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.test.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { extractTextfromJSON, getHtmlFromJson } from './get-html-from-json';
+
+const tiptap = (text: string, marks?: any[]) => ({ type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text, ...(marks ? { marks } : {}) }] }] });
+
+describe('getHtmlFromJson', () => {
+    it('wraps plain-string titles in a bold paragraph (legacy format)', () => {
+        expect(getHtmlFromJson('Hello')).toBe('<p><strong>Hello</strong></p>');
+    });
+
+    it('renders Tiptap JSON to HTML', () => {
+        expect(getHtmlFromJson(tiptap('Hi there') as any)).toContain('Hi there');
+    });
+
+    it('returns null for empty input', () => {
+        expect(getHtmlFromJson(undefined)).toBeNull();
+        expect(getHtmlFromJson('')).toBeNull();
+    });
+});
+
+describe('extractTextfromJSON', () => {
+    const field = (overrides: Partial<StandardFormFieldDto>): StandardFormFieldDto => ({ id: 'f', index: 0, type: FieldTypes.SHORT_TEXT, ...overrides });
+
+    it('strips tags from a rendered title', () => {
+        expect(extractTextfromJSON(field({ title: tiptap('Plain text') as any }))).toBe('Plain text');
+    });
+
+    it('strips tags from string titles too', () => {
+        expect(extractTextfromJSON(field({ title: 'Simple' }))).toBe('Simple');
+    });
+
+    it('falls back to the per-type placeholder for untitled fields', () => {
+        expect(extractTextfromJSON(field({}))).toBe('Enter Question');
+        expect(extractTextfromJSON(field({ type: FieldTypes.EMAIL }))).toBe('Enter Your Email Address');
+        expect(extractTextfromJSON(field({ type: FieldTypes.YES_NO }))).toBe('Are you sure?');
+    });
+});

--- a/webapp/src/utils/vvalidation-utils.test.ts
+++ b/webapp/src/utils/vvalidation-utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { validateFormOpen, validateSlide } from './vvalidation-utils';
+
+const q = (id: string, required = false, extra: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({ id, index: 0, type: FieldTypes.SHORT_TEXT, ...(required ? { validations: { required: true } } : {}), ...extra });
+
+const slide = (fields: StandardFormFieldDto[]): StandardFormFieldDto => ({ id: 's', index: 0, type: FieldTypes.SLIDE, properties: { fields } }) as StandardFormFieldDto;
+
+describe('validateSlide — the responder Next-button gate', () => {
+    it('flags required fields with no answer', () => {
+        const invalid = validateSlide(slide([q('a', true), q('b')]), {});
+        expect(Object.keys(invalid)).toEqual(['a']);
+    });
+
+    it('passes required fields that have an answer', () => {
+        const invalid = validateSlide(slide([q('a', true)]), { a: { type: 'text', text: 'hi' } });
+        expect(Object.keys(invalid)).toEqual([]);
+    });
+
+    it('optional unanswered fields never block', () => {
+        const invalid = validateSlide(slide([q('a'), q('b')]), {});
+        expect(Object.keys(invalid)).toEqual([]);
+    });
+
+    it('required matrix fields check every row', () => {
+        const matrix = q('m', true, {
+            type: FieldTypes.MATRIX,
+            properties: { fields: [q('row1'), q('row2')] }
+        });
+        // one row unanswered → the matrix is flagged
+        const invalid = validateSlide(slide([matrix]), { row1: { type: 'choice', choice: { value: 'x' } } });
+        expect(Object.keys(invalid)).toEqual(['m']);
+        // all rows answered → passes
+        const ok = validateSlide(slide([matrix]), { row1: { type: 'choice', choice: { value: 'x' } }, row2: { type: 'choice', choice: { value: 'y' } } });
+        expect(Object.keys(ok)).toEqual([]);
+    });
+});
+
+describe('validateFormOpen', () => {
+    it('forms with no close date are open', () => {
+        expect(validateFormOpen(undefined)).toBe(true);
+    });
+
+    it('future close dates are open, past ones are closed', () => {
+        expect(validateFormOpen('2999-01-01T00:00:00Z')).toBe(true);
+        expect(validateFormOpen('2000-01-01T00:00:00Z')).toBe(false);
+    });
+});

--- a/webapp/src/views/molecules/form-builder/condition-editor-shared.test.tsx
+++ b/webapp/src/views/molecules/form-builder/condition-editor-shared.test.tsx
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { Comparison } from '@app/models/types/form-builder-shared';
+import { buildSourceFields, comparisonsForField, fieldText, isConditionComplete, needsValue, newConditionFor, pageLabel } from './condition-editor-shared';
+
+const field = (id: string, index: number, opts: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({ id, index, type: FieldTypes.SHORT_TEXT, ...opts });
+
+const slide = (id: string, fields: StandardFormFieldDto[]): StandardFormFieldDto => ({ id, index: 0, type: FieldTypes.SLIDE, properties: { fields } }) as StandardFormFieldDto;
+
+const tiptapTitle = (text: string) => ({ type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] });
+
+describe('fieldText — labels always match what the canvas shows', () => {
+    it('uses a plain-string title', () => {
+        expect(fieldText(field('f', 0, { title: 'Your name?' }))).toBe('Your name?');
+    });
+
+    it('extracts text from a Tiptap JSON title', () => {
+        expect(fieldText(field('f', 0, { title: tiptapTitle('Rich title') as any }))).toBe('Rich title');
+    });
+
+    it('falls back to the type placeholder for untitled questions (canvas parity)', () => {
+        // The canvas shows "Enter Question" for an untitled short-text — the picker must match.
+        expect(fieldText(field('f', 0, { type: FieldTypes.SHORT_TEXT }))).toBe('Enter Question');
+    });
+
+    it('handles missing fields', () => {
+        expect(fieldText(undefined)).toBe('');
+    });
+});
+
+describe('pageLabel — stable, content-derived page names', () => {
+    it('includes the first question text', () => {
+        expect(pageLabel(slide('s', [field('f', 0, { title: 'Contact info' })]), 0)).toBe('Page 1 · Contact info');
+    });
+
+    it('falls back to the bare page number for empty pages', () => {
+        expect(pageLabel(slide('s', []), 2)).toBe('Page 3');
+    });
+});
+
+describe('buildSourceFields', () => {
+    const form = [slide('s1', [field('a', 0, { title: 'A' }), field('b', 1, { title: 'B' })]), slide('s2', [field('c', 0, { title: 'C' })])];
+
+    it('applies the predicate and labels with page context on multi-page forms', () => {
+        const sources = buildSourceFields(form, (_s, sIdx) => sIdx === 0);
+        expect(sources.map((s) => s.field.id)).toEqual(['a', 'b']);
+        expect(sources[0].label).toBe('Page 1 · A');
+    });
+
+    it('omits the page prefix on single-page forms', () => {
+        const sources = buildSourceFields([form[0]], () => true);
+        expect(sources[0].label).toBe('A');
+    });
+});
+
+describe('comparisonsForField — comparators adapt to the source type', () => {
+    it('Yes/No only offers equality', () => {
+        const c = comparisonsForField(field('f', 0, { type: FieldTypes.YES_NO }));
+        expect(c).toEqual([Comparison.IS_EQUAL, Comparison.IS_NOT_EQUAL]);
+    });
+
+    it('numeric types offer ordering comparators', () => {
+        const c = comparisonsForField(field('f', 0, { type: FieldTypes.NUMBER }));
+        expect(c).toContain(Comparison.GREATER_THAN);
+        expect(c).toContain(Comparison.LESS_THAN_EQUAL);
+        expect(c).not.toContain(Comparison.CONTAINS);
+    });
+
+    it('multi-select choice fields use membership comparators', () => {
+        const single = comparisonsForField(field('f', 0, { type: FieldTypes.MULTIPLE_CHOICE }));
+        expect(single).toContain(Comparison.IS_EQUAL);
+        const multi = comparisonsForField(field('f', 0, { type: FieldTypes.MULTIPLE_CHOICE, properties: { allowMultipleSelection: true } }));
+        expect(multi).toContain(Comparison.CONTAINS);
+        expect(multi).not.toContain(Comparison.IS_EQUAL);
+    });
+
+    it('text types offer the full string set', () => {
+        const c = comparisonsForField(field('f', 0));
+        expect(c).toEqual(expect.arrayContaining([Comparison.CONTAINS, Comparison.STARTS_WITH, Comparison.ENDS_WITH, Comparison.IS_EMPTY]));
+    });
+});
+
+describe('rule completeness', () => {
+    it('needsValue is false only for the emptiness checks', () => {
+        expect(needsValue(Comparison.IS_EMPTY)).toBe(false);
+        expect(needsValue(Comparison.IS_NOT_EMPTY)).toBe(false);
+        expect(needsValue(Comparison.IS_EQUAL)).toBe(true);
+    });
+
+    it('isConditionComplete requires field, comparison, and (when needed) a value', () => {
+        expect(isConditionComplete({ fieldId: 'f', fieldType: 't', comparison: Comparison.IS_EQUAL, value: 'x' })).toBe(true);
+        expect(isConditionComplete({ fieldId: 'f', fieldType: 't', comparison: Comparison.IS_EQUAL, value: '' })).toBe(false);
+        expect(isConditionComplete({ fieldId: 'f', fieldType: 't', comparison: Comparison.IS_EMPTY, value: '' })).toBe(true);
+        expect(isConditionComplete({ fieldId: '', fieldType: 't', comparison: Comparison.IS_EQUAL, value: 'x' })).toBe(false);
+        expect(isConditionComplete(undefined)).toBe(false);
+    });
+
+    it('newConditionFor seeds from the first source (or empty when none)', () => {
+        const sources = buildSourceFields([slide('s1', [field('a', 0, { title: 'A' })])], () => true);
+        expect(newConditionFor(sources)).toMatchObject({ fieldId: 'a', comparison: Comparison.IS_EQUAL, value: '' });
+        expect(newConditionFor([])).toMatchObject({ fieldId: '', comparison: Comparison.IS_EQUAL });
+    });
+});

--- a/webapp/src/views/molecules/form/trust-layer.test.tsx
+++ b/webapp/src/views/molecules/form/trust-layer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import TrustLayer from './trust-layer';
+
+describe('TrustLayer — the privacy story on every form (Design-Language §4)', () => {
+    it('names who is collecting the responses', () => {
+        render(<TrustLayer ownerName="Acme Corp" />);
+        expect(screen.getByText(/Collected by/)).toBeInTheDocument();
+        expect(screen.getByText(/Acme Corp/)).toBeInTheDocument();
+    });
+
+    it('links to the privacy policy only when a URL exists', () => {
+        const { rerender } = render(<TrustLayer ownerName="Acme" privacyUrl="https://acme.test/privacy" />);
+        const link = screen.getByRole('link', { name: /how your data is used/i });
+        expect(link).toHaveAttribute('href', 'https://acme.test/privacy');
+
+        rerender(<TrustLayer ownerName="Acme" />);
+        expect(screen.queryByRole('link', { name: /how your data is used/i })).not.toBeInTheDocument();
+    });
+
+    it('always states the right to view or delete the response', () => {
+        render(<TrustLayer ownerName="Acme" />);
+        expect(screen.getByText(/view or delete your response/i)).toBeInTheDocument();
+    });
+
+    it('shows purpose and retention when provided', () => {
+        render(<TrustLayer ownerName="Acme" purpose="To schedule your appointment" retention="kept for 90 days" />);
+        expect(screen.getByText(/schedule your appointment/i)).toBeInTheDocument();
+        expect(screen.getByText(/kept for 90 days/i)).toBeInTheDocument();
+    });
+});

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.test.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { describe, expect, it, vi } from 'vitest';
+
+// RenderImage drags in the whole builder field registry — irrelevant here.
+vi.mock('@app/views/organism/form-builder/fields/render-field', () => ({
+    RenderImage: () => null,
+    default: () => null
+}));
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import QuestionWrapper from './question-wrapper';
+
+const field = (overrides: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({ id: 'f1', index: 0, type: FieldTypes.SHORT_TEXT, title: 'Your name?', ...overrides });
+
+/** Renders QuestionWrapper with optional pre-seeded invalid fields. */
+const renderWrapper = (f: StandardFormFieldDto, invalid?: Record<string, any[]>) => {
+    const Harness = () => {
+        const { setInvalidFields } = useFormResponse();
+        const [ready, setReady] = React.useState(!invalid);
+        React.useEffect(() => {
+            if (invalid) {
+                setInvalidFields(invalid as any);
+                setReady(true);
+            }
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
+        return ready ? <QuestionWrapper field={f} /> : null;
+    };
+    return render(
+        <Provider>
+            <Harness />
+        </Provider>
+    );
+};
+
+describe('QuestionWrapper — no-dark-patterns contracts (Design-Language §5)', () => {
+    it('marks optional answerable fields explicitly — optionality is never hidden', () => {
+        renderWrapper(field());
+        expect(screen.getByText('Optional')).toBeInTheDocument();
+    });
+
+    it('does not mark required fields as optional', () => {
+        renderWrapper(field({ validations: { required: true } }));
+        expect(screen.queryByText('Optional')).not.toBeInTheDocument();
+    });
+
+    it('display-only fields (statements) carry no optional marker', () => {
+        renderWrapper(field({ type: FieldTypes.TEXT }));
+        expect(screen.queryByText('Optional')).not.toBeInTheDocument();
+    });
+
+    it('renders the question title', () => {
+        renderWrapper(field());
+        expect(screen.getByText('Your name?')).toBeInTheDocument();
+    });
+
+    it('shows calm, instructive validation copy when the field is invalid', () => {
+        renderWrapper(field({ validations: { required: true } }), { f1: [0] });
+        expect(screen.getByText('Please answer this question to continue.')).toBeInTheDocument();
+    });
+
+    it('shows no validation message when the field is valid', () => {
+        renderWrapper(field());
+        expect(screen.queryByText(/Please answer/)).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Summary

103 new tests (112 total, ~1.2s runtime) pinning down the behavior shipped in #542 so future features can't silently break it. **Zero production code changed** — this PR adds test files only.

| Suite | Tests | Protects |
|---|---|---|
| `utils/conditional-logic` | 36 | Every comparison operator per field type, AND/OR folding, SHOW/HIDE visibility, first-match-wins jump resolution, broken-target rejection, orphan pruning, and `computeFlowTraffic` replay (linear/jump/submit paths, the shipped 6-response verification scenario, cycle termination via hop cap) |
| `store/jotai/field-selectors` | 13 | Undo/redo: load-baseline guard (undo can never blank a loaded form), dedupe of identical commits, redo truncation, deep-copied snapshots; delete sweeps orphaned rules; duplicateSlide regenerates ids and drops canvas position |
| `store/jotai/responder-form-state` | 7 | Jump-aware history stack — Back retraces jumps instead of index−1 |
| `store/jotai/responder-form-response` | 7 | The exact answer shapes the evaluator + submit payload read |
| `views/.../condition-editor-shared` | 15 | Canvas-parity labels (`fieldText`/`pageLabel`), page-context source labels, per-type comparator sets, rule completeness |
| `question-wrapper` + `trust-layer` | 10 | No-dark-patterns contracts (explicit "Optional", calm validation copy) and the trust-layer promises |
| `vvalidation-utils`, `object-utils`, `get-html-from-json` | 15 | `validateSlide` required/matrix gate, `deepCopy` arrays-stay-arrays (the `{...array}` editor-crash class), rich-text placeholder parity |

Several tests encode bugs we actually hit during #542 (the `{...array}` atom poisoning, undo-past-baseline data loss, silently orphaned logic rules) — those regressions are now caught at PR time.

## Notes
- No infra changes: Vitest + testing-library were already configured, and the existing `webapp-tests` CI job already runs `yarn test:run`, so this suite gates every PR from now on.
- Test files remain excluded from the Next build tsconfig (no impact on `next build`).
- Deliberately out of scope: the React Flow canvas component (better served by a future Playwright E2E pass) and redux/router-coupled page components (low value-to-brittleness).

## Test plan
- [x] `yarn test:run` — 12 files, 112 tests, all green locally
- [x] CI `webapp-tests` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)