### PR TITLE
Flow builder: drop-off analytics, templates, a11y + self-hosted Umami

### DIFF
--- a/.env.deployment
+++ b/.env.deployment
@@ -46,6 +46,17 @@ AES_HEX_KEY='UAW6iquPs8Q2ZdKqjgIWcBZ-H8kPsGyFzedSGis7ZTA='
 
 GOOGLE_AES_KEY='UAW6iquPs8Q2ZdKqjgIWcBZ-H8kPsGyFzedSGis7ZTA='
 
+# Umami (self-hosted product analytics — see
+# plans/umami-self-hosted-form-analytics.md). UMAMI_URL is set on the backend
+# service itself in docker-compose.deployment.yml (internal docker network);
+# only the credentials/website id need to come from here. UMAMI_SCRIPT_URL is
+# browser-facing — point it at wherever you expose the umami service publicly
+# (e.g. http://<host>:3003/script.js, or a reverse-proxied domain).
+UMAMI_USERNAME=
+UMAMI_PASSWORD=
+UMAMI_WEBSITE_ID=
+UMAMI_SCRIPT_URL=
+
 #Mail
 MAIL_USER=
 MAIL_PASSWORD=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,9 @@ Public site: https://bettercollected.com · License: see [LICENSE](LICENSE).
 | [common/](common/) | Python package (Beanie/JWT/crypto) | — | Shared models/enums/services for all Python services |
 
 **Infra** (via `docker-compose.local.yml` / `docker-compose.deployment.yml`): **MongoDB** (app data),
-**PostgreSQL + Temporal server** (workflow engine), **Redis**, **nginx** (routes the admin / client / custom-domain hosts).
+**PostgreSQL + Temporal server** (workflow engine), **Redis**, **nginx** (routes the admin / client / custom-domain
+hosts), **Umami + its own PostgreSQL** (self-hosted product analytics, admin UI on `:3003` — see
+`backend/AGENTS.md` "Analytics (Umami)" and `plans/umami-self-hosted-form-analytics.md`).
 
 > Note: `integrations/typeform/` and `common/` are referenced by build scripts but live in separate repos /
 > are vendored per service. Only `integrations/google` and a top-level `common/` are present in this checkout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   `TypeError` instead of a clean HTTP error (the app's custom `HTTPException`
   takes `content=`, not `detail=`); a failed retry after a 401 also went
   unchecked instead of surfacing a clean error.
+- Form analytics `/stats` endpoint 500'd against current self-hosted Umami's
+  response shape (flat ints + a `comparison` object, not nested `{value,
+  prev}` per metric) — surfaced once Umami was actually reachable end-to-end.
+- Local dev: `nginx-local.conf` 502'd on the client-host/custom-domain ports
+  (e.g. a form's share URL) because it proxied to `localhost:3000`, which
+  inside the nginx container isn't the host where webapp/backend actually run.
 - Backend boots without an `OPENAI_API_KEY` (OpenAI client is created lazily).
 - Forms listing/pagination failure (fastapi-pagination under Starlette 1.x).
 - Login "Failed to send OTP" flow (route, API host, and cookie-domain issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   Job application with screening) auto-seeded on every startup — idempotent,
   gated by `DEFAULT_SEED_FLOW_TEMPLATES`/`DEFAULT_WORKSPACE_ID`. See
   `backend/AGENTS.md` "Seed scripts" for the env vars and how to add more.
+- Self-hosted product analytics: Umami now ships as a first-class Docker
+  Compose service (its own Postgres, admin UI on `:3003`) instead of a
+  BetterCollected-hosted default — no self-hosted deployment now silently
+  phones home. Form views are attributed to a canonical
+  `/{workspace_name}/forms/{slug}` path from the webapp regardless of
+  client-host vs. custom-domain routing. See `backend/AGENTS.md`
+  "Analytics (Umami)" and `plans/umami-self-hosted-form-analytics.md`.
 
 ### Changed
 
@@ -54,6 +61,10 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 - Invalid nested `<button>` in the form-published modal.
 - Analytics now distinguishes a genuine load error (with a retry) from an
   empty state.
+- Backend Umami client (`umami_client.py`): error paths raised a raw
+  `TypeError` instead of a clean HTTP error (the app's custom `HTTPException`
+  takes `content=`, not `detail=`); a failed retry after a 401 also went
+  unchecked instead of surfacing a clean error.
 - Backend boots without an `OPENAI_API_KEY` (OpenAI client is created lazily).
 - Forms listing/pagination failure (fastapi-pagination under Starlette 1.x).
 - Login "Failed to send OTP" flow (route, API host, and cookie-domain issues).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 - Dependabot configuration for weekly npm, uv, and GitHub Actions updates.
 - Initial frontend test suite (Vitest + Testing Library) with a shared config.
 - Mailpit for catching outbound email in local development.
+- Backend: flow-native template gallery (Support triage, Lead qualification,
+  Job application with screening) auto-seeded on every startup — idempotent,
+  gated by `DEFAULT_SEED_FLOW_TEMPLATES`/`DEFAULT_WORKSPACE_ID`. See
+  `backend/AGENTS.md` "Seed scripts" for the env vars and how to add more.
 
 ### Changed
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,6 +52,22 @@ ELASTIC_APM_ENVIRONMENT=
 #Template
 TEMPLATE_PREDEFINED_WORKSPACE_ID=
 
-
-# Workspace that owns the predefined template gallery
+# Predefined template gallery (see backend/AGENTS.md "Seed scripts" for the full
+# writeup). The templates API (`GET /templates`) only serves public templates
+# whose workspace_id matches DEFAULT_WORKSPACE_ID — if it's unset, the gallery
+# is always empty, no matter what's in the DB.
+#
+# DEFAULT_WORKSPACE_ID must be a real, valid ObjectId hex string (any workspace
+# id works — it doesn't need to be an existing/real workspace since predefined
+# templates are looked up by this id, not by a workspace document). Leaving it
+# blank/unset is safe: the gallery is simply empty and startup seeding no-ops
+# with a log warning instead of failing.
 DEFAULT_WORKSPACE_ID=
+# Show the "Templates" section in the create-form UI at all (independent of
+# whether any templates are actually seeded).
+DEFAULT_SHOW_TEMPLATES=false
+# Auto-seed the flow-native template gallery (backend/scripts/seed_flow_templates.py)
+# on every backend startup. Idempotent — only creates templates that don't
+# already exist by title, never overwrites. Defaults to true; set false to
+# disable entirely (e.g. if you manage the gallery by hand).
+DEFAULT_SEED_FLOW_TEMPLATES=true

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -71,3 +71,15 @@ DEFAULT_SHOW_TEMPLATES=false
 # already exist by title, never overwrites. Defaults to true; set false to
 # disable entirely (e.g. if you manage the gallery by hand).
 DEFAULT_SEED_FLOW_TEMPLATES=true
+
+# Umami (self-hosted product analytics — see
+# plans/umami-self-hosted-form-analytics.md). All four must be set for the
+# `/{workspace_name}/forms/{slug}/{stats,pageviews,metrics}` endpoints to work;
+# if any is missing they return 503 "Analytics is not configured" instead of
+# silently failing. `docker compose -f docker-compose.local.yml up` starts a
+# local Umami at http://localhost:3003 (default login admin/umami) — log in,
+# change the password, create a website, then paste its id below.
+UMAMI_URL=http://localhost:3003
+UMAMI_USERNAME=
+UMAMI_PASSWORD=
+UMAMI_WEBSITE_ID=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,3 +52,6 @@ ELASTIC_APM_ENVIRONMENT=
 #Template
 TEMPLATE_PREDEFINED_WORKSPACE_ID=
 
+
+# Workspace that owns the predefined template gallery
+DEFAULT_WORKSPACE_ID=

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -53,6 +53,36 @@ Beanie Documents are registered in [backend/app/handlers/database.py](backend/ap
 (`User`, `StandardForm`, `StandardFormResponse`, `Consent`) come from the shared `common` package, not from here.
 APScheduler uses a separate DB (`init_scheduler_db`).
 
+## Seed scripts
+
+`backend/scripts/` holds idempotent seed scripts that populate collections a fresh (or already-running) environment
+needs but that don't belong in a migration. Pattern to follow for new ones: a reusable `async def seed_x(...)`
+function that assumes Beanie is already initialized (so it can be called from `lifespan` on every boot), plus a thin
+`_main()`/`if __name__ == "__main__":` CLI wrapper that creates its own Mongo client for one-off manual runs. Never
+overwrite existing data — check-then-create, so re-running (including "run" via a normal app restart) is always safe.
+
+**`seed_flow_templates.py`** — seeds the flow-native template gallery (branching used as the hook: support triage,
+lead qualification, job-application screening). It's wired into [asgi.py](backend/app/asgi.py)'s `lifespan`
+right after `init_db`, so **it runs automatically on every backend startup** — an already-deployed environment picks
+up new/changed templates the next time it restarts, no manual step required.
+
+- Gated by `DEFAULT_SEED_FLOW_TEMPLATES` (`DefaultResourcesWorkspaceSettings`, default `true`). Set `false` to
+  disable if you manage the gallery by hand.
+- Requires `DEFAULT_WORKSPACE_ID` to be a valid ObjectId hex string — templates are matched to the gallery by
+  `workspace_id`, and the templates API (`GET /templates`) only serves public templates from that one workspace id.
+  **If it's unset, seeding is skipped with a log warning** (not an error) — this is also why an empty/misconfigured
+  `DEFAULT_WORKSPACE_ID` silently produces an empty gallery even with templates in the DB: check this first.
+- Idempotent by title + `builder_version="v2"` — never overwrites an existing template, so hand-edits in the DB
+  survive restarts.
+- To add a template: write a new zero-arg builder function returning `{title, description, category, fields}` (see
+  `support_triage()`/`lead_qualification()` for the shape) and add it to `TEMPLATE_BUILDERS`.
+- To force a re-seed of a changed template, delete it from `form_templates` first (by title) — the next restart (or
+  a manual run) recreates it.
+- Manual one-off run (e.g. without restarting the app): `uv run python -m scripts.seed_flow_templates` from `backend/`.
+- **Gotcha this script already tripped on:** `PydanticObjectId` fields don't validate an *empty string* the way you'd
+  expect from an "unset" env var — double-check with a real value, not just `KEY=` in `.env`, if the gallery stays
+  empty.
+
 ## Cross-service integration points
 
 - **Auth:** `services/auth_service.py` — OAuth state + OTP, JWT via `common.services.jwt_service`; refresh-token

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -83,6 +83,29 @@ up new/changed templates the next time it restarts, no manual step required.
   expect from an "unset" env var — double-check with a real value, not just `KEY=` in `.env`, if the gallery stays
   empty.
 
+## Analytics (Umami)
+
+Form-view analytics (`FormAnalyticsRouter` — `/{workspace_name}/forms/{slug}/{stats,pageviews,metrics}`) proxy a
+self-hosted [Umami](https://umami.is) instance via `services/umami_client.py`. It used to default to a
+BetterCollected-hosted Umami; that's gone — see `plans/umami-self-hosted-form-analytics.md` for the full rationale
+and architecture.
+
+- **Local dev:** `docker compose -f docker-compose.local.yml up` starts Umami at `http://localhost:3003` (default
+  login `admin`/`umami` — change it). Create a website there, copy its id into `UMAMI_WEBSITE_ID`.
+- **Config** (`config/UmamiSettings.py`, env prefix `UMAMI_`): `URL`, `USERNAME`, `PASSWORD`, `WEBSITE_ID` — all four
+  required. `UmamiClient.authenticate()` checks `settings.umami_settings.is_configured` up front and raises a clean
+  503 ("Analytics is not configured on this instance.") instead of attempting a doomed login — check this first if
+  the analytics endpoints 503 unexpectedly.
+- **Gotcha this file already tripped on:** the app's custom `HTTPException` (`app/exceptions/http.py`) takes a
+  `content=` kwarg, not FastAPI's `detail=` — passing `detail=` raises a `TypeError` instead of the intended clean
+  error. Already fixed in `umami_client.py`; keep this in mind if you add more raises there.
+- Canonical path construction (`form_url = f"/{workspace_name}/forms/{slug}"`) must stay in sync with the webapp's
+  `trackCanonicalFormView` helper (`webapp/src/lib/analytics/umami.ts`) — both sides hard-code the same shape so
+  custom-domain and client-host traffic land under one path.
+- Deployment: `docker-compose.deployment.yml`'s `backend` service sets `UMAMI_URL=http://umami:3000` (internal
+  docker network) automatically — only `UMAMI_USERNAME`/`UMAMI_PASSWORD`/`UMAMI_WEBSITE_ID` need to come from
+  `.env.deployment`.
+
 ## Cross-service integration points
 
 - **Auth:** `services/auth_service.py` — OAuth state + OTP, JWT via `common.services.jwt_service`; refresh-token

--- a/backend/backend/app/asgi.py
+++ b/backend/backend/app/asgi.py
@@ -23,6 +23,7 @@ from backend.app.handlers.database import close_db, init_db
 from backend.app.middlewares import DynamicCORSMiddleware, include_middlewares
 from backend.app.router import root_api_router
 from backend.app.utils import AiohttpClient
+from scripts.seed_flow_templates import seed_flow_templates
 
 
 @asynccontextmanager
@@ -42,6 +43,24 @@ async def lifespan(app: FastAPI):
         client = AsyncMongoClient(settings.mongo_settings.URI)
         container.database_client.override(providers.Object(client))
     await init_db(settings.mongo_settings.DB, client)
+
+    # Auto-seed the flow-native template gallery (idempotent — skips templates
+    # that already exist). Gated by DEFAULT_SEED_FLOW_TEMPLATES (default on) and
+    # a no-op without DEFAULT_WORKSPACE_ID. Never blocks startup on failure —
+    # see backend/AGENTS.md "Seed scripts" for the full writeup.
+    if settings.default_workspace_settings.SEED_FLOW_TEMPLATES:
+        workspace_id = settings.default_workspace_settings.WORKSPACE_ID
+        if not workspace_id:
+            logger.warning(
+                "DEFAULT_WORKSPACE_ID is not set — skipping flow-template gallery seeding."
+            )
+        else:
+            try:
+                result = await seed_flow_templates(workspace_id)
+                if result["seeded"]:
+                    logger.info(f"Seeded flow templates: {', '.join(result['seeded'])}")
+            except Exception:
+                logger.exception("Flow-template seeding failed; continuing startup.")
 
     yield
 

--- a/backend/backend/app/controllers/analytics_router.py
+++ b/backend/backend/app/controllers/analytics_router.py
@@ -89,7 +89,7 @@ class FormAnalyticsRouter(Routable):
         params = {k: v for k, v in params.items() if v is not None}
 
         stats_data = await self.umami_client.fetch_stats(params)
-        return StatsModel(**stats_data)
+        return StatsModel.from_umami(stats_data)
 
     @get(
         "/{workspace_name}/forms/{slug}/pageviews",

--- a/backend/backend/app/controllers/workspace_responses.py
+++ b/backend/backend/app/controllers/workspace_responses.py
@@ -1,9 +1,10 @@
 from typing import Any, List
 
 from beanie import PydanticObjectId
-from classy_fastapi import delete, get
+from classy_fastapi import delete, get, post
 from common.models.user import User
 from fastapi import Depends
+from fastapi_camelcase import CamelModel
 from fastapi_pagination import Page
 
 from backend.app.container import container
@@ -13,9 +14,17 @@ from backend.app.models.enum.user_tag_enum import UserTagType
 from backend.app.models.filter_queries.form_responses import FormResponseFilterQuery
 from backend.app.models.filter_queries.sort import SortRequest
 from backend.app.router import router
+from backend.app.schemas.flow_event import FlowEventDocument
 from backend.app.services.form_response_service import FormResponseService
 from backend.app.services.user_service import get_logged_user
 from backend.app.utils.custom_routable import CustomRoutable
+from backend.app.utils.flow_analytics import aggregate_flow_events
+
+
+class FlowEventRequest(CamelModel):
+    session_id: str
+    from_page: str
+    to_page: str
 
 
 @router(
@@ -69,6 +78,42 @@ class WorkspaceResponsesRouter(CustomRoutable):
             )
         )
         return responses
+
+    @post("/forms/{form_id}/flow-events")
+    async def record_flow_event(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        event: FlowEventRequest,
+    ):
+        """
+        Record one anonymous navigation step from a responder. Public and
+        fire-and-forget by design: no answers, no identity — see
+        FlowEventDocument. Inputs are length-capped so the open endpoint can't
+        be used to store arbitrary payloads.
+        """
+        if len(event.session_id) > 64 or len(event.from_page) > 64 or len(event.to_page) > 64:
+            return {"ok": False}
+        await FlowEventDocument(
+            form_id=form_id,
+            session_id=event.session_id,
+            from_page=event.from_page,
+            to_page=event.to_page,
+        ).save()
+        return {"ok": True}
+
+    @get("/forms/{form_id}/flow-analytics")
+    async def get_flow_analytics(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        user: User = Depends(get_logged_user),
+    ):
+        """Aggregate drop-off + transition counts for the builder's Insights overlay."""
+        events = await FlowEventDocument.find(
+            FlowEventDocument.form_id == form_id
+        ).to_list()
+        return aggregate_flow_events([e.model_dump() for e in events])
 
     @get(
         "/all-submissions",

--- a/backend/backend/app/handlers/database.py
+++ b/backend/backend/app/handlers/database.py
@@ -30,6 +30,7 @@ from backend.app.schemas.workspace_invitation import (
 from backend.app.schemas.workspace_user import (
     WorkspaceUserDocument,
 )
+from backend.app.schemas.flow_event import FlowEventDocument
 
 document_models = []
 
@@ -68,6 +69,7 @@ async def init_db(db: str, client: AsyncMongoClient):
             ResponderGroupFormDocument,
             ResponderGroupMemberDocument,
             ResponderGroupDocument,
+            FlowEventDocument,
         ]
     )
     await init_beanie(

--- a/backend/backend/app/models/dtos/stats_model_dto.py
+++ b/backend/backend/app/models/dtos/stats_model_dto.py
@@ -1,4 +1,8 @@
+from typing import Any, Dict
+
 from pydantic import BaseModel
+
+_STATS_METRICS = ("pageviews", "visitors", "visits", "bounces", "totaltime")
 
 
 class StatDetailModel(BaseModel):
@@ -12,3 +16,23 @@ class StatsModel(BaseModel):
     visits: StatDetailModel
     bounces: StatDetailModel
     totaltime: StatDetailModel
+
+    @classmethod
+    def from_umami(cls, raw: Dict[str, Any]) -> "StatsModel":
+        """Build from Umami's `/stats` response shape.
+
+        Umami returns flat current-period ints alongside a sibling
+        `comparison` object holding the previous period's ints, e.g.
+        `{"pageviews": 18, ..., "comparison": {"pageviews": 0, ...}}` —
+        not the nested `{value, prev}` per metric the rest of the app expects.
+        """
+        comparison = raw.get("comparison") or {}
+        return cls(
+            **{
+                metric: {
+                    "value": raw.get(metric, 0),
+                    "prev": comparison.get(metric, 0),
+                }
+                for metric in _STATS_METRICS
+            }
+        )

--- a/backend/backend/app/schemas/flow_event.py
+++ b/backend/backend/app/schemas/flow_event.py
@@ -1,0 +1,24 @@
+from pymongo import IndexModel
+
+from common.configs.mongo_document import MongoDocument
+
+
+class FlowEventDocument(MongoDocument):
+    """
+    A single anonymous navigation step inside a form fill.
+
+    Deliberately privacy-first: no answers, no identity — only a random
+    client-generated session id and which page led to which. This is enough to
+    aggregate per-branch traffic and drop-off without ever persisting content
+    a responder hasn't chosen to submit.
+    """
+
+    form_id: str
+    session_id: str
+    # page id, or the sentinels "__welcome__" / "__submit__"
+    from_page: str
+    to_page: str
+
+    class Settings:
+        name = "form_flow_events"
+        indexes = [IndexModel("form_id"), IndexModel("session_id")]

--- a/backend/backend/app/services/umami_client.py
+++ b/backend/backend/app/services/umami_client.py
@@ -13,6 +13,16 @@ class UmamiClient:
         self.client = httpx.AsyncClient()
 
     async def authenticate(self):
+        if not settings.umami_settings.is_configured:
+            logger.warning(
+                "Umami is not configured (UMAMI_URL/UMAMI_USERNAME/UMAMI_PASSWORD/"
+                "UMAMI_WEBSITE_ID) — analytics endpoints will be unavailable."
+            )
+            raise HTTPException(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+                content="Analytics is not configured on this instance.",
+            )
+
         auth_url = f"{settings.umami_settings.URL}/api/auth/login"
         try:
             logger.info("Attempting to authenticate with Umami API.")
@@ -31,7 +41,7 @@ class UmamiClient:
                 logger.error("Authentication failed: Token not found in response.")
                 raise HTTPException(
                     status_code=HTTPStatus.UNAUTHORIZED,
-                    detail="Authentication token not found",
+                    content="Authentication token not found",
                 )
 
             logger.info("Authenticated successfully, token acquired.")
@@ -39,7 +49,7 @@ class UmamiClient:
             logger.error(f"Authentication failed: {e}")
             raise HTTPException(
                 status_code=HTTPStatus.UNAUTHORIZED,
-                detail="Failed to authenticate",
+                content="Failed to authenticate",
             )
 
     def make_request(endpoint: str):
@@ -61,39 +71,46 @@ class UmamiClient:
                         url, headers=headers, params=params, timeout=180
                     )
                     response.raise_for_status()
-                    logger.info(
-                        f"Request to {endpoint} successful. Response: {response.json()}"
-                    )
+                    logger.info(f"Request to {endpoint} successful.")
                     return response.json()
 
                 except httpx.HTTPStatusError as e:
                     logger.error(
-                        f"Request to {endpoint} failed with status {e.response.status_code}: {e.response.text}"
+                        f"Request to {endpoint} failed with status {e.response.status_code}"
                     )
                     if e.response.status_code == 401:
                         logger.info(
                             "Token expired, re-authenticating and retrying request."
                         )
                         await self.authenticate()
-                        retry_response = await self.client.get(
-                            url,
-                            headers={"Authorization": f"Bearer {self.token}"},
-                            params=params,
-                            timeout=180,
-                        )
-                        logger.info(
-                            f"Retry response for {endpoint}: {retry_response.json()}"
-                        )
-                        return retry_response.json()
+                        try:
+                            retry_response = await self.client.get(
+                                url,
+                                headers={"Authorization": f"Bearer {self.token}"},
+                                params=params,
+                                timeout=180,
+                            )
+                            retry_response.raise_for_status()
+                            logger.info(f"Retry for {endpoint} succeeded.")
+                            return retry_response.json()
+                        except httpx.HTTPStatusError as retry_error:
+                            logger.error(
+                                f"Retry for {endpoint} failed with status "
+                                f"{retry_error.response.status_code}"
+                            )
+                            raise HTTPException(
+                                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                                content=f"Failed to fetch data from {endpoint}",
+                            )
                     raise HTTPException(
                         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                        detail=f"Failed to fetch data from {endpoint}",
+                        content=f"Failed to fetch data from {endpoint}",
                     )
                 except Exception as e:
                     logger.error(f"Unexpected error while accessing {endpoint}: {e}")
                     raise HTTPException(
                         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
-                        detail=f"Unexpected error fetching data from {endpoint}",
+                        content=f"Unexpected error fetching data from {endpoint}",
                     )
 
             return wrapper

--- a/backend/backend/app/utils/flow_analytics.py
+++ b/backend/backend/app/utils/flow_analytics.py
@@ -1,0 +1,48 @@
+"""Aggregation for anonymous flow events — kept pure for testability."""
+
+from typing import Any, Dict, List
+
+SUBMIT = "__submit__"
+
+
+def aggregate_flow_events(events: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Fold raw flow events into what the builder's Insights overlay needs.
+
+    Each event: {session_id, from_page, to_page, created_at}. A session that
+    never reaches ``__submit__`` counts as a drop-off on the last page it
+    entered (its final ``to_page``).
+
+    Returns camelCase keys (consumed directly by the webapp):
+      totalSessions, submittedSessions,
+      dropOffs: {page_id: sessions that went dark there},
+      transitions: [{from, to, count}]
+    """
+    sessions: Dict[str, List[Dict[str, Any]]] = {}
+    transitions: Dict[tuple, int] = {}
+
+    for event in events:
+        sid = event.get("session_id")
+        frm, to = event.get("from_page"), event.get("to_page")
+        if not sid or not frm or not to:
+            continue
+        sessions.setdefault(sid, []).append(event)
+        transitions[(frm, to)] = transitions.get((frm, to), 0) + 1
+
+    submitted = 0
+    drop_offs: Dict[str, int] = {}
+    for steps in sessions.values():
+        if any(s.get("to_page") == SUBMIT for s in steps):
+            submitted += 1
+            continue
+        ordered = sorted(steps, key=lambda s: s.get("created_at") or 0)
+        last_page = ordered[-1].get("to_page")
+        if last_page and last_page != SUBMIT:
+            drop_offs[last_page] = drop_offs.get(last_page, 0) + 1
+
+    return {
+        "totalSessions": len(sessions),
+        "submittedSessions": submitted,
+        "dropOffs": drop_offs,
+        "transitions": [{"from": frm, "to": to, "count": count} for (frm, to), count in sorted(transitions.items())],
+    }

--- a/backend/backend/config/UmamiSettings.py
+++ b/backend/backend/config/UmamiSettings.py
@@ -7,7 +7,11 @@ class UmamiSettings(BaseSettings):
 
     USERNAME: Optional[str] = ""
     PASSWORD: Optional[str] = ""
-    WEBSITE_ID: Optional[str] = "305e6851-f6fc-4640-8cbf-6f749768d118"
-    URL: str = "https://umami.sireto.io"
+    WEBSITE_ID: Optional[str] = ""
+    URL: Optional[str] = ""
 
     model_config = SettingsConfigDict(env_prefix="UMAMI_")
+
+    @property
+    def is_configured(self) -> bool:
+        return bool(self.URL and self.USERNAME and self.PASSWORD and self.WEBSITE_ID)

--- a/backend/backend/config/template_settings.py
+++ b/backend/backend/config/template_settings.py
@@ -5,5 +5,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class DefaultResourcesWorkspaceSettings(BaseSettings):
     WORKSPACE_ID: PydanticObjectId = None
     SHOW_TEMPLATES: bool = False
+    # Auto-seed the flow-native template gallery (scripts/seed_flow_templates.py)
+    # on every app startup. Idempotent (skips templates that already exist) and
+    # a no-op if WORKSPACE_ID is unset, so it's safe to leave on everywhere.
+    SEED_FLOW_TEMPLATES: bool = True
 
     model_config = SettingsConfigDict(env_prefix='DEFAULT_')

--- a/backend/scripts/seed_flow_templates.py
+++ b/backend/scripts/seed_flow_templates.py
@@ -5,9 +5,18 @@ Idempotent: skips any template whose title already exists with builder_version
 "v2". Uses the backend's own Beanie documents so the stored encoding is exactly
 what the API writes — never hand-rolled JSON.
 
-Run from backend/:  uv run python -m scripts.seed_flow_templates
+**This runs automatically on every backend startup** (see the call in
+`backend/app/asgi.py`'s lifespan, right after `init_db`), gated by
+`DEFAULT_SEED_FLOW_TEMPLATES` (default on) and skipped with a warning if
+`DEFAULT_WORKSPACE_ID` isn't set. That means existing/already-deployed
+environments pick up new or changed templates the next time the backend
+restarts — no manual step required. See backend/AGENTS.md "Seed scripts" for
+the full writeup (env vars, what's idempotent, how to add a template).
+
+For one-off manual runs (e.g. to seed without restarting the app), run from
+backend/:  uv run python -m scripts.seed_flow_templates
 Env: MONGO_URI (default mongodb://root:root@localhost:27017), DB name
-     bettercollected_backend.
+     bettercollected_backend, DEFAULT_WORKSPACE_ID (required — see above).
 
 Note: create_form_from_template copies template fields VERBATIM (no id
 regeneration), so the slide/field ids referenced by jumps and visibility rules
@@ -18,17 +27,7 @@ import asyncio
 import os
 import uuid
 
-from beanie import init_beanie
-from pymongo import AsyncMongoClient
-
 from backend.app.schemas.template import FormTemplateDocument
-from backend.config import settings
-
-MONGO_URI = os.environ.get("MONGO_URI", "mongodb://root:root@localhost:27017")
-DB_NAME = os.environ.get("BACKEND_DB", "bettercollected_backend")
-# Predefined (gallery) templates are served only from this workspace — the
-# same setting the templates API filters by.
-TEMPLATE_WORKSPACE_ID = settings.default_workspace_settings.WORKSPACE_ID
 
 THEME = {
     "title": "Default",
@@ -129,19 +128,31 @@ def job_screening() -> dict:
     }
 
 
-async def main() -> None:
-    client = AsyncMongoClient(MONGO_URI)
-    await init_beanie(database=client[DB_NAME], document_models=[FormTemplateDocument])
+# Add new flow-native templates here — each is a zero-arg builder returning the
+# payload shape above. Startup seeding and the CLI both iterate this tuple.
+TEMPLATE_BUILDERS = (support_triage, lead_qualification, job_screening)
 
-    for build in (support_triage, lead_qualification, job_screening):
+
+async def seed_flow_templates(workspace_id) -> dict:
+    """
+    Create any of TEMPLATE_BUILDERS that don't already exist (matched by title +
+    builder_version="v2"). Assumes Beanie is already initialized with
+    FormTemplateDocument — true both at app startup (see asgi.py) and in the
+    standalone CLI path below. Safe to call repeatedly: existing templates are
+    left untouched, never overwritten.
+
+    Returns {"seeded": [...titles...], "skipped": [...titles...]}.
+    """
+    seeded, skipped = [], []
+    for build in TEMPLATE_BUILDERS:
         payload = build()
         existing = await FormTemplateDocument.find_one(
             FormTemplateDocument.title == payload["title"], FormTemplateDocument.builder_version == "v2"
         )
         if existing:
-            print(f"skip (exists): {payload['title']}")
+            skipped.append(payload["title"])
             continue
-        # fix slide indexes
+        # fix slide/field indexes
         for i, slide in enumerate(payload["fields"]):
             slide["index"] = i
             for j, f in enumerate(slide["properties"]["fields"]):
@@ -149,7 +160,7 @@ async def main() -> None:
         doc = FormTemplateDocument(
             builder_version="v2",
             type="form",
-            workspace_id=TEMPLATE_WORKSPACE_ID,
+            workspace_id=workspace_id,
             title=payload["title"],
             description=payload["description"],
             fields=payload["fields"],
@@ -159,8 +170,34 @@ async def main() -> None:
             settings={"is_public": True},
         )
         await doc.save()
-        print(f"seeded: {payload['title']}")
+        seeded.append(payload["title"])
+    return {"seeded": seeded, "skipped": skipped}
+
+
+async def _main() -> None:
+    """Standalone CLI entry point: creates its own Mongo client + Beanie init,
+    since the app isn't running. Startup auto-seeding (asgi.py) calls
+    seed_flow_templates() directly against the already-initialized app db."""
+    from beanie import init_beanie
+    from pymongo import AsyncMongoClient
+
+    from backend.config import settings
+
+    mongo_uri = os.environ.get("MONGO_URI", "mongodb://root:root@localhost:27017")
+    db_name = os.environ.get("BACKEND_DB", "bettercollected_backend")
+    workspace_id = settings.default_workspace_settings.WORKSPACE_ID
+    if not workspace_id:
+        print("DEFAULT_WORKSPACE_ID is not set — refusing to seed without a stable predefined-templates workspace id.")
+        return
+
+    client = AsyncMongoClient(mongo_uri)
+    await init_beanie(database=client[db_name], document_models=[FormTemplateDocument])
+    result = await seed_flow_templates(workspace_id)
+    for title in result["seeded"]:
+        print(f"seeded: {title}")
+    for title in result["skipped"]:
+        print(f"skip (exists): {title}")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    asyncio.run(_main())

--- a/backend/scripts/seed_flow_templates.py
+++ b/backend/scripts/seed_flow_templates.py
@@ -1,0 +1,166 @@
+"""
+Seed flow-native v2 templates (branching logic as the starting point).
+
+Idempotent: skips any template whose title already exists with builder_version
+"v2". Uses the backend's own Beanie documents so the stored encoding is exactly
+what the API writes — never hand-rolled JSON.
+
+Run from backend/:  uv run python -m scripts.seed_flow_templates
+Env: MONGO_URI (default mongodb://root:root@localhost:27017), DB name
+     bettercollected_backend.
+
+Note: create_form_from_template copies template fields VERBATIM (no id
+regeneration), so the slide/field ids referenced by jumps and visibility rules
+below keep working in every form instantiated from these templates.
+"""
+
+import asyncio
+import os
+import uuid
+
+from beanie import init_beanie
+from pymongo import AsyncMongoClient
+
+from backend.app.schemas.template import FormTemplateDocument
+from backend.config import settings
+
+MONGO_URI = os.environ.get("MONGO_URI", "mongodb://root:root@localhost:27017")
+DB_NAME = os.environ.get("BACKEND_DB", "bettercollected_backend")
+# Predefined (gallery) templates are served only from this workspace — the
+# same setting the templates API filters by.
+TEMPLATE_WORKSPACE_ID = settings.default_workspace_settings.WORKSPACE_ID
+
+THEME = {
+    "title": "Default",
+    "primary": "#2E2E2E",
+    "secondary": "#0764EB",
+    "tertiary": "#A2C5F8",
+    "accent": "#F2F7FF",
+}
+LAYOUT = "SINGLE_COLUMN_NO_BACKGROUND"
+
+
+def _id() -> str:
+    return str(uuid.uuid4())
+
+
+def _cond(field_id: str, comparison: str, value: str = "", field_type: str = "dropdown") -> dict:
+    return {"field_id": field_id, "field_type": field_type, "comparison": comparison, "value": value}
+
+
+def _jump(field_id: str, value: str, target: str, field_type: str = "dropdown") -> dict:
+    return {"operator": "AND", "conditions": [_cond(field_id, "IS_EQUAL", value, field_type)], "target": target}
+
+
+def _slide(fields: list, jumps: list | None = None) -> dict:
+    slide = {"id": _id(), "index": 0, "type": "slide", "properties": {"layout": LAYOUT, "fields": fields}}
+    if jumps:
+        slide["properties"]["jumps"] = jumps
+    return slide
+
+
+def _q(qtype: str, title: str, extra_props: dict | None = None, required: bool = False) -> dict:
+    field = {"id": _id(), "index": 0, "type": qtype, "title": title}
+    if extra_props:
+        field["properties"] = extra_props
+    if required:
+        field["validations"] = {"required": True}
+    return field
+
+
+def _choices(*labels: str) -> dict:
+    return {"choices": [{"id": _id(), "value": label} for label in labels]}
+
+
+def support_triage() -> dict:
+    topic = _q("dropdown", "What do you need help with?", _choices("Billing", "Technical issue", "Something else"), required=True)
+    billing = _slide([_q("short_text", "Which invoice or charge is this about?")])
+    technical = _slide([_q("long_text", "Describe the issue — what did you expect, and what happened?")])
+    contact = _slide([_q("email", "Where should we reply?", required=True)])
+    intro = _slide(
+        [topic],
+        jumps=[
+            _jump(topic["id"], "Billing", billing["id"]),
+            _jump(topic["id"], "Technical issue", technical["id"]),
+            # "Something else" routes straight to contact — irrelevant pages skipped.
+            _jump(topic["id"], "Something else", contact["id"]),
+        ],
+    )
+    # After the billing branch, skip the technical page.
+    billing["properties"]["jumps"] = [_jump(topic["id"], "Billing", contact["id"])]
+    return {
+        "title": "Support triage",
+        "description": "Route billing, technical and general requests to the right questions — respondents only see what applies to them.",
+        "category": None,
+        "fields": [intro, billing, technical, contact],
+    }
+
+
+def lead_qualification() -> dict:
+    timeline = _q("yes_no", "Are you looking to get started in the next 3 months?", None, required=True)
+    details = _slide([_q("short_text", "What's the main problem you're hoping to solve?"), _q("number", "How many people are on your team?")])
+    contact = _slide([_q("email", "Best email to reach you", required=True)])
+    intro = _slide(
+        [timeline],
+        # Not in the market → polite, short exit; qualified leads continue.
+        jumps=[_jump(timeline["id"], "No", "__SUBMIT__", field_type="yes_no")],
+    )
+    return {
+        "title": "Lead qualification",
+        "description": "Qualify prospects in one question — unqualified visitors exit politely instead of filling pages that don't apply.",
+        "category": None,
+        "fields": [intro, details, contact],
+    }
+
+
+def job_screening() -> dict:
+    authorized = _q("yes_no", "Are you legally authorized to work in this role's location?", None, required=True)
+    experience = _slide([_q("long_text", "Tell us about your most relevant experience."), _q("url", "Portfolio or LinkedIn")])
+    contact = _slide([_q("email", "Contact email", required=True), _q("phone_number", "Phone number")])
+    intro = _slide(
+        [authorized],
+        jumps=[_jump(authorized["id"], "No", "__SUBMIT__", field_type="yes_no")],
+    )
+    return {
+        "title": "Job application with screening",
+        "description": "A knock-out screening question up front — ineligible applicants finish quickly, eligible ones continue to the full application.",
+        "category": None,
+        "fields": [intro, experience, contact],
+    }
+
+
+async def main() -> None:
+    client = AsyncMongoClient(MONGO_URI)
+    await init_beanie(database=client[DB_NAME], document_models=[FormTemplateDocument])
+
+    for build in (support_triage, lead_qualification, job_screening):
+        payload = build()
+        existing = await FormTemplateDocument.find_one(
+            FormTemplateDocument.title == payload["title"], FormTemplateDocument.builder_version == "v2"
+        )
+        if existing:
+            print(f"skip (exists): {payload['title']}")
+            continue
+        # fix slide indexes
+        for i, slide in enumerate(payload["fields"]):
+            slide["index"] = i
+            for j, f in enumerate(slide["properties"]["fields"]):
+                f["index"] = j
+        doc = FormTemplateDocument(
+            builder_version="v2",
+            type="form",
+            workspace_id=TEMPLATE_WORKSPACE_ID,
+            title=payload["title"],
+            description=payload["description"],
+            fields=payload["fields"],
+            theme=THEME,
+            welcome_page={"title": payload["title"], "layout": LAYOUT, "buttonText": "Start"},
+            thankyou_page=[{"layout": LAYOUT}],
+            settings={"is_public": True},
+        )
+        await doc.save()
+        print(f"seeded: {payload['title']}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/app/models/dtos/test_stats_model_dto.py
+++ b/backend/tests/app/models/dtos/test_stats_model_dto.py
@@ -1,0 +1,34 @@
+from backend.app.models.dtos.stats_model_dto import StatsModel
+
+
+def test_from_umami_reshapes_flat_response_with_comparison():
+    raw = {
+        "pageviews": 18,
+        "visitors": 2,
+        "visits": 2,
+        "bounces": 1,
+        "totaltime": 1432,
+        "comparison": {
+            "pageviews": 5,
+            "visitors": 1,
+            "visits": 1,
+            "bounces": 0,
+            "totaltime": 100,
+        },
+    }
+
+    stats = StatsModel.from_umami(raw)
+
+    assert stats.pageviews.value == 18
+    assert stats.pageviews.prev == 5
+    assert stats.totaltime.value == 1432
+    assert stats.totaltime.prev == 100
+
+
+def test_from_umami_defaults_missing_fields_to_zero():
+    stats = StatsModel.from_umami({"pageviews": 3})
+
+    assert stats.pageviews.value == 3
+    assert stats.pageviews.prev == 0
+    assert stats.visitors.value == 0
+    assert stats.visitors.prev == 0

--- a/backend/tests/app/services/test_umami_client.py
+++ b/backend/tests/app/services/test_umami_client.py
@@ -1,0 +1,74 @@
+from http import HTTPStatus
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from backend.app.exceptions.http import HTTPException
+from backend.app.services.umami_client import UmamiClient
+from backend.config import settings
+
+
+def _configure_umami(monkeypatch, **overrides):
+    defaults = {
+        "URL": "http://umami.test",
+        "USERNAME": "admin",
+        "PASSWORD": "secret",
+        "WEBSITE_ID": "site-id",
+    }
+    defaults.update(overrides)
+    for key, value in defaults.items():
+        monkeypatch.setattr(settings.umami_settings, key, value)
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "http://umami.test/api/websites/site-id/stats")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+async def test_authenticate_raises_clear_error_when_not_configured(monkeypatch):
+    _configure_umami(monkeypatch, WEBSITE_ID="")
+    client = UmamiClient()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await client.authenticate()
+
+    assert exc_info.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+
+
+async def test_fetch_stats_re_authenticates_once_on_401(monkeypatch):
+    _configure_umami(monkeypatch)
+    client = UmamiClient()
+    client.token = "stale-token"
+
+    client.client.get = AsyncMock(
+        side_effect=[
+            _http_status_error(401),
+            httpx.Response(
+                200,
+                json={"pageviews": {"value": 1}},
+                request=httpx.Request("GET", "http://umami.test"),
+            ),
+        ]
+    )
+    client.authenticate = AsyncMock(side_effect=lambda: setattr(client, "token", "fresh-token"))
+
+    result = await client.fetch_stats({})
+
+    assert result == {"pageviews": {"value": 1}}
+    assert client.authenticate.await_count == 1
+
+
+async def test_fetch_stats_raises_clean_error_when_retry_also_fails(monkeypatch):
+    _configure_umami(monkeypatch)
+    client = UmamiClient()
+    client.token = "stale-token"
+
+    client.client.get = AsyncMock(side_effect=[_http_status_error(401), _http_status_error(500)])
+    client.authenticate = AsyncMock(side_effect=lambda: setattr(client, "token", "fresh-token"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await client.fetch_stats({})
+
+    assert exc_info.value.status_code == HTTPStatus.INTERNAL_SERVER_ERROR

--- a/backend/tests/app/utils/test_flow_analytics.py
+++ b/backend/tests/app/utils/test_flow_analytics.py
@@ -1,0 +1,74 @@
+from backend.app.utils.flow_analytics import aggregate_flow_events
+
+
+def ev(sid, frm, to, ts=0):
+    return {"session_id": sid, "from_page": frm, "to_page": to, "created_at": ts}
+
+
+class TestAggregateFlowEvents:
+    def test_empty(self):
+        result = aggregate_flow_events([])
+        assert result == {
+            "totalSessions": 0,
+            "submittedSessions": 0,
+            "dropOffs": {},
+            "transitions": [],
+        }
+
+    def test_submitted_session_is_not_a_drop_off(self):
+        events = [
+            ev("s1", "__welcome__", "p1", 1),
+            ev("s1", "p1", "p2", 2),
+            ev("s1", "p2", "__submit__", 3),
+        ]
+        result = aggregate_flow_events(events)
+        assert result["totalSessions"] == 1
+        assert result["submittedSessions"] == 1
+        assert result["dropOffs"] == {}
+
+    def test_abandoned_session_drops_on_last_entered_page(self):
+        events = [
+            ev("s1", "__welcome__", "p1", 1),
+            ev("s1", "p1", "p2", 2),
+            # went dark on p2
+        ]
+        result = aggregate_flow_events(events)
+        assert result["submittedSessions"] == 0
+        assert result["dropOffs"] == {"p2": 1}
+
+    def test_out_of_order_events_use_timestamps(self):
+        events = [
+            ev("s1", "p1", "p2", 2),
+            ev("s1", "__welcome__", "p1", 1),  # arrives late
+        ]
+        result = aggregate_flow_events(events)
+        assert result["dropOffs"] == {"p2": 1}
+
+    def test_mixed_sessions_and_transition_counts(self):
+        events = [
+            # session a: submits via a jump from p1
+            ev("a", "__welcome__", "p1", 1),
+            ev("a", "p1", "__submit__", 2),
+            # session b: linear, abandons on p2
+            ev("b", "__welcome__", "p1", 1),
+            ev("b", "p1", "p2", 2),
+            # session c: abandons on p1
+            ev("c", "__welcome__", "p1", 1),
+        ]
+        result = aggregate_flow_events(events)
+        assert result["totalSessions"] == 3
+        assert result["submittedSessions"] == 1
+        assert result["dropOffs"] == {"p2": 1, "p1": 1}
+        counts = {(t["from"], t["to"]): t["count"] for t in result["transitions"]}
+        assert counts[("__welcome__", "p1")] == 3
+        assert counts[("p1", "p2")] == 1
+        assert counts[("p1", "__submit__")] == 1
+
+    def test_malformed_events_are_ignored(self):
+        events = [
+            ev("s1", "__welcome__", "p1", 1),
+            {"session_id": "", "from_page": "x", "to_page": "y"},
+            {"session_id": "s2", "from_page": None, "to_page": "y"},
+        ]
+        result = aggregate_flow_events(events)
+        assert result["totalSessions"] == 1

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 volumes:
   mongo-data:
+  umami-db-data:
 services:
   mongodb:
     image: mongo:latest
@@ -88,6 +89,9 @@ services:
     environment:
       AUTH_BASE_URL: http://auth:8000/api/v1
       AUTH_CALLBACK_URI: http://auth:8000/api/v1/auth/callback
+      # Backend reaches Umami over the compose network; only UMAMI_USERNAME/
+      # UMAMI_PASSWORD/UMAMI_WEBSITE_ID need to come from .env.deployment.
+      UMAMI_URL: http://umami:3000
     env_file:
       - .env.deployment
     ports:
@@ -95,6 +99,7 @@ services:
     depends_on:
       - temporal
       - mongodb
+      - umami
 
   auth:
     image: bettercollected/auth:nightly
@@ -119,4 +124,42 @@ services:
     image: bettercollected/integrations-google:nightly
     env_file:
       - .env.deployment
+
+  # Self-hosted product analytics (see plans/umami-self-hosted-form-analytics.md).
+  # First-pass exposure: plain host port 3003, no TLS/reverse-proxy — put it
+  # behind nginx/TLS yourself for a production deployment. After first boot,
+  # open http://<host>:3003, log in as admin/umami, change the password, create
+  # a website, then set UMAMI_WEBSITE_ID (backend + webapp) and UMAMI_SCRIPT_URL
+  # (webapp, e.g. http://<host>:3003/script.js) in .env.deployment.
+  #
+  # UMAMI_APP_SECRET below is substituted by docker compose itself (not passed
+  # through .env.deployment) — export it in your shell or put it in a root
+  # `.env` file (docker compose's own var-substitution file) before `up`:
+  #   UMAMI_APP_SECRET=$(openssl rand -hex 32)
+  umami-postgresql:
+    image: postgres:15-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: umami
+    volumes:
+      - umami-db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U umami -d umami']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    restart: always
+    ports:
+      - '3003:3000'
+    environment:
+      DATABASE_URL: postgresql://umami:umami@umami-postgresql:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+    depends_on:
+      umami-postgresql:
+        condition: service_healthy
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -33,6 +33,13 @@ services:
         ports:
             - '3001:3001'
             - '3002:3002'
+        # webapp/backend run on the host in local dev (not in this compose
+        # network), so nginx-local.conf proxies to host.docker.internal rather
+        # than localhost (which inside this container means the container
+        # itself). host-gateway is required explicitly on Linux — Docker
+        # Desktop adds it automatically, but this doesn't.
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
 
     # Local email testing: captures all outgoing mail (OTP codes, invites).
     # Host ports 1026/8026 are used to avoid clashing with any other Mailpit

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
     mongo-data:
+    umami-db-data:
 
 services:
     mongodb:
@@ -46,3 +47,36 @@ services:
         environment:
             MP_SMTP_AUTH_ACCEPT_ANY: 'true'
             MP_SMTP_AUTH_ALLOW_INSECURE: 'true'
+
+    # Self-hosted product analytics (see plans/umami-self-hosted-form-analytics.md).
+    # Admin UI: http://localhost:3003 — default login admin/umami, change it, then
+    # create a website and copy its id into backend UMAMI_WEBSITE_ID and webapp
+    # UMAMI_WEBSITE_ID. backend/webapp run on the host here (not in compose), so
+    # they reach Umami via http://localhost:3003, not the internal service name.
+    umami-postgresql:
+        image: postgres:15-alpine
+        restart: unless-stopped
+        environment:
+            POSTGRES_DB: umami
+            POSTGRES_USER: umami
+            POSTGRES_PASSWORD: umami
+        volumes:
+            - umami-db-data:/var/lib/postgresql/data
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U umami -d umami']
+            interval: 5s
+            timeout: 5s
+            retries: 5
+
+    umami:
+        image: ghcr.io/umami-software/umami:postgresql-latest
+        restart: unless-stopped
+        ports:
+            - '3003:3000'
+        environment:
+            DATABASE_URL: postgresql://umami:umami@umami-postgresql:5432/umami
+            # Local-only placeholder — deployment must override with a real secret.
+            APP_SECRET: local-dev-only-umami-app-secret
+        depends_on:
+            umami-postgresql:
+                condition: service_healthy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -127,12 +127,16 @@ The backend can migrate legacy **APScheduler** jobs into Temporal Schedules on s
 ## Observability
 
 Sentry + Elastic APM are initialized across services (backend `asgi.py`, and the Python services generally). Product
-analytics use **Umami** (`umami_client.py` + `analytics_service.py`; webapp proxies `/script.js`). Transactional email
+analytics use **Umami**, self-hosted as its own compose service (`umami_client.py` + `analytics_service.py` query it;
+the webapp loads its tracker script directly from `UMAMI_SCRIPT_URL` and calls `umami.track()` to attribute public
+form views to a canonical `/{workspace_name}/forms/{slug}` path regardless of client-host vs. custom-domain routing —
+see `backend/AGENTS.md` "Analytics (Umami)" and `plans/umami-self-hosted-form-analytics.md`). Transactional email
 and events go through **Brevo** / SMTP (`brevo_service.py`, `mail_service.py`).
 
 ## Deployment
 
 - Images built per service (`.github/workflows/build-images.yml`), tagged `bettercollected/<service>:nightly`.
 - `docker-compose.deployment.yml` runs the full stack (webapp, backend, auth, both integrations, temporal + workers,
-  mongo + seed, postgres, nginx). `deploy.sh` / `Dockerfile.*.mongo-seed` handle seeding.
-- nginx (`nginx-deployment.conf`) fronts the admin/client/custom-domain hosts.
+  mongo + seed, postgres, nginx, **umami + its own postgres**). `deploy.sh` / `Dockerfile.*.mongo-seed` handle seeding.
+- nginx (`nginx-deployment.conf`) fronts the admin/client/custom-domain hosts. Umami's admin UI is exposed directly on
+  host port `3003` in this first pass (no nginx/TLS routing yet).

--- a/nginx-local.conf
+++ b/nginx-local.conf
@@ -3,7 +3,7 @@ server {
     listen 3000;
     
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
     }
 }
@@ -12,7 +12,7 @@ server {
     listen 3001;
     
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
     }
 }
@@ -21,7 +21,7 @@ server {
     listen 3002;
     
     location / {
-        proxy_pass http://localhost:3000;
+        proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
     }
 }

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -7,8 +7,12 @@ HTTP_SCHEME=http://
 # Workspace Configuration
 CUSTOM_DOMAIN_IP=135.181.40.62
 
-# Analytics & Monitoring
-UMAMI_SCRIPT_URL=https://eu.umami.is/script.js
+# Analytics & Monitoring (self-hosted Umami — see
+# plans/umami-self-hosted-form-analytics.md). `docker compose -f
+# docker-compose.local.yml up` starts Umami at http://localhost:3003 (default
+# login admin/umami); create a website there and paste its id below. The
+# script is only rendered when both vars are set.
+UMAMI_SCRIPT_URL=http://localhost:3003/script.js
 UMAMI_WEBSITE_ID=
 
 # Elastic APM

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -8,14 +8,6 @@ const nextConfig = {
         emotion: true,
         removeConsole: false
     },
-    async rewrites() {
-        return [
-            {
-                source: '/script.js',
-                destination: 'https://umami.sireto.io/script.js'
-            }
-        ];
-    },
     async headers() {
         return [
             {

--- a/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/create/page.tsx
+++ b/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/create/page.tsx
@@ -128,7 +128,9 @@ export default function CreateFormPage(props: { searchParams: Promise<{ modal?: 
                             <div className="h3-new text-black-800 mb-4 mt-12">Templates</div>
                             <div className="flex w-full flex-row flex-wrap gap-x-6 gap-y-10  ">
                                 {templates?.map((template) => (
-                                    <button key={template?.id} className="outline-none" data-umami-event={'Create Form With Template'} data-umami-event-email={authState.email}>
+                                    // Plain div: the scaled WelcomePage preview inside contains buttons,
+                                    // and <button> can't nest inside <button> (hydration error).
+                                    <div key={template?.id} className="outline-none" data-umami-event={'Create Form With Template'} data-umami-event-email={authState.email}>
                                         <div className="flex flex-col rounded-lg border border-transparent">
                                             <div
                                                 data-umami-event={'Create Form With Template'}
@@ -145,7 +147,7 @@ export default function CreateFormPage(props: { searchParams: Promise<{ modal?: 
                                             </div>
                                             <div className="p2-new mt-2 !font-medium">{template.title}</div>
                                         </div>
-                                    </button>
+                                    </div>
                                 ))}
                             </div>
                         </>

--- a/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
+++ b/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Loader from '@app/components/ui/loader';
+import { trackCanonicalFormView } from '@app/lib/analytics/umami';
 import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
 import { setForm } from '@app/store/forms/slice';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
@@ -38,6 +39,14 @@ const FetchFormWrapper = ({ slug }: { slug: string }) => {
     );
 
     const router = useRouter();
+    const trackedViewRef = useRef(false);
+
+    useEffect(() => {
+        if (trackedViewRef.current) return;
+        if (!workspace?.workspaceName || !data?.formId) return;
+        trackedViewRef.current = true;
+        trackCanonicalFormView(workspace.workspaceName, slug);
+    }, [workspace?.workspaceName, data?.formId, slug]);
 
     const hasFileUpload = (fields: Array<any>) => {
         let isUploadField = false;

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -76,12 +76,8 @@ export default function RootLayout({
     return (
         <html lang="en" suppressHydrationWarning>
             <body className={cn('max-h-screen overflow-auto', publicSans.variable, publicSans.className)}>
-                {environments.NEXT_PUBLIC_NODE_ENV === 'production' && environments.UMAMI_WEBSITE_ID && (
-                    <Script
-                        src="https://umami.sireto.io/script.js"
-                        data-website-id={environments.UMAMI_WEBSITE_ID}
-                        strategy="lazyOnload"
-                    />
+                {environments.UMAMI_SCRIPT_URL && environments.UMAMI_WEBSITE_ID && (
+                    <Script src={environments.UMAMI_SCRIPT_URL} data-website-id={environments.UMAMI_WEBSITE_ID} strategy="lazyOnload" />
                 )}
                 <SwRegister />
                 <script src="/api/config" defer></script>

--- a/webapp/src/lib/analytics/umami.test.ts
+++ b/webapp/src/lib/analytics/umami.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { buildCanonicalFormPath, trackCanonicalFormView } from './umami';
+
+describe('buildCanonicalFormPath', () => {
+    it('joins workspace and slug into the shared analytics path', () => {
+        expect(buildCanonicalFormPath('acme', 'contact-us')).toBe('/acme/forms/contact-us');
+    });
+});
+
+describe('trackCanonicalFormView', () => {
+    afterEach(() => {
+        delete (window as any).umami;
+        vi.restoreAllMocks();
+    });
+
+    it('does nothing when Umami is not loaded', () => {
+        expect(() => trackCanonicalFormView('acme', 'contact-us')).not.toThrow();
+    });
+
+    it('does nothing when workspace or slug is missing', () => {
+        const track = vi.fn();
+        (window as any).umami = { track };
+
+        trackCanonicalFormView('', 'contact-us');
+        trackCanonicalFormView('acme', '');
+
+        expect(track).not.toHaveBeenCalled();
+    });
+
+    it('tracks a pageview overriding url to the canonical path', () => {
+        const track = vi.fn();
+        (window as any).umami = { track };
+
+        trackCanonicalFormView('acme', 'contact-us');
+
+        expect(track).toHaveBeenCalledTimes(1);
+        const callback = track.mock.calls[0][0];
+        expect(callback({ url: '/forms/contact-us', title: 'x' })).toEqual({
+            url: '/acme/forms/contact-us',
+            title: 'x'
+        });
+    });
+
+    it('fails silently if umami.track throws', () => {
+        (window as any).umami = {
+            track: () => {
+                throw new Error('boom');
+            }
+        };
+
+        expect(() => trackCanonicalFormView('acme', 'contact-us')).not.toThrow();
+    });
+});

--- a/webapp/src/lib/analytics/umami.ts
+++ b/webapp/src/lib/analytics/umami.ts
@@ -1,0 +1,27 @@
+// Canonical form-view tracking for the self-hosted Umami integration (see
+// plans/umami-self-hosted-form-analytics.md). Public forms can be reached via
+// the client-host route (`/{workspace}/forms/{slug}`) or a custom domain
+// (`/forms/{slug}`) — both must attribute to the same analytics path, so we
+// track it explicitly instead of relying on Umami's automatic pageview.
+
+export function buildCanonicalFormPath(workspaceName: string, slug: string): string {
+    return `/${workspaceName}/forms/${slug}`;
+}
+
+type UmamiTracker = {
+    track: (payload: (props: Record<string, unknown>) => Record<string, unknown>) => void;
+};
+
+export function trackCanonicalFormView(workspaceName: string, slug: string): void {
+    if (typeof window === 'undefined' || !workspaceName || !slug) return;
+
+    const umami = (window as unknown as { umami?: UmamiTracker }).umami;
+    if (!umami || typeof umami.track !== 'function') return;
+
+    const canonicalUrl = buildCanonicalFormPath(workspaceName, slug);
+    try {
+        umami.track((props) => ({ ...props, url: canonicalUrl }));
+    } catch {
+        // Analytics must never break the form.
+    }
+}

--- a/webapp/src/store/redux/form-api.ts
+++ b/webapp/src/store/redux/form-api.ts
@@ -47,6 +47,20 @@ export const formsApi = createApi({
                 body: request.body
             })
         }),
+        // One anonymous navigation step for drop-off analytics (no answers, no identity).
+        sendFlowEvent: builder.mutation<any, { workspaceId: string; formId: string; sessionId: string; fromPage: string; toPage: string }>({
+            query: ({ workspaceId, formId, sessionId, fromPage, toPage }) => ({
+                url: `/workspaces/${workspaceId}/forms/${formId}/flow-events`,
+                method: 'POST',
+                body: { sessionId, fromPage, toPage }
+            })
+        }),
+        getFlowAnalytics: builder.query<{ totalSessions: number; submittedSessions: number; dropOffs: Record<string, number>; transitions: Array<{ from: string; to: string; count: number }> }, { workspaceId: string; formId: string }>({
+            query: ({ workspaceId, formId }) => ({
+                url: `/workspaces/${workspaceId}/forms/${formId}/flow-analytics`,
+                method: 'GET'
+            })
+        }),
         logOut: builder.query<any, any>({
             query: () => ({
                 url: `/auth/logout`,
@@ -63,4 +77,4 @@ export const formsApi = createApi({
     })
 });
 
-export const { useCreateV2FormMutation, usePatchV2FormMutation, usePublishV2FormMutation, useGetFormResponseQuery, useSubmitResponseMutation, useLazyLogOutQuery, useCreateFormWithAIMutation } = formsApi;
+export const { useCreateV2FormMutation, usePatchV2FormMutation, usePublishV2FormMutation, useGetFormResponseQuery, useSubmitResponseMutation, useSendFlowEventMutation, useGetFlowAnalyticsQuery, useLazyLogOutQuery, useCreateFormWithAIMutation } = formsApi;

--- a/webapp/src/utils/flow-session.test.ts
+++ b/webapp/src/utils/flow-session.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getFlowSessionId, resetFlowSession } from './flow-session';
+
+describe('flow-session — anonymous per-form session ids', () => {
+    it('is stable for a form within a page load', () => {
+        const a = getFlowSessionId('form-a');
+        expect(getFlowSessionId('form-a')).toBe(a);
+    });
+
+    it('differs between forms', () => {
+        expect(getFlowSessionId('form-a')).not.toBe(getFlowSessionId('form-b'));
+    });
+
+    it('reset yields a fresh attempt', () => {
+        const before = getFlowSessionId('form-c');
+        resetFlowSession('form-c');
+        expect(getFlowSessionId('form-c')).not.toBe(before);
+    });
+
+    it('looks like a uuid — random, nothing derivable about the responder', () => {
+        expect(getFlowSessionId('form-d')).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    });
+});

--- a/webapp/src/utils/flow-session.ts
+++ b/webapp/src/utils/flow-session.ts
@@ -1,0 +1,24 @@
+import { v4 } from 'uuid';
+
+/**
+ * Anonymous flow-analytics session ids: one random uuid per form per page
+ * load. Nothing about the responder is stored or derivable from it — it only
+ * lets the backend group navigation steps into "one attempt" for drop-off
+ * aggregation. Not persisted anywhere client-side either: a reload is simply
+ * a new attempt.
+ */
+const sessions = new Map<string, string>();
+
+export function getFlowSessionId(formId: string): string {
+    let id = sessions.get(formId);
+    if (!id) {
+        id = v4();
+        sessions.set(formId, id);
+    }
+    return id;
+}
+
+/** Test hook / future "restart" support. */
+export function resetFlowSession(formId: string): void {
+    sessions.delete(formId);
+}

--- a/webapp/src/views/organism/form-builder/flow-view.tsx
+++ b/webapp/src/views/organism/form-builder/flow-view.tsx
@@ -45,19 +45,35 @@ const dotStyle = (isArmed: boolean): React.CSSProperties => ({
     transition: 'all 120ms ease'
 });
 
+/** Keyboard parity for the interactive connect dots (Enter/Space = click). */
+const dotKeyDown = (handler: () => void) => (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        handler();
+    }
+};
+
 function PageNode({ id, data, selected }: NodeProps<Node<any>>) {
     return (
-        <div className={'flex w-[300px] flex-col gap-1 rounded-xl border bg-white px-4 py-3 shadow-sm transition-shadow ' + (selected ? 'border-brand-500 shadow-bubble' : 'border-black-200 hover:border-brand-300')}>
+        <div
+            aria-label={`Page ${data.pageNumber}: ${data.label} — ${data.questionCount} question${data.questionCount === 1 ? '' : 's'}`}
+            className={'flex w-[300px] flex-col gap-1 rounded-xl border bg-white px-4 py-3 shadow-sm transition-shadow ' + (selected ? 'border-brand-500 shadow-bubble' : 'border-black-200 hover:border-brand-300')}
+        >
             <Handle id="next-in" type="target" position={Position.Top} isConnectable={false} style={{ opacity: 0 }} />
             <Handle
                 id="jump-in"
                 type="target"
                 position={Position.Left}
+                role="button"
+                tabIndex={0}
+                aria-label={`Create a jump into page ${data.pageNumber}`}
                 style={dotStyle(data.armedMode === 'into')}
                 onClick={(e) => {
                     e.stopPropagation();
                     data.onDotClick?.(id, 'in');
                 }}
+                onKeyDown={dotKeyDown(() => data.onDotClick?.(id, 'in'))}
             />
             {/* Invisible right-side anchor: edges from pages in the same column enter
                 here so they bow beside the column instead of crossing it. Users still
@@ -100,11 +116,15 @@ function PageNode({ id, data, selected }: NodeProps<Node<any>>) {
                 id="jump-out"
                 type="source"
                 position={Position.Right}
+                role="button"
+                tabIndex={0}
+                aria-label={`Create a jump from page ${data.pageNumber}`}
                 style={dotStyle(data.armedMode === 'from')}
                 onClick={(e) => {
                     e.stopPropagation();
                     data.onDotClick?.(id, 'out');
                 }}
+                onKeyDown={dotKeyDown(() => data.onDotClick?.(id, 'out'))}
             />
             <Handle id="next-out" type="source" position={Position.Bottom} isConnectable={false} style={{ opacity: 0 }} />
         </div>
@@ -121,11 +141,15 @@ function TerminalNode({ id, data }: NodeProps<Node<any>>) {
                     id="jump-in"
                     type="target"
                     position={Position.Left}
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Create a jump straight to submit"
                     style={dotStyle(data.armedMode === 'into')}
                     onClick={(e) => {
                         e.stopPropagation();
                         data.onDotClick?.(id, 'in');
                     }}
+                    onKeyDown={dotKeyDown(() => data.onDotClick?.(id, 'in'))}
                 />
             )}
             {isEnd && <Handle id="jump-in-right" type="target" position={Position.Right} isConnectable={false} style={{ opacity: 0, top: '35%' }} />}
@@ -411,6 +435,14 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
     }, [armed]);
+
+    // Escape closes the page-editor overlay (matching the backdrop click).
+    useEffect(() => {
+        if (!overlayId) return;
+        const onKey = (e: KeyboardEvent) => e.key === 'Escape' && setOverlayId(null);
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [overlayId]);
     const armedName = armed ? (armed.id === '__end__' ? 'Submit' : `Page ${(slides.findIndex((s) => s.id === armed.id) ?? 0) + 1}`) : null;
 
     const onEdgesDelete = useCallback(
@@ -452,13 +484,16 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
             <div className="border-b-black-200 flex items-center justify-between border-b px-6 py-3">
                 <div>
                     <div className="text-black-900 text-base font-semibold">Flow</div>
-                    {armed ? (
-                        <div className="text-brand-600 text-xs font-medium">
-                            {armed.mode === 'from' ? `Creating a jump from ${armedName} — click the destination page` : `Creating a jump into ${armedName} — click the source page`} · Esc to cancel
-                        </div>
-                    ) : (
-                        <div className="text-black-500 text-xs">Click or drag a blue dot to branch. Select a page to edit its rules.</div>
-                    )}
+                    {/* aria-live: screen readers announce entering/leaving connect mode */}
+                    <div aria-live="polite">
+                        {armed ? (
+                            <div className="text-brand-600 text-xs font-medium">
+                                {armed.mode === 'from' ? `Creating a jump from ${armedName} — click the destination page` : `Creating a jump into ${armedName} — click the source page`} · Esc to cancel
+                            </div>
+                        ) : (
+                            <div className="text-black-500 text-xs">Click or drag a blue dot to branch. Select a page to edit its rules.</div>
+                        )}
+                    </div>
                 </div>
                 <div className="flex items-center gap-2">
                     {showInsights && flowAnalytics && flowAnalytics.totalSessions > 0 && (
@@ -585,7 +620,7 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
 
             {/* Page-editor overlay — edit content without leaving the flow */}
             {overlaySlide && (
-                <div className="absolute inset-0 z-30 flex flex-col bg-black/40 p-5" onClick={() => setOverlayId(null)}>
+                <div role="dialog" aria-modal="true" aria-label={`Edit page ${overlayIndex + 1}`} className="absolute inset-0 z-30 flex flex-col bg-black/40 p-5" onClick={() => setOverlayId(null)}>
                     <div className="flex min-h-0 flex-1 overflow-hidden rounded-xl bg-white shadow-2xl" onClick={(e) => e.stopPropagation()}>
                         <div className="bg-new-white-200 relative flex min-w-0 flex-1 flex-col overflow-hidden">
                             <div className="border-b-black-200 flex items-center justify-between border-b bg-white px-4 py-2.5">

--- a/webapp/src/views/organism/form-builder/flow-view.tsx
+++ b/webapp/src/views/organism/form-builder/flow-view.tsx
@@ -10,6 +10,7 @@ import useFormFieldsAtom from '@app/store/jotai/field-selectors';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
+import { useGetFlowAnalyticsQuery } from '@app/store/redux/form-api';
 import { useGetFormAllSubmissionsQuery } from '@app/store/workspaces/api';
 import { computeFlowTraffic, fieldHasLogic, FlowTraffic, isJumpTargetValid } from '@app/utils/conditional-logic';
 import { buildSourceFields, fieldText, newConditionFor, pageLabel } from '@app/views/molecules/form-builder/condition-editor-shared';
@@ -87,6 +88,11 @@ function PageNode({ id, data, selected }: NodeProps<Node<any>>) {
                 {data.visits !== undefined && (
                     <span className="text-black-700 bg-black-100 rounded px-1.5 py-[1px] font-semibold" title="Submissions whose path visited this page">
                         {data.visits}/{data.totalResponses} visited
+                    </span>
+                )}
+                {data.dropOffs > 0 && (
+                    <span className="rounded bg-amber-50 px-1.5 py-[1px] font-semibold text-amber-700" title="Responders whose last activity was on this page — they never submitted">
+                        {data.dropOffs} dropped here
                     </span>
                 )}
             </div>
@@ -191,6 +197,10 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
         return computeFlowTraffic(slides, submissions.map((s: any) => s?.answers ?? {}));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [showInsights, submissions, slides]);
+    // Anonymous navigation events → where responders went dark (drop-off).
+    const { data: flowAnalytics } = useGetFlowAnalyticsQuery({ workspaceId: workspace?.id, formId: standardForm?.formId } as any, {
+        skip: !showInsights || !workspace?.id || !standardForm?.formId
+    });
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const selectedIndex = slides.findIndex((s) => s.id === selectedId);
     const selectedSlide = selectedIndex >= 0 ? slides[selectedIndex] : undefined;
@@ -236,6 +246,7 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
                 brokenCount: ((slide.properties?.jumps as PageJump[] | undefined) ?? []).filter((j) => j?.conditions?.length && !isJumpTargetValid(j.target, slideIds)).length,
                 visits: traffic ? traffic.nodeVisits.get(slide.id) ?? 0 : undefined,
                 totalResponses: traffic?.total,
+                dropOffs: showInsights ? flowAnalytics?.dropOffs?.[slide.id] ?? 0 : undefined,
                 armedMode: armed?.id === slide.id ? armed.mode : undefined,
                 onDotClick: (nid: string, side: 'in' | 'out') => dotClickRef.current?.(nid, side)
             }
@@ -251,7 +262,7 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
                 deletable: false
             }
         ];
-    }, [slides, slideIds, traffic, armed]);
+    }, [slides, slideIds, traffic, armed, flowAnalytics, showInsights]);
 
     const buildEdges = useCallback((): Edge[] => {
         const edges: Edge[] = [];
@@ -332,7 +343,7 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
         setNodes(buildNodes());
         setEdges(buildEdges());
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [modelSignature, traffic, armed]);
+    }, [modelSignature, traffic, armed, flowAnalytics, showInsights]);
 
     /* ------------------------------ actions ------------------------------ */
 
@@ -450,7 +461,12 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
                     )}
                 </div>
                 <div className="flex items-center gap-2">
-                    {showInsights && !insightsLoading && traffic?.total === 0 && <span className="text-black-500 mr-1 text-xs">No responses yet</span>}
+                    {showInsights && flowAnalytics && flowAnalytics.totalSessions > 0 && (
+                        <span className="text-black-600 mr-1 text-xs">
+                            {flowAnalytics.totalSessions} started · {flowAnalytics.submittedSessions} finished
+                        </span>
+                    )}
+                    {showInsights && !insightsLoading && traffic?.total === 0 && (!flowAnalytics || flowAnalytics.totalSessions === 0) && <span className="text-black-500 mr-1 text-xs">No responses yet</span>}
                     <button
                         onClick={() => setShowInsights((v) => !v)}
                         title="Overlay how submitted responses travelled each branch"

--- a/webapp/src/views/organism/form/form-slide.tsx
+++ b/webapp/src/views/organism/form/form-slide.tsx
@@ -12,7 +12,8 @@ import { selectAuth } from '@app/store/auth/slice';
 import useFormAtom from '@app/store/jotai/form-file';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
-import { useSubmitResponseMutation } from '@app/store/redux/form-api';
+import { useSendFlowEventMutation, useSubmitResponseMutation } from '@app/store/redux/form-api';
+import { getFlowSessionId } from '@app/utils/flow-session';
 import { getHiddenFieldIds, resolveJumpTargetId } from '@app/utils/conditional-logic';
 import { JUMP_TARGET_SUBMIT } from '@app/models/types/form-builder-shared';
 import { validateSlide } from '@app/utils/vvalidation-utils';
@@ -133,6 +134,13 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
     // render, so the form reacts live as the responder answers earlier questions.
     const hiddenFieldIds = getHiddenFieldIds(formSlide?.properties?.fields, formResponse.answers || {});
 
+    const [sendFlowEvent] = useSendFlowEventMutation();
+    // Anonymous drop-off breadcrumb: page → page, never answers, never in preview.
+    const emitFlow = (fromPage: string, toPage: string) => {
+        if (isPreviewMode || !workspace?.id || !standardForm?.formId) return;
+        sendFlowEvent({ workspaceId: workspace.id, formId: standardForm.formId, sessionId: getFlowSessionId(standardForm.formId), fromPage, toPage }).catch(() => {});
+    };
+
     const finishForm = () => {
         if (isPreviewMode) setCurrentSlideToThankyouPage();
         else
@@ -164,6 +172,7 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
         const jumpTargetId = resolveJumpTargetId(formSlide, formResponse.answers || {});
         if (jumpTargetId === JUMP_TARGET_SUBMIT) {
             if (isPreviewMode) toast({ description: 'Logic rule matched → submitting the form' });
+            emitFlow(formSlide.id, '__submit__');
             finishForm();
             return;
         }
@@ -171,13 +180,19 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
             const targetIndex = standardForm?.fields?.findIndex((s) => s.id === jumpTargetId) ?? -1;
             if (targetIndex >= 0) {
                 if (isPreviewMode) toast({ description: `Logic rule matched → jumped to Page ${targetIndex + 1}` });
+                emitFlow(formSlide.id, jumpTargetId);
                 goToSlide(targetIndex);
                 return;
             }
         }
 
-        if (currentSlide + 1 === standardForm?.fields?.length) finishForm();
-        else nextSlide();
+        if (currentSlide + 1 === standardForm?.fields?.length) {
+            emitFlow(formSlide.id, '__submit__');
+            finishForm();
+        } else {
+            emitFlow(formSlide.id, standardForm?.fields?.[currentSlide + 1]?.id ?? '__next__');
+            nextSlide();
+        }
     };
 
     if (!formSlide) return <FullScreenLoader />;

--- a/webapp/src/views/organism/form/welcome-page.tsx
+++ b/webapp/src/views/organism/form/welcome-page.tsx
@@ -10,6 +10,8 @@ import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
 import { selectWorkspace } from '@app/store/workspaces/slice';
+import { useSendFlowEventMutation } from '@app/store/redux/form-api';
+import { getFlowSessionId } from '@app/utils/flow-session';
 import UserAvatarDropDown from '@app/views/molecules/user-avatar-dropdown';
 import { Lock } from 'lucide-react';
 
@@ -32,6 +34,14 @@ export default function WelcomePage({
 
     const welcomePage = welcomePageData || standardForm.welcomePage;
     const formTheme = theme || standardForm?.theme;
+
+    const [sendFlowEvent] = useSendFlowEventMutation();
+    // Anonymous drop-off breadcrumb for "started the form" — never in preview.
+    const emitStart = () => {
+        const firstPageId = standardForm?.fields?.[0]?.id;
+        if (isPreviewMode || !workspace?.id || !standardForm?.formId || !firstPageId) return;
+        sendFlowEvent({ workspaceId: workspace.id, formId: standardForm.formId, sessionId: getFlowSessionId(standardForm.formId), fromPage: '__welcome__', toPage: firstPageId }).catch(() => {});
+    };
 
     return (
         <>
@@ -110,6 +120,7 @@ export default function WelcomePage({
                                     if (!auth.id && standardForm?.settings?.requireVerifiedIdentity) {
                                         router.push(responderSignInUrl);
                                     } else {
+                                        emitStart();
                                         nextSlide();
                                         return;
                                     }


### PR DESCRIPTION
## Summary

Completes the deferred items from the graph-first builder feasibility plan, plus self-hosted product analytics:

- **Drop-off analytics**: anonymous per-session navigation events (no answers, no identity) power a "N started · M finished" summary and per-page drop-off badges on the Flow view.
- **Flow-native template gallery**: three branching-showcase templates (support triage, lead qualification, job application with screening), auto-seeded idempotently on every backend startup — no manual step needed on existing environments.
- **Flow canvas accessibility**: keyboard + screen-reader support for jump handles, the armed-connect hint, and the page-editor overlay (focusable, labeled, `aria-live`, Escape-to-close, modal semantics).
- **Self-hosted Umami analytics**: Umami now ships as a first-class Docker Compose service (own Postgres, admin UI on `:3003`) instead of defaulting to a BetterCollected-hosted instance — closes a real gap in the privacy-first self-hosting story. Public form views attribute to a canonical `/{workspace_name}/forms/{slug}` path so client-host and custom-domain routing land under one analytics path.
- **Bug fixes found along the way**: `umami_client.py` raised a raw `TypeError` on every error path (the app's custom `HTTPException` takes `content=`, not `detail=`) and didn't check a failed 401-retry; `/stats` 500'd against current self-hosted Umami's actual response shape (flat ints + `comparison`, not nested `{value, prev}`); local dev's `nginx-local.conf` 502'd on the client-host/custom-domain ports (share URLs) because it proxied to `localhost` inside the nginx container instead of the host running webapp/backend.

## Test plan

- [x] Backend: `uv run pytest` — 140 passed
- [x] Webapp: `yarn vitest run` — 121 passed across 14 files
- [x] Verified live against a real self-hosted Umami container: created a website via its API, sent a canonical-path pageview, confirmed the backend's `UmamiClient` (real auth, real retry path) round-trips it correctly, and confirmed `/stats` no longer 500s
- [x] Verified the flow-template seed automation live: deleted a template from Mongo, restarted the backend, confirmed auto-recreation; confirmed idempotent on a subsequent restart
- [x] Verified `nginx-local.conf` fix: `:3001`/`:3002` return 200 instead of 502
- [ ] Browser check for Umami auto-track vs. explicit canonical-path tracking double-counting a single form view (flagged as a follow-up — this sandbox's Next dev server hits an unrelated OS file-watcher limit; verified script rendering via a production build+server instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)