### PR TITLE
fix(analytics): stop Umami double-counting form views; document self-hosting in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,17 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Fixed
 
+- Umami pageview double-counting: automatic tracking is now disabled
+  (`data-auto-track="false"`) and public form views send only the explicit
+  canonical-path event — previously every form view would count twice (auto +
+  canonical), and dashboard activity was tracked too. The tracker is also
+  rendered as a plain deferred `<script>` (not `next/script`), so analytics
+  loads even if client-side hydration stalls, and the canonical event now
+  waits for the tracker script instead of being dropped when it loads late.
+- Local dev: `nginx-local.conf` didn't forward WebSocket upgrades, so Next.js
+  dev-server HMR fell back to a `/_next/webpack-hmr` 404 polling loop through
+  the proxied hosts (`:3001`/`:3002`) and pages could stall on a loader
+  without hydrating.
 - React 19 form-rendering crash and DOM-prop console errors in the webapp.
 - React 19 DOM-prop warnings from data tables (`react-data-table-component` v8).
 - Form editor no longer auto-saves on load — only on real user edits.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ More at [bettercollected.com](https://bettercollected.com).
 - 🔐 Consent + purpose declaration, response viewing, and deletion requests
 - 🔗 Import forms and responses from **Google Forms** and **Typeform**
 - 🏢 Multi-tenant **workspaces** with members and custom domains
-- 📊 Response analytics and CSV export
+- 📊 Form analytics powered by **self-hosted [Umami](https://umami.is)** — no
+  responder data leaves your infrastructure — plus CSV export
 - 🤖 AI-assisted form generation
 
 ## Try it
@@ -56,7 +57,8 @@ bettercollected is a polyglot microservices monorepo:
 | [`temporal/`](temporal) | Temporal workers | Background jobs (imports, deletion, CSV, previews) |
 | [`common/`](common) | Shared Python package | Models, enums, crypto, JWT |
 
-Infra: MongoDB, Redis, PostgreSQL + Temporal, and nginx. A deep dive lives in
+Infra: MongoDB, Redis, PostgreSQL + Temporal, nginx, and Umami (self-hosted
+analytics, with its own PostgreSQL). A deep dive lives in
 **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 
 ## Quick start (local development)
@@ -83,6 +85,33 @@ The full walkthrough — env vars, shared secrets, provider OAuth, Temporal, and
 common gotchas — is in **[docs/DEVELOPERS_GUIDE.md](docs/DEVELOPERS_GUIDE.md)**.
 Integration setup (Google/Typeform apps) is in
 [docs/RUNNING_INTEGRATIONS.md](docs/RUNNING_INTEGRATIONS.md).
+
+## Self-hosting
+
+The entire stack — including analytics — runs on your own machine, so no
+third-party service ever sees responder data:
+
+```bash
+./deploy.sh                # everything except form-provider integrations
+./deploy.sh googleform     # ... with Google Forms import
+./deploy.sh typeform       # ... with Typeform import
+./deploy.sh both           # ... with both
+./deploy.sh down           # stop the stack
+```
+
+`deploy.sh` brings up the full stack from
+[`docker-compose.deployment.yml`](docker-compose.deployment.yml) with health
+checks and correct startup ordering: webapp (`:3000`), backend (`:8000`),
+auth, MongoDB (+ seed data), Temporal + workers, nginx (`:3001`/`:3002`), and
+[Umami](https://umami.is) analytics (`:3003`, default login `admin`/`umami` —
+change it). On first run it also generates a random `UMAMI_APP_SECRET` into a
+gitignored root `.env`. The backend auto-provisions the Umami website on
+startup, so analytics needs no manual setup.
+
+Configuration lives in [`.env.deployment`](.env.deployment). **The tracked
+defaults (including secrets) are for local evaluation only — generate fresh
+secrets before exposing an instance to the internet**, and put TLS or a
+reverse proxy in front of it yourself.
 
 ## Contributing
 

--- a/nginx-local.conf
+++ b/nginx-local.conf
@@ -1,27 +1,45 @@
 
+# WebSocket upgrade for Next.js dev HMR (and any app websockets). Without
+# these headers the HMR socket dies at the proxy and the dev client falls
+# back to polling /_next/webpack-hmr in a 404 loop, stalling hydration on
+# proxied hosts (:3001/:3002).
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}
+
 server {
     listen 3000;
-    
+
     location / {
         proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }
 
 server {
     listen 3001;
-    
+
     location / {
         proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }
 
 server {
     listen 3002;
-    
+
     location / {
         proxy_pass http://host.docker.internal:3000;
         proxy_set_header Host $host:$server_port;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
     }
 }

--- a/webapp/src/app/layout.tsx
+++ b/webapp/src/app/layout.tsx
@@ -16,7 +16,6 @@ import ReduxProvider from '@app/shared/hocs/redux-provider';
 import ThemeProvider from '@app/shared/hocs/theme-provider';
 import BaseModalContainer from '@Components/modals/containers/base-modal-container';
 import { Viewport } from 'next';
-import Script from 'next/script';
 
 // One honest, humanist face used everywhere (see Design-Language.md §2).
 // Public Sans is self-hosted by next/font — no external font request at runtime.
@@ -77,7 +76,17 @@ export default function RootLayout({
         <html lang="en" suppressHydrationWarning>
             <body className={cn('max-h-screen overflow-auto', publicSans.variable, publicSans.className)}>
                 {environments.UMAMI_SCRIPT_URL && environments.UMAMI_WEBSITE_ID && (
-                    <Script src={environments.UMAMI_SCRIPT_URL} data-website-id={environments.UMAMI_WEBSITE_ID} strategy="lazyOnload" />
+                    // Plain <script> like /api/config below, NOT next/script: next/script
+                    // only injects after hydration completes, so any client-side stall
+                    // (or a lazyOnload idle wait) silently drops the tracker. A plain
+                    // deferred tag executes with the document, independent of app health.
+                    // data-auto-track="false": Umami's automatic pageview would fire with
+                    // the raw URL alongside our explicit canonical-path event (see
+                    // src/lib/analytics/umami.ts), double-counting every public form view
+                    // and splitting the same form across client-host/custom-domain paths.
+                    // Only the explicit canonical event is sent — which also means
+                    // logged-in dashboard activity is never tracked, only public forms.
+                    <script src={environments.UMAMI_SCRIPT_URL} data-website-id={environments.UMAMI_WEBSITE_ID} data-auto-track="false" defer></script>
                 )}
                 <SwRegister />
                 <script src="/api/config" defer></script>

--- a/webapp/src/lib/analytics/umami.test.ts
+++ b/webapp/src/lib/analytics/umami.test.ts
@@ -12,10 +12,7 @@ describe('trackCanonicalFormView', () => {
     afterEach(() => {
         delete (window as any).umami;
         vi.restoreAllMocks();
-    });
-
-    it('does nothing when Umami is not loaded', () => {
-        expect(() => trackCanonicalFormView('acme', 'contact-us')).not.toThrow();
+        vi.useRealTimers();
     });
 
     it('does nothing when workspace or slug is missing', () => {
@@ -40,6 +37,38 @@ describe('trackCanonicalFormView', () => {
             url: '/acme/forms/contact-us',
             title: 'x'
         });
+    });
+
+    it('waits for the Umami script to load, then tracks exactly once', () => {
+        vi.useFakeTimers();
+
+        trackCanonicalFormView('acme', 'contact-us');
+
+        const track = vi.fn();
+        vi.advanceTimersByTime(1000);
+        (window as any).umami = { track };
+        vi.advanceTimersByTime(1000);
+
+        expect(track).toHaveBeenCalledTimes(1);
+        const callback = track.mock.calls[0][0];
+        expect(callback({ url: '/forms/contact-us' })).toEqual({ url: '/acme/forms/contact-us' });
+
+        // The retry loop must stop after firing — no further calls.
+        vi.advanceTimersByTime(30000);
+        expect(track).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up quietly if the script never loads', () => {
+        vi.useFakeTimers();
+
+        trackCanonicalFormView('acme', 'contact-us');
+        vi.advanceTimersByTime(30000);
+
+        const track = vi.fn();
+        (window as any).umami = { track };
+        vi.advanceTimersByTime(30000);
+
+        expect(track).not.toHaveBeenCalled();
     });
 
     it('fails silently if umami.track throws', () => {

--- a/webapp/src/lib/analytics/umami.ts
+++ b/webapp/src/lib/analytics/umami.ts
@@ -3,6 +3,9 @@
 // the client-host route (`/{workspace}/forms/{slug}`) or a custom domain
 // (`/forms/{slug}`) — both must attribute to the same analytics path, so we
 // track it explicitly instead of relying on Umami's automatic pageview.
+// Automatic tracking is disabled entirely (data-auto-track="false" in
+// app/layout.tsx) — it would double-count every form view against this
+// explicit event and split the same form across host-specific paths.
 
 export function buildCanonicalFormPath(workspaceName: string, slug: string): string {
     return `/${workspaceName}/forms/${slug}`;
@@ -12,16 +15,47 @@ type UmamiTracker = {
     track: (payload: (props: Record<string, unknown>) => Record<string, unknown>) => void;
 };
 
-export function trackCanonicalFormView(workspaceName: string, slug: string): void {
-    if (typeof window === 'undefined' || !workspaceName || !slug) return;
-
+function getUmami(): UmamiTracker | undefined {
+    if (typeof window === 'undefined') return undefined;
     const umami = (window as unknown as { umami?: UmamiTracker }).umami;
-    if (!umami || typeof umami.track !== 'function') return;
+    return umami && typeof umami.track === 'function' ? umami : undefined;
+}
 
-    const canonicalUrl = buildCanonicalFormPath(workspaceName, slug);
+function sendCanonicalPageview(umami: UmamiTracker, canonicalUrl: string): void {
     try {
         umami.track((props) => ({ ...props, url: canonicalUrl }));
     } catch {
         // Analytics must never break the form.
     }
+}
+
+// The Umami script loads asynchronously (next/script afterInteractive), so the
+// form page's mount effect can run before window.umami exists. Since the
+// explicit event is the ONLY pageview (auto-track is off), poll briefly for
+// the script instead of dropping the view.
+const RETRY_INTERVAL_MS = 250;
+const MAX_RETRIES = 40; // ~10s — beyond that the script is blocked/unreachable.
+
+export function trackCanonicalFormView(workspaceName: string, slug: string): void {
+    if (typeof window === 'undefined' || !workspaceName || !slug) return;
+
+    const canonicalUrl = buildCanonicalFormPath(workspaceName, slug);
+
+    const umami = getUmami();
+    if (umami) {
+        sendCanonicalPageview(umami, canonicalUrl);
+        return;
+    }
+
+    let attempts = 0;
+    const timer = window.setInterval(() => {
+        attempts += 1;
+        const tracker = getUmami();
+        if (tracker) {
+            window.clearInterval(timer);
+            sendCanonicalPageview(tracker, canonicalUrl);
+        } else if (attempts >= MAX_RETRIES) {
+            window.clearInterval(timer);
+        }
+    }, RETRY_INTERVAL_MS);
 }


### PR DESCRIPTION
## What

Closes the last open item from the self-hosted Umami work (#563): the browser-side double-count check — which confirmed the double-count was real — plus a dev-proxy bug found while verifying, and a new README self-hosting section.

## Why

Umami's automatic pageview tracking was live alongside our explicit canonical-path event (`umami.track()` with `url` override). Every public form view counted **twice**, and the same form split across client-host (`/{workspace}/forms/{slug}`) vs. custom-domain (`/forms/{slug}`) paths. Confirmed empirically: dashboard browsing showed up as auto-tracked events in Umami's `website_event` table.

## Changes

- **`webapp/src/app/layout.tsx`** — `data-auto-track="false"` on the Umami tag; only the explicit canonical event is sent. Side effect (intended): logged-in dashboard activity is no longer tracked at all — analytics covers public form views only. The tag is also now a plain `<script defer>` (like the `/api/config` tag) instead of `next/script`, which only injects after hydration completes — any client-side stall silently dropped the tracker.
- **`webapp/src/lib/analytics/umami.ts`** — since the canonical event is now the *only* pageview, `trackCanonicalFormView` polls briefly (250ms × 40) for `window.umami` instead of silently dropping the view when the script loads after mount. Tests extended to cover the retry/give-up paths (6 passing).
- **`nginx-local.conf`** — forward WebSocket upgrades (`proxy_http_version 1.1` + `Upgrade`/`Connection` via a `map`). Without this, the Next dev HMR socket died at the proxy, fell into a `/_next/webpack-hmr` 404 polling loop, and pages served via `:3001`/`:3002` stalled on a loader without hydrating (dev-only, but it made share URLs appear blank in local dev).
- **`README.md`** — new **Self-hosting** section: `deploy.sh` modes, port map, Umami default login + auto-generated `UMAMI_APP_SECRET`, backend website auto-provisioning, and an explicit warning that the tracked `.env.deployment` secrets are for evaluation only. Umami added to features + infra summary.
- **`CHANGELOG.md`** — entries for both fixes.

## Verification

- Real browser against a real self-hosted Umami container: **3 page loads → exactly 3 `website_event` rows** at the canonical path, exactly one `/api/send` per load, 1 visitor / 1 visit. (Note: Umami's `metrics?type=path` y-values are session-deduped — raw table / `/stats` are the honest counters.)
- Webapp: 122/122 vitest tests pass, `tsc --noEmit` clean.
- Form share URL through nginx (`:3001`) hydrates and renders correctly in dev after the WebSocket fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)