### PR TITLE
feat: answer piping + hidden fields, trust-first design pass, real anonymity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,22 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Changed (trust-first design pass — responder form + builder)
 
+- **Form details page (dashboard) redesigned**: the 8-tab bar — which silently
+  overflowed and hid the Form Link and Analytics tabs entirely on desktop —
+  is now 5 always-visible tabs (Preview · Responses · Analytics · Share ·
+  Settings). Deletion requests became a segment inside Responses; Visibility
+  and Integrations became Settings sections (old URLs redirect); tabs use a
+  single active affordance with count badges. The header gained a real
+  breadcrumb and a plain-words meta line (Published/Draft chip, response
+  count, provenance) in place of an unlabeled provider glyph; Share is the
+  one primary action. Settings rows follow a label+description/control grid
+  with dividers between (not inside) settings, a locked state for Pro-gated
+  toggles, and a proper danger zone stating consequences. Preview shows
+  labelled page cards that open the full-screen preview. Anonymous responses
+  show a shield chip instead of "--"; creator-facing titles no longer leak
+  answer-piping editor syntax; every tab pane sits on one horizontal grid,
+  and pages end with a quiet "Version · Open form" line.
+
 - **Responder form redesigned to the trust-first design language**: questions
   now render at 24px/600 ink and answers at 16–18px ink (the input no longer
   out-shouts the question, and answers no longer render in link-blue); every
@@ -97,6 +113,10 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Fixed
 
+- Form details page: the Deletion Requests empty state showed the responses
+  copy ("No responses yet" on a form with responses); "bettercolleceted"
+  typo in the branding setting; preview cards had a pointer cursor but no
+  click behaviour and didn't survive window resizes.
 - **Identity sharing is now opt-in, and anonymity is actually enforced.** The
   "Show your identity" checkbox on the submit step arrived pre-checked
   (contradicting the no-dark-patterns design law) — it now starts unchecked,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Added
 
+- **Answer piping / recall**: question titles can reference earlier answers or
+  hidden fields ("Thanks, @name!") via an "@ Answer" menu in the builder's
+  title toolbar — stored as inline TipTap nodes, resolved live in the
+  responder runtime through the same value extractor conditional logic uses.
+  Plain-text surfaces (field descriptions, thank-you message) support
+  `{{field:<id>}}` / `{{hidden:<name>|fallback}}` tokens. Pipes referencing
+  deleted fields are pruned automatically.
+- **Hidden fields (URL parameters)**: creators declare parameter names
+  (e.g. `utm_source`) form-wide in the builder; values are captured from the
+  share link when a form loads (declared names only — arbitrary query params
+  are never stored), submitted with the response, encrypted at rest exactly
+  like answers, and shown in the response detail view. `?field_<id>=value`
+  parameters prefill text-like input fields.
+
 - Open-source contributor docs and community health files: `CONTRIBUTING.md`,
   `CODE_OF_CONDUCT.md`, `SECURITY.md`, issue/PR templates, `SUPPORT.md`,
   `GOVERNANCE.md`, `ROADMAP.md`, `CODEOWNERS`, and this changelog.
@@ -62,8 +76,41 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 - Batched routine dependency updates across all services (npm + uv + GitHub
   Actions) and moved CI actions to Node-24 majors.
 
+### Changed (trust-first design pass — responder form + builder)
+
+- **Responder form redesigned to the trust-first design language**: questions
+  now render at 24px/600 ink and answers at 16–18px ink (the input no longer
+  out-shouts the question, and answers no longer render in link-blue); every
+  field type shares one bordered white input with a visible themed focus ring
+  (short/long-text fields had regressed to an underline with no focus
+  indicator); the default theme is a calm neutral surface (`#F6F8FC`) with
+  trust-blue actions (`#2456CC`) instead of the full-bleed pale-blue wash
+  (saturated themes remain opt-in); buttons say what happens ("Continue",
+  "Submit response") at proper weight; a provenance chip + "Page x of y"
+  progress meta sits where the eye starts; the trust strip is legible (13px)
+  and links "How your data is used" and "View or delete your response".
+- **Builder**: the slide canvas now sits on a neutral mat as a bordered white
+  card (figure/ground for the thing being edited); the title editor matches
+  the responder's 24px question scale (honest WYSIWYG); panel section headers
+  share one 12px-caps rhythm; empty pages show an "Add a question" affordance
+  that opens the Insert menu; piping chips use the trust palette.
+
 ### Fixed
 
+- **Identity sharing is now opt-in, and anonymity is actually enforced.** The
+  "Show your identity" checkbox on the submit step arrived pre-checked
+  (contradicting the no-dark-patterns design law) — it now starts unchecked,
+  in a legible 15px consent container. Worse: the backend accepted the
+  `anonymize` flag but never honoured it — "anonymously submitted" responses
+  still stored the signed-in email as `dataOwnerIdentifier`. Anonymous
+  responses now store no owner identifier and no email, only a one-way hash
+  (`anonymous_identity`) so the responder can still find and delete their own
+  submission.
+- Builder `useFormState` setters spread a stale render-time snapshot instead
+  of the current state, so mount-effect writers (theme, welcome description)
+  could silently wipe keys written between render and effect — this ate the
+  form title and hidden-field list under hot-reload/multi-writer conditions.
+  All setters now use functional updates.
 - Umami pageview double-counting: automatic tracking is now disabled
   (`data-auto-track="false"`) and public form views send only the explicit
   canonical-path event — previously every form view would count twice (auto +

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -53,6 +53,12 @@ Beanie Documents are registered in [backend/app/handlers/database.py](backend/ap
 (`User`, `StandardForm`, `StandardFormResponse`, `Consent`) come from the shared `common` package, not from here.
 APScheduler uses a separate DB (`init_scheduler_db`).
 
+Response `answers` **and** `hidden_fields` (captured URL parameters, see `StandardForm.hidden_fields` for the
+declared names) are encrypted at rest via `crypto_service` in `form_response_repository.save_form_response` and
+decrypted in `form_response_service.decrypt_form_response` — any new respondent-data field on
+`StandardFormResponse` must go through the same two choke points. Answer piping itself is resolved entirely
+client-side (webapp `src/utils/answer-piping.ts`); the backend only stores the pipe nodes inside field titles.
+
 ## Seed scripts
 
 `backend/scripts/` holds idempotent seed scripts that populate collections a fresh (or already-running) environment

--- a/backend/backend/app/models/dtos/minified_form.py
+++ b/backend/backend/app/models/dtos/minified_form.py
@@ -42,6 +42,7 @@ class FormDtoCamelModel(CamelModel):
     imported_by: Optional[str] = None
     importer_details: Optional[FormImporterDetails] = None
     fields: Optional[List[StandardFormFieldCamelModel]] = None
+    hidden_fields: Optional[List[str]] = None
     version: Optional[str | int] = None
     updated_at: Optional[dt.datetime] = None
     actions: Optional[Dict[Trigger, List[ActionState]]] = None

--- a/backend/backend/app/repositories/form_repository.py
+++ b/backend/backend/app/repositories/form_repository.py
@@ -300,6 +300,10 @@ class FormRepository:
     async def update_form(self, form_id: PydanticObjectId, form: StandardForm):
         form_document = await FormDocument.find_one({"form_id": str(form_id)})
         form_document.fields = form.fields
+        # None means "the client didn't send hidden fields" (e.g. an older
+        # webapp bundle) — preserve what's stored. An explicit [] clears them.
+        if form.hidden_fields is not None:
+            form_document.hidden_fields = form.hidden_fields
         form_document.title = form.title
         form_document.logo = form.logo
         form_document.cover_image = form.cover_image

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -266,6 +266,12 @@ class FormResponseRepository(BaseRepository):
                 form_id=form_id,
                 data=json.dumps(response_document.answers),
             )
+            if isinstance(response_document.hidden_fields, dict):
+                response_document.hidden_fields = crypto_service.encrypt(
+                    workspace_id=workspace_id,
+                    form_id=form_id,
+                    data=json.dumps(response_document.hidden_fields),
+                )
         response_document.form_id = str(form_id)
         response_document.provider = "self"
         return await response_document.save()

--- a/backend/backend/app/services/form_response_service.py
+++ b/backend/backend/app/services/form_response_service.py
@@ -310,15 +310,22 @@ class FormResponseService:
         workspace_id: PydanticObjectId,
         response: StandardFormResponseCamelModel,
     ):
-        if isinstance(response.answers, dict):
-            return response
-        response.answers = json.loads(
-            crypto_service.decrypt(
-                workspace_id=workspace_id,
-                form_id=response.form_id,
-                data=response.answers,
+        if not isinstance(response.answers, dict):
+            response.answers = json.loads(
+                crypto_service.decrypt(
+                    workspace_id=workspace_id,
+                    form_id=response.form_id,
+                    data=response.answers,
+                )
             )
-        )
+        if isinstance(response.hidden_fields, (bytes, str)):
+            response.hidden_fields = json.loads(
+                crypto_service.decrypt(
+                    workspace_id=workspace_id,
+                    form_id=response.form_id,
+                    data=response.hidden_fields,
+                )
+            )
         return response
 
     async def submit_form_response(

--- a/backend/backend/app/services/form_service.py
+++ b/backend/backend/app/services/form_service.py
@@ -384,6 +384,7 @@ class FormService:
             and form.description == latest_version.description
             and form.consent == latest_version.consent
             and form.fields == latest_version.fields
+            and form.hidden_fields == latest_version.hidden_fields
             and form.logo == latest_version.logo
             and form.cover_image == latest_version.cover_image
             and form.button_text == latest_version.button_text

--- a/backend/backend/app/services/workspace_form_service.py
+++ b/backend/backend/app/services/workspace_form_service.py
@@ -539,7 +539,17 @@ class WorkspaceFormService:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND, content="Form not found"
             )
-        if not response.dataOwnerIdentifier and user:
+        # Honour the responder's anonymity choice server-side. Previously the
+        # webapp's `anonymize` flag was accepted but never enforced: the UI said
+        # "anonymously submitted" while dataOwnerIdentifier still recorded the
+        # signed-in email. Anonymous responses keep only a one-way hash so the
+        # responder can still find and delete their own submission.
+        if bool(getattr(response, "anonymize", False)):
+            response.dataOwnerIdentifier = None
+            response.respondent_email = None
+            if user:
+                response.anonymous_identity = hash_string(user.sub)
+        elif not response.dataOwnerIdentifier and user:
             response.dataOwnerIdentifier = user.sub
 
         form_response = await self.form_response_service.submit_form_response(

--- a/backend/tests/app/services/test_hidden_fields.py
+++ b/backend/tests/app/services/test_hidden_fields.py
@@ -1,0 +1,119 @@
+import json
+
+from common.models.standard_form import StandardForm, StandardFormResponse
+
+from backend.app.container import container
+from backend.app.schemas.standard_form_response import FormResponseDocument
+
+
+async def test_submitted_hidden_fields_are_encrypted_at_rest_and_decrypted_on_read(
+    workspace, workspace_form
+):
+    hidden = {"utm_source": "newsletter", "name": "Ada"}
+    response = await container.form_response_service().submit_form_response(
+        workspace_form.form_id,
+        StandardFormResponse(answers={}, hidden_fields=hidden),
+        workspace.id,
+    )
+
+    # The service returns the decrypted view for the caller...
+    assert response.hidden_fields == hidden
+
+    # ...but at rest the values are an encrypted blob, like answers.
+    stored = await FormResponseDocument.find_one(
+        {"response_id": response.response_id}
+    )
+    assert isinstance(stored.hidden_fields, (bytes, str))
+    assert json.dumps(hidden) != stored.hidden_fields
+
+    decrypted = container.form_response_service().decrypt_form_response(
+        workspace_id=workspace.id, response=stored
+    )
+    assert decrypted.hidden_fields == hidden
+
+
+async def test_submission_without_hidden_fields_stays_none(workspace, workspace_form):
+    response = await container.form_response_service().submit_form_response(
+        workspace_form.form_id,
+        StandardFormResponse(answers={}),
+        workspace.id,
+    )
+    stored = await FormResponseDocument.find_one(
+        {"response_id": response.response_id}
+    )
+    assert stored.hidden_fields is None
+
+
+async def test_update_form_persists_declared_hidden_fields(workspace, workspace_form):
+    form = StandardForm(**workspace_form.model_dump(mode="json"))
+    form.hidden_fields = ["utm_source", "utm_medium"]
+
+    updated = await container.form_service().update_form(
+        form_id=workspace_form.form_id, form=form
+    )
+    assert updated.hidden_fields == ["utm_source", "utm_medium"]
+
+    # A PATCH that omits hidden_fields (e.g. an older webapp bundle) must not
+    # wipe them — only an explicit empty list clears.
+    form.hidden_fields = None
+    preserved = await container.form_service().update_form(
+        form_id=workspace_form.form_id, form=form
+    )
+    assert preserved.hidden_fields == ["utm_source", "utm_medium"]
+
+    form.hidden_fields = []
+    cleared = await container.form_service().update_form(
+        form_id=workspace_form.form_id, form=form
+    )
+    assert cleared.hidden_fields == []
+
+
+async def test_changing_hidden_fields_marks_form_as_updated(workspace, workspace_form):
+    form_service = container.form_service()
+    published = await form_service.publish_form(workspace_form.form_id)
+
+    # No changes since publishing -> not "updated".
+    current = await form_service.get_form_document_by_id(str(workspace_form.form_id))
+    assert form_service.has_form_been_updated(current, published) is False
+
+    current.hidden_fields = ["utm_source"]
+    assert form_service.has_form_been_updated(current, published) is True
+
+
+async def test_anonymize_is_enforced_server_side(workspace, published_form):
+    from backend.app.models.dtos.response_dtos import StandardFormResponseCamelModel
+    from tests.app.controllers.data import testUser
+
+    response = await container.workspace_form_service().submit_response(
+        workspace.id,
+        published_form.form_id,
+        StandardFormResponseCamelModel(answers={}, anonymize=True),
+        testUser,
+    )
+
+    stored = await FormResponseDocument.find_one(
+        {"response_id": response.response_id}
+    )
+    # The anonymity choice must hold at rest: no owner identifier, no email —
+    # only the one-way hash that lets the responder find their own submission.
+    assert stored.dataOwnerIdentifier is None
+    assert stored.respondent_email is None
+    assert stored.anonymous_identity is not None
+    assert stored.anonymous_identity != testUser.sub
+
+
+async def test_identity_is_kept_when_not_anonymized(workspace, published_form):
+    from backend.app.models.dtos.response_dtos import StandardFormResponseCamelModel
+    from tests.app.controllers.data import testUser
+
+    response = await container.workspace_form_service().submit_response(
+        workspace.id,
+        published_form.form_id,
+        StandardFormResponseCamelModel(answers={}, anonymize=False),
+        testUser,
+    )
+
+    stored = await FormResponseDocument.find_one(
+        {"response_id": response.response_id}
+    )
+    assert stored.dataOwnerIdentifier == testUser.sub

--- a/common/common/models/standard_form.py
+++ b/common/common/models/standard_form.py
@@ -467,6 +467,11 @@ class StandardForm(BaseModel):
     button_text: Optional[str] = None
     is_multi_page: Optional[bool] = None
     fields: Optional[List[StandardFormField]] = None
+    # Creator-declared URL parameter names ("hidden fields"): captured from the
+    # share link's query string at fill time (e.g. utm_source), stored with the
+    # response, and available to answer piping in question text. Names only —
+    # values never live on the form.
+    hidden_fields: Optional[List[str]] = None
     consent: Optional[List[Consent]] = None
     state: Optional[State] = Field(default_factory=State)
     settings: Optional[StandardFormSettings] = Field(
@@ -519,6 +524,10 @@ class StandardFormResponse(BaseModel):
     answers: (
         Optional[Dict[str, StandardFormResponseAnswer | Dict[str, Any]]] | bytes | str
     ) = None
+    # Captured hidden-field (URL parameter) values for this submission, keyed by
+    # the declared name. Encrypted at rest alongside `answers` (bytes/str once
+    # persisted), decrypted on the same read path.
+    hidden_fields: Optional[Dict[str, str] | bytes | str] = None
     form_version: Optional[int] = None
     created_at: Optional[dt.datetime] = None
     updated_at: Optional[dt.datetime] = None

--- a/webapp/AGENTS.md
+++ b/webapp/AGENTS.md
@@ -56,6 +56,17 @@ Drag-and-drop engine in `src/lib/builders/` (managers + listeners), editor state
 A **V2 builder** exists behind `ENABLE_V2_BUILDER`, wired into the App Router edit/preview routes. Form data conforms
 to the backend **StandardForm** shape — keep field types in sync with `common/common/models/standard_form.py`.
 
+**Answer piping + hidden fields (v2):** question titles can embed earlier answers or URL parameters. A pipe is an
+inline `answerPipe` TipTap node (`src/utils/richTextEditorExtenstion/answer-pipe.ts`, inserted via the "@ Answer"
+menu in the title toolbar); plain-text surfaces (descriptions, thank-you message) use `{{field:<id>}}` /
+`{{hidden:<name>|fallback}}` tokens. The resolver lives in `src/utils/answer-piping.ts` and reads values through the
+same `getComparableAnswerValue` as conditional logic — extend both together. Hidden-field *names* live on the form
+(`StandardFormDto.hiddenFields`, edited in the page properties drawer, form-wide); *values* are captured from the
+share link's query string on the public form page (declared names only), held in
+`src/store/jotai/responder-hidden-fields.ts`, submitted as `hidden_fields`, and encrypted at rest like answers.
+`?field_<fieldId>=value` URL params prefill text-like input fields. Deleting a field/hidden name prunes its pipes
+(`pruneOrphanedPipes`, called next to `pruneOrphanedConditions`).
+
 ## Commands
 
 ```bash

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -47,6 +47,7 @@
     "@tiptap/pm": "^2.2.4",
     "@tiptap/react": "^2.2.4",
     "@tiptap/starter-kit": "^2.2.4",
+    "@tiptap/suggestion": "^2.7.2",
     "@typeform/embed-react": "^2.11.0",
     "@uiw/react-markdown-preview": "^5.1.1",
     "@uiw/react-md-editor": "^4.0.4",

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -290,7 +290,7 @@
           "DESCRIPTION": "When you pin a form in bettercollected, the form will be added to the top of the form so that it is the first thing that your audience can see from your form page."
         },
         "BRANDING": {
-          "TITLE": "bettercolleceted branding",
+          "TITLE": "bettercollected branding",
           "DESCRIPTION": "Show Powered by: bettercollected in your form."
         },
         "FORM_PURPOSE": {

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
@@ -8,19 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import Divider from '@Components/common/divider';
 import PrivateFormButtonWrapper from '@Components/common/private-form-button-wrapper';
-import {
-    BarChart,
-    Blocks,
-    ChevronRight,
-    Edit2,
-    Eye,
-    History,
-    Link2Icon,
-    Play,
-    Settings,
-    Share2,
-    Trash2
-} from 'lucide-react';
+import { Edit2, Play, Share2 } from 'lucide-react';
 
 import { useModal } from '@app/components/modal-views/context';
 import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
@@ -39,7 +27,6 @@ import getFormShareURL from '@app/utils/form-utils';
 import { getEditFormURL } from '@app/utils/url-utils';
 import { validateFormOpen } from '@app/utils/vvalidation-utils';
 import PublishButton from '@app/views/molecules/form-builder/publish-button';
-import FormProviderIcon from '@Components/icons/form-provider-icon';
 
 export default function FormDashboardLayoutClient({
     form,
@@ -78,56 +65,25 @@ export default function FormDashboardLayoutClient({
 
 
     const tabMenu = useMemo(() => {
-        const tabs = [
-            {
-                icon: <Eye className="h-5 w-5" />,
-                title: t(formConstant.preview),
-                path: 'preview'
-            },
-            {
-                icon: <Settings className="h-5 w-5" />,
-                title: t(localesCommon.settings),
-                path: 'settings'
-            }
-        ];
+        // Five top-level destinations, all visible at once (the old 8-tab bar
+        // silently overflowed and hid Form Link + Analytics). Deletion requests
+        // live inside Responses as a segment; Visibility and Integrations are
+        // Settings sections; /links is surfaced as "Share".
+        const tabs: Array<{ title: string; path: string; count?: number; matches: string[] }> = [{ title: t(formConstant.preview), path: 'preview', matches: ['preview'] }];
 
         if (form?.isPublished) {
-            if (form?.settings?.provider === 'self' && form?.builderVersion === 'v2') {
-                tabs.push({
-                    icon: <Blocks className="h-5 w-5" />,
-                    title: 'Integrations',
-                    path: 'integrations'
-                });
-            }
             tabs.push({
-                icon: <History className="h-5 w-5" />,
-                title: t(formConstant.responders) + ' (' + form.responses + ')',
-                path: 'responses'
+                title: 'Responses',
+                path: 'responses',
+                count: form.responses ?? 0,
+                matches: ['responses', 'deletion-requests']
             });
-            tabs.push({
-                icon: <Trash2 className="h-5 w-5" />,
-                title: t(formConstant.deletionRequests) + ' (' + (form as any).deletionRequests + ')',
-                path: 'deletion-requests'
-            });
-            tabs.push({
-                icon: <Eye className="h-5 w-5" />,
-                title: t(formConstant.settings.visibility.title),
-                path: 'visibility'
-            });
-
             if (isFormOpen) {
-                tabs.push({
-                    icon: <Link2Icon className="h-5 w-5" />,
-                    title: t(formConstant.settings.formLink.title),
-                    path: 'links'
-                });
-                tabs.push({
-                    icon: <BarChart className="h-5 w-5" />,
-                    title: 'Analytics',
-                    path: 'analytics'
-                });
+                tabs.push({ title: 'Analytics', path: 'analytics', matches: ['analytics'] });
+                tabs.push({ title: 'Share', path: 'links', matches: ['links'] });
             }
         }
+        tabs.push({ title: t(localesCommon.settings), path: 'settings', matches: ['settings', 'visibility', 'integrations'] });
         return tabs;
     }, [form, t, isFormOpen]);
 
@@ -172,21 +128,20 @@ export default function FormDashboardLayoutClient({
                     <FormPageLayer className="px-4 md:px-10 lg:px-28">
                         <div className="flex justify-between">
                             <div className="flex flex-col gap-1">
-                                <button
-                                    type="button"
-                                    onClick={handleBackClick}
-                                    className="text-black-600 hover:text-black-800 flex w-fit items-center gap-1 text-sm"
-                                >
-                                    <ChevronRight className="h-4 w-4 rotate-180" />
-                                    Forms
-                                </button>
-                                {isMobile ? <h1 className="hp3-new">{formTitle}</h1> : <h1 className="h2-new text-pink">{formTitle}</h1>}
+                                <nav aria-label="Breadcrumb" className="text-black-600 flex w-fit items-center gap-1.5 text-[13px]">
+                                    <button type="button" onClick={handleBackClick} className="hover:text-black-900 hover:underline">
+                                        Forms
+                                    </button>
+                                    <span className="text-black-400">/</span>
+                                    <span className="text-black-800 max-w-[320px] truncate font-medium">{formTitle}</span>
+                                </nav>
+                                {isMobile ? <h1 className="hp3-new">{formTitle}</h1> : <h1 className="h2-new">{formTitle}</h1>}
                             </div>
                             <div className="hidden gap-4 lg:flex">
                                 {form?.settings?.provider === 'self' && form?.builderVersion === 'v2' && (
                                     <Button
-                                        icon={<Edit2 className="h-6 w-6" />}
-                                        variant={['sm', 'md', 'lg', 'xl', '2xl'].indexOf(breakpoint) !== -1 ? 'secondary' : 'ghost'}
+                                        icon={<Edit2 className="h-5 w-5" />}
+                                        variant="v2Button"
                                         className="!px-0 sm:!px-5"
                                         onClick={() => {
                                             router.push(getEditFormURL(workspace, form));
@@ -198,9 +153,9 @@ export default function FormDashboardLayoutClient({
                                 {form?.isPublished && isFormOpen && (
                                     <PrivateFormButtonWrapper isPrivate={workspaceForm?.settings?.hidden}>
                                         <Button
-                                            variant={['sm', 'md', 'lg', 'xl', '2xl'].indexOf(breakpoint) !== -1 ? 'primary' : 'ghost'}
+                                            variant="primary"
                                             icon={<Share2 className="h-5 w-5" />}
-                                            className="!px-0 sm:!px-5"
+                                            className="!bg-[#2456CC] hover:!bg-[#1E49AD] !px-0 text-white sm:!px-5"
                                             disabled={workspaceForm?.settings?.hidden}
                                             onClick={() =>
                                                 openModal('SHARE_VIEW', {
@@ -250,8 +205,15 @@ export default function FormDashboardLayoutClient({
                             </div>
                         </div>
                         {!isMobile && (
-                            <div className="flex flex-row items-center gap-1 mb-4">
-                                <FormProviderIcon provider={form.settings?.provider === 'self' && form.importedFormId && form.settings.showOriginalForm ? 'google' : form?.settings?.provider} />
+                            <div className="text-black-700 mb-4 mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px]">
+                                {form?.isPublished ? (
+                                    <span className="rounded-full bg-[#E7F4EE] px-2 py-0.5 text-xs font-semibold text-[#0E8A5F]">Published</span>
+                                ) : (
+                                    <span className="bg-black-200 text-black-700 rounded-full px-2 py-0.5 text-xs font-semibold">Draft</span>
+                                )}
+                                <span className="tabular-nums">{form?.responses ?? 0} responses</span>
+                                <span className="text-black-400">·</span>
+                                <span>{formProvenance(form)}</span>
                             </div>
                         )}
                         <Divider className="mt-6 hidden md:flex" />
@@ -259,16 +221,16 @@ export default function FormDashboardLayoutClient({
                     <div className="md:px-10 lg:px-28 pt-4">
                         <div ref={tabsContainerRef} className="flex space-x-1 border-b border-gray-200 overflow-x-auto">
                             {tabMenu.map((tab) => {
-                                const isActive = pathname?.includes(`/${tab.path}`);
+                                const isActive = tab.matches.some((m) => pathname?.includes(`/${m}`));
                                 return (
                                     <Link key={tab.path} data-tab-active={isActive} href={`/${params.workspace_name}/dashboard/forms/${params.form_id}/${tab.path}`} className={cn(
-                                        'flex items-center gap-2 px-4 py-2 text-sm font-medium cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap',
+                                        'flex items-center gap-1.5 whitespace-nowrap border-b-2 px-4 py-2.5 text-sm',
                                         isActive
-                                            ? 'border-b-2 border-black-900 text-black-900 bg-gray-100 rounded-t'
-                                            : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                            ? 'border-[#2456CC] text-black-900 font-semibold'
+                                            : 'text-black-600 hover:text-black-900 border-transparent font-medium'
                                     )}>
-                                        {tab.icon}
                                         {tab.title}
+                                        {typeof tab.count === 'number' && <span className="bg-black-200 text-black-700 rounded-full px-2 py-0.5 text-xs font-medium tabular-nums">{tab.count}</span>}
                                     </Link>
                                 );
                             })}
@@ -277,6 +239,15 @@ export default function FormDashboardLayoutClient({
                     <div className="w-full pt-5">
                         {children}
                     </div>
+                    {form?.isPublished && (
+                        <div className="border-black-200 text-black-600 mx-4 mt-16 flex flex-wrap items-center justify-center gap-x-2 gap-y-1 border-t py-4 text-[13px] md:mx-10 lg:mx-28">
+                            {typeof (form as any)?.version === 'number' && <span>Version {(form as any).version}</span>}
+                            {typeof (form as any)?.version === 'number' && <span className="text-black-400">·</span>}
+                            <a href={getFormShareURL(workspaceForm ?? form, workspace)} target="_blank" rel="noopener noreferrer" className="hover:text-black-900 underline decoration-dotted underline-offset-2">
+                                Open form ↗
+                            </a>
+                        </div>
+                    )}
                 </div>
             </div>
         </TopNavLayout>
@@ -286,3 +257,11 @@ export default function FormDashboardLayoutClient({
 const FormPageLayer = ({ children, className }: any) => {
     return <div className={className}>{children}</div>;
 };
+
+/** Plain-words provenance for the header meta line. */
+function formProvenance(form: StandardFormDto): string {
+    const provider = form?.settings?.provider;
+    if (provider === 'google') return 'Imported from Google Forms';
+    if (provider === 'typeform') return 'Imported from Typeform';
+    return 'bettercollected form';
+}

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/analytics/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/analytics/page.tsx
@@ -4,7 +4,7 @@ import FormAnalyticsDashboard from '@Components/form/analytics-dashboard';
 
 export default function Page() {
     return (
-        <div className="px-2 md:px-32 mt-4">
+        <div className="mt-4 px-4 md:px-10 lg:px-28">
             <FormAnalyticsDashboard />
         </div>
     );

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/deletion-requests/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/deletion-requests/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import FormResponsesTable from '@Components/datatable/form-responses';
+import ResponseSegments from '@app/components/form/response-segments';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
@@ -10,6 +11,9 @@ export default function Page() {
     const workspace = useAppSelector(selectWorkspace);
 
     return (
-        <FormResponsesTable props={{ formId: form.formId, workspace, requestForDeletion: true }} />
+        <div className="mt-4 px-4 md:px-10 lg:px-28">
+            <ResponseSegments />
+            <FormResponsesTable props={{ formId: form.formId, workspace, requestForDeletion: true }} />
+        </div>
     );
 }

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/integrations/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/integrations/page.tsx
@@ -1,7 +1,7 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import FormIntegrations from '@Components/form/integrations';
-
-export default function Page() {
-    return <FormIntegrations />;
+// Integrations is a Settings section now — see visibility/page.tsx.
+export default async function Page(props: { params: Promise<{ workspace_name: string; form_id: string }> }) {
+    const { workspace_name, form_id } = await props.params;
+    redirect(`/${workspace_name}/dashboard/forms/${form_id}/settings`);
 }

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/links/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/links/page.tsx
@@ -4,7 +4,7 @@ import FormLinks from '@Components/form/links';
 
 export default function Page() {
     return (
-        <div className="px-2 md:px-32 mt-4">
+        <div className="mt-4 px-4 md:px-10 lg:px-28">
             <FormLinks />
         </div>
     );

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/responses/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/responses/page.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import FormResponses from '@Components/form/responses';
+import FormResponses from '@app/components/form/responses';
+import ResponseSegments from '@app/components/form/response-segments';
 
 export default function Page() {
-    return <FormResponses />;
+    return (
+        <div className="mt-4 px-4 md:px-10 lg:px-28">
+            <ResponseSegments />
+            <FormResponses />
+        </div>
+    );
 }

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/settings/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/settings/page.tsx
@@ -4,7 +4,7 @@ import FormSettings from '@Components/form/settings';
 
 export default function Page() {
     return (
-        <div className="px-2 md:px-32 mt-4">
+        <div className="mt-4 px-4 md:px-10 lg:px-28">
             <FormSettings />
         </div>
     );

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/visibility/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/visibility/page.tsx
@@ -1,11 +1,8 @@
-'use client';
+import { redirect } from 'next/navigation';
 
-import FormVisibilities from '@Components/form/visibility';
-
-export default function Page() {
-    return (
-        <div className="px-2 md:px-32 mt-4">
-            <FormVisibilities />
-        </div>
-    );
+// Visibility is a Settings section now (the standalone tab was one of the
+// reasons the tab bar overflowed and hid entire features).
+export default async function Page(props: { params: Promise<{ workspace_name: string; form_id: string }> }) {
+    const { workspace_name, form_id } = await props.params;
+    redirect(`/${workspace_name}/dashboard/forms/${form_id}/settings`);
 }

--- a/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/edit/_components/form-edit-page.tsx
+++ b/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/edit/_components/form-edit-page.tsx
@@ -116,7 +116,8 @@ export default function FormEditPage(props: { params: Promise<{ form_id: string 
                     ...formState,
                     title: standardForm.title,
                     thankyouPage: copiedThankyouPage,
-                    welcomePage: copiedWelcomePage
+                    welcomePage: copiedWelcomePage,
+                    hiddenFields: standardForm.hiddenFields
                 };
                 setFormState(form);
             }
@@ -135,8 +136,10 @@ export default function FormEditPage(props: { params: Promise<{ form_id: string 
             <AutoSaveForm formId={formId} />
             <div className="max-h-body-content  flex w-full flex-row items-center">
                 <LeftDrawer formFields={formFields} activeSlideComponent={activeSlideComponent} />
+                {/* Neutral workspace mat behind the canvas, so the slide being edited
+                    reads as the artefact and separates from the tool's chrome. */}
                 <div
-                    className=" relative flex max-h-full max-w-full flex-1 justify-center overflow-x-hidden px-5 py-14"
+                    className=" relative flex max-h-full max-w-full flex-1 justify-center overflow-x-hidden bg-[#E9EEF5] px-5 py-14"
                     onClick={() => {
                         setActiveFieldComponent(null);
                     }}
@@ -146,7 +149,7 @@ export default function FormEditPage(props: { params: Promise<{ form_id: string 
                             width: getScaledDivWidth()
                         }}
                     >
-                        <div className="!shadow-slide aspect-video overflow-hidden" style={scaledDivStyle}>
+                        <div className="!shadow-slide border-black-300 aspect-video overflow-hidden rounded-lg border bg-white" style={scaledDivStyle}>
                             <div className="   mx-auto h-full w-full  rounded-lg">
                                 {activeSlideComponent?.id && activeSlideComponent?.index >= 0 && <SlideBuilder slide={formFields[activeSlideComponent?.index]} />}
                                 {!activeSlideComponent?.id && <div>Add a slide to start</div>}

--- a/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
+++ b/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
@@ -6,8 +6,11 @@ import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
 import { setForm } from '@app/store/forms/slice';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
 import { useFormState } from '@app/store/jotai/form';
+import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { useGetWorkspaceFormQuery } from '@app/store/workspaces/api';
 import { selectWorkspace } from '@app/store/workspaces/slice';
+import { captureHiddenFieldValues, getPrefillEntries } from '@app/utils/answer-piping';
 import FullScreenLoader from '@app/views/atoms/full-screen-loader';
 import Form from '@app/views/organism/form/form';
 import TrustLayer from '@app/views/molecules/form/trust-layer';
@@ -47,6 +50,52 @@ const FetchFormWrapper = ({ slug }: { slug: string }) => {
         trackedViewRef.current = true;
         trackCanonicalFormView(workspace.workspaceName, slug);
     }, [workspace?.workspaceName, data?.formId, slug]);
+
+    const { setHiddenValues } = useHiddenFieldValues();
+    const { addFieldTextAnswer, addFieldEmailAnswer, addFieldNumberAnswer, addFieldURLAnswer, addFieldPhoneNumberAnswer, addFieldDateAnswer } = useFormResponse();
+    const capturedParamsRef = useRef(false);
+
+    // Once the form definition is in: capture the declared hidden-field values
+    // from the share link and apply any `?field_<id>=` prefills. window.location
+    // (not useSearchParams) so this stays out of the server render entirely.
+    useEffect(() => {
+        if (capturedParamsRef.current || !data?.formId) return;
+        capturedParamsRef.current = true;
+
+        const search = window.location.search;
+        if (!search) return;
+
+        const captured = captureHiddenFieldValues(data.hiddenFields, search);
+        if (Object.keys(captured).length) setHiddenValues(captured);
+
+        getPrefillEntries(data.fields, search).forEach(({ field, value }) => {
+            switch (field.type) {
+                case FieldTypes.SHORT_TEXT:
+                case FieldTypes.LONG_TEXT:
+                    addFieldTextAnswer(field.id, value);
+                    break;
+                case FieldTypes.EMAIL:
+                    addFieldEmailAnswer(field.id, value);
+                    break;
+                case FieldTypes.NUMBER:
+                    if (Number.isFinite(Number(value))) addFieldNumberAnswer(field.id, Number(value));
+                    break;
+                case FieldTypes.LINK:
+                    addFieldURLAnswer(field.id, value);
+                    break;
+                case FieldTypes.PHONE_NUMBER:
+                    addFieldPhoneNumberAnswer(field.id, value);
+                    break;
+                case FieldTypes.DATE:
+                    addFieldDateAnswer(field.id, value);
+                    break;
+                default:
+                    // Choice/rating/matrix prefill needs option matching — not
+                    // supported in this first pass.
+                    break;
+            }
+        });
+    }, [data?.formId]);
 
     const hasFileUpload = (fields: Array<any>) => {
         let isUploadField = false;
@@ -108,6 +157,7 @@ const FetchFormWrapper = ({ slug }: { slug: string }) => {
                         ownerName={workspace?.title || workspace?.workspaceName}
                         ownerImage={workspace?.profileImage}
                         privacyUrl={data?.settings?.privacyPolicyUrl}
+                        portalUrl={typeof window !== 'undefined' && window.PUBLIC_CONFIG ? `${window.PUBLIC_CONFIG.HTTP_SCHEME}${window.PUBLIC_CONFIG.FORM_DOMAIN}/${workspace?.workspaceName}` : undefined}
                     />
                 </div>
             )}

--- a/webapp/src/assets/css/globals.css
+++ b/webapp/src/assets/css/globals.css
@@ -188,3 +188,18 @@ div::-webkit-scrollbar-thumb:hover {
         background-image: linear-gradient(135.6deg, #FE3678 0%, #0764EB 98.97%) !important;
     }
 }
+
+/* Answer-piping chip (answerPipe tiptap node) — shown in the builder title
+   editor; the responder runtime replaces the node with the resolved answer. */
+.answer-pipe-chip {
+    display: inline-block;
+    padding: 0 0.375rem;
+    border-radius: 0.25rem;
+    /* Trust palette (Design-Language §1): chip-bg on trust blue. */
+    background: #e9effc;
+    color: #2456cc;
+    font-size: 0.9em;
+    font-weight: 500;
+    white-space: nowrap;
+    user-select: none;
+}

--- a/webapp/src/components/dashboard/form-settings.tsx
+++ b/webapp/src/components/dashboard/form-settings.tsx
@@ -302,205 +302,136 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
                 );
             case 'DEFAULT':
                 return (
-                    <div className=" mb-10 flex flex-col gap-7 ">
+                    <div className="divide-black-200 flex flex-col divide-y">
                         {form?.importedFormId && (
-                            <FormSettingsCard>
-                                <div className=" flex w-full flex-col items-start">
-                                    {/*<div className="h5-new !text-black-800">{t('FORM_PAGE.SETTINGS.DEFAULT.COLLECT_EMAILS.TITLE')}</div>*/}
-                                    <div className="h5-new !text-black-800">Show Original Form</div>
-                                    <Divider className={'my-2 w-full'} />
-                                    <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4 flex-1">Original Google Form in Embed mode is shown if this is enabled.</div>
-                                        {/*<div className="body4 !text-black-700 w-3/4">{t('FORM_PAGE.SETTINGS.DEFAULT.COLLECT_EMAILS.DESCRIPTION')}</div>*/}
-                                        <Switch
-                                            data-umami-event="Show Original Google Form Switch"
-                                            data-umami-event-email={auth.email}
-                                            data-testid="show-original-form-switch"
-                                            checked={!!form?.settings?.showOriginalForm}
-                                            onCheckedChange={(checked) => {
-                                                onShowOriginalFormChange(checked, form);
-                                            }}
-                                        />
-                                    </div>
-                                    <Divider className={'my-2 w-full'} />
-                                </div>
-                            </FormSettingsCard>
-                        )}
-
-                        {form?.settings?.provider === 'self' && (
-                            <FormSettingsCard>
-                                <div className=" flex w-full flex-col items-start">
-                                    {/*<div className="h5-new !text-black-800">{t('FORM_PAGE.SETTINGS.DEFAULT.COLLECT_EMAILS.TITLE')}</div>*/}
-                                    <div className="h5-new !text-black-800">Require Verified Identity</div>
-                                    <Divider className={'my-2 w-full'} />
-                                    <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4 flex-1">When enabled, respondents must verify their email before they can fill out this form.</div>
-                                        {/*<div className="body4 !text-black-700 w-3/4">{t('FORM_PAGE.SETTINGS.DEFAULT.COLLECT_EMAILS.DESCRIPTION')}</div>*/}
-                                        <Switch
-                                            data-umami-event="Require Verified Identity Switch"
-                                            data-umami-event-email={auth.email}
-                                            data-testid="require-verified-identity-switch"
-                                            checked={!!form?.settings?.requireVerifiedIdentity}
-                                            onCheckedChange={(checked) => {
-                                                onCollectEmailsChange(checked, form);
-                                            }}
-                                        />
-                                    </div>
-                                    <Divider className={'my-2 w-full'} />
-                                </div>
-                            </FormSettingsCard>
+                            <SettingRow title="Show original form" description="Show the original Google Form in embed mode instead of the bettercollected renderer.">
+                                <Switch
+                                    data-umami-event="Show Original Google Form Switch"
+                                    data-umami-event-email={auth.email}
+                                    data-testid="show-original-form-switch"
+                                    checked={!!form?.settings?.showOriginalForm}
+                                    onCheckedChange={(checked) => {
+                                        onShowOriginalFormChange(checked, form);
+                                    }}
+                                />
+                            </SettingRow>
                         )}
                         {form?.settings?.provider === 'self' && (
-                            <FormSettingsCard>
-                                <div className=" flex w-full flex-col items-start">
-                                    <div className="h5-new !text-black-800">Show Submission Number</div>
-                                    <Divider className={'my-2 w-full'} />
-                                    <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4">When enabled, respondents get a submission ID they can use to view their response and request its deletion.</div>
-                                        <Switch
-                                            data-umami-event="Show Submission Number Switch"
-                                            data-umami-event-email={auth.email}
-                                            data-testid="show-submission-number-switch"
-                                            checked={!!form?.settings?.showSubmissionNumber}
-                                            onCheckedChange={(checked) => {
-                                                onShowSubmissionNumberChange(checked, form);
-                                            }}
-                                        />
-                                    </div>
-                                    <Divider className={'my-2 w-full'} />
-                                </div>
-                            </FormSettingsCard>
+                            <SettingRow title="Require verified identity" description="Respondents must verify their email before they can fill out this form.">
+                                <Switch
+                                    data-umami-event="Require Verified Identity Switch"
+                                    data-umami-event-email={auth.email}
+                                    data-testid="require-verified-identity-switch"
+                                    checked={!!form?.settings?.requireVerifiedIdentity}
+                                    onCheckedChange={(checked) => {
+                                        onCollectEmailsChange(checked, form);
+                                    }}
+                                />
+                            </SettingRow>
+                        )}
+                        {form?.settings?.provider === 'self' && (
+                            <SettingRow title="Show submission number" description="Respondents get a submission ID they can use to view their response and request its deletion.">
+                                <Switch
+                                    data-umami-event="Show Submission Number Switch"
+                                    data-umami-event-email={auth.email}
+                                    data-testid="show-submission-number-switch"
+                                    checked={!!form?.settings?.showSubmissionNumber}
+                                    onCheckedChange={(checked) => {
+                                        onShowSubmissionNumberChange(checked, form);
+                                    }}
+                                />
+                            </SettingRow>
                         )}
                         {form?.settings?.provider === 'self' && form?.settings?.requireVerifiedIdentity && (
-                            <FormSettingsCard>
-                                <div className=" flex w-full flex-col items-start">
-                                    <div className="h5-new !text-black-800">Allow Response Editing</div>
-                                    <Divider className={'my-2 w-full'} />
-                                    <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                        <div className="body4 !text-black-700 w-3/4">The verified responder can change their response if this is enabled</div>
-                                        <Switch
-                                            data-umami-event="Allow Response Editing Switch"
-                                            data-umami-event-email={auth.email}
-                                            data-testid="pinned-switch"
-                                            checked={!!form?.settings?.allowEditingResponse}
-                                            onCheckedChange={(checked) => {
-                                                onAllowResponseEditingChange(checked, form);
-                                            }}
-                                        />
-                                    </div>
-                                    <Divider className={'my-2 w-full'} />
-                                </div>
-                            </FormSettingsCard>
+                            <SettingRow title="Allow response editing" description="Verified responders can change their response after submitting.">
+                                <Switch
+                                    data-umami-event="Allow Response Editing Switch"
+                                    data-umami-event-email={auth.email}
+                                    data-testid="allow-response-editing-switch"
+                                    checked={!!form?.settings?.allowEditingResponse}
+                                    onCheckedChange={(checked) => {
+                                        onAllowResponseEditingChange(checked, form);
+                                    }}
+                                />
+                            </SettingRow>
                         )}
                         {form?.isPublished && isFormOpen && (
                             <>
                                 {!form?.settings?.private && (
-                                    <FormSettingsCard>
-                                        <div className=" flex w-full flex-col items-start">
-                                            <div className="h5-new !text-black-800">{t(formPage.pinFormTitle)}</div>
-                                            <Divider className={'my-2 w-full'} />
-                                            <div className="flex flex-row items-center justify-between md:gap-4">
-                                                <div className="body4 !text-black-700 w-3/4">{t(formPage.pinFormDescription)}</div>
-                                                <Switch data-umami-event="Pin Form Switch" data-umami-event-email={auth.email} data-testid="pinned-switch" checked={!!form?.settings?.pinned} onCheckedChange={(checked) => onPinnedChange(checked, form)} />
-                                            </div>
-                                            <Divider className={'my-2 w-full'} />
-                                        </div>
-                                    </FormSettingsCard>
+                                    <SettingRow title={t(formPage.pinFormTitle)} description={t(formPage.pinFormDescription)}>
+                                        <Switch data-umami-event="Pin Form Switch" data-umami-event-email={auth.email} data-testid="pinned-switch" checked={!!form?.settings?.pinned} onCheckedChange={(checked) => onPinnedChange(checked, form)} />
+                                    </SettingRow>
                                 )}
-                                <FormSettingsCard className={cn('', !isProPlan && isAdmin && '')}>
-                                    <div className=" flex w-full flex-col items-start">
-                                        <div className="h5-new !text-black-800 flex flex-row justify-between gap-4">
-                                            <h1>{t(formPage.brandingTitle)}</h1>
-                                            <ProLogo />
-                                        </div>
-                                        <Divider className={'my-2 w-full'} />
-                                        <div className="flex w-full flex-row items-center justify-between md:gap-4">
-                                            <div className="body4 !text-black-700 w-3/4">{t(formPage.brandingDescription)}</div>
-                                            <Switch
-                                                disabled={!isProPlan}
-                                                data-umami-event="Disable Branding Switch"
-                                                data-umami-event-email={auth.email}
-                                                data-testid="disable-branding-switch"
-                                                checked={!form?.settings?.disableBranding}
-                                                onCheckedChange={(checked) => onDisableBrandingChange(checked, form)}
-                                            />
-                                        </div>
-                                        <Divider className={'my-2 w-full'} />
-                                    </div>
-                                </FormSettingsCard>
+                                <SettingRow
+                                    title={t(formPage.brandingTitle)}
+                                    titleExtra={<ProLogo />}
+                                    description={t(formPage.brandingDescription)}
+                                    hint={
+                                        !isProPlan ? (
+                                            <span className="text-black-600 flex items-center gap-1 text-xs">
+                                                <Lock className="h-3 w-3" /> Available on Pro — the control is locked on your current plan.
+                                            </span>
+                                        ) : undefined
+                                    }
+                                >
+                                    <Switch
+                                        disabled={!isProPlan}
+                                        data-umami-event="Disable Branding Switch"
+                                        data-umami-event-email={auth.email}
+                                        data-testid="disable-branding-switch"
+                                        checked={!form?.settings?.disableBranding}
+                                        onCheckedChange={(checked) => onDisableBrandingChange(checked, form)}
+                                    />
+                                </SettingRow>
                             </>
                         )}
                         {form?.settings?.provider === 'self' && form?.isPublished && (
-                            <FormSettingsCard>
-                                <div className="flex w-full flex-col items-start">
-                                    <div className="body1">{t(formPage.closeForm)}</div>
-                                    <Divider className={'my-2 w-full'} />
-                                    {(!form?.settings?.formCloseDate || moment.utc(form?.settings?.formCloseDate).isBefore(moment.utc())) && (
-                                        <>
-                                            <div className=" flex w-full flex-row items-center justify-between gap-4">
-                                                <div className="!text-black-700 text-sm">{t(formPage.closeFormDescription)}</div>
-                                                <Switch
-                                                    data-umami-event="Close Form Switch"
-                                                    data-umami-event-email={auth.email}
-                                                    data-testid="close-form-switch"
-                                                    // checked={false}
-                                                    checked={closeFormChecked}
-                                                    onCheckedChange={(checked) => {
-                                                        if (closeFormChecked) {
-                                                            openModal('REOPEN_FORM_CONFIRMATION_MODAL', { reopenForm });
-                                                        } else {
-                                                            openModal('CLOSE_FORM_CONFIRMATION_MODAL', { closeForm });
-                                                        }
-                                                    }}
-                                                />
-                                            </div>
-                                            {!closeFormChecked && !moment(form?.settings?.formCloseDate).isAfter(moment.utc()) && (
-                                                <Button
-                                                    data-umami-event="Select Form Close Date Button"
-                                                    data-umami-event-email={auth.email}
-                                                    className="mt-2"
-                                                    variant="ghost"
-                                                    onClick={() => {
-                                                        openBottomSheetModal('SELECT_FORM_CLOSE_DATE', {
-                                                            onFormClosedChange: onFormClosedChange,
-                                                            closeDate: form?.settings?.formCloseDate
-                                                        });
-                                                    }}
-                                                >
-                                                    {t(formPage.schedule)}
-                                                </Button>
-                                            )}
-                                        </>
-                                    )}
-
-                                    {form?.settings?.formCloseDate && moment(form?.settings?.formCloseDate).isAfter(moment.utc()) && (
-                                        <div className="bg-black-200 my-2 flex w-full justify-between rounded-md p-5">
-                                            <div>
-                                                {t(formPage.automaticallyCloseOn)} {utcToLocalDateTIme(form?.settings?.formCloseDate)}
-                                            </div>
-                                            <div>
-                                                <div onClick={reopenForm}>
-                                                    <Close width="24px" height="24px" className="text-black-800" />
-                                                </div>
+                            <div className="flex w-full flex-col">
+                                <SettingRow title={t(formPage.closeForm)} description={t(formPage.closeFormDescription)}>
+                                    <Switch
+                                        data-umami-event="Close Form Switch"
+                                        data-umami-event-email={auth.email}
+                                        data-testid="close-form-switch"
+                                        checked={closeFormChecked}
+                                        onCheckedChange={(checked) => {
+                                            if (closeFormChecked) {
+                                                openModal('REOPEN_FORM_CONFIRMATION_MODAL', { reopenForm });
+                                            } else {
+                                                openModal('CLOSE_FORM_CONFIRMATION_MODAL', { closeForm });
+                                            }
+                                        }}
+                                    />
+                                </SettingRow>
+                                {!closeFormChecked && !moment(form?.settings?.formCloseDate).isAfter(moment.utc()) && (
+                                    <Button
+                                        data-umami-event="Select Form Close Date Button"
+                                        data-umami-event-email={auth.email}
+                                        className="mb-4 w-fit"
+                                        variant="ghost"
+                                        onClick={() => {
+                                            openBottomSheetModal('SELECT_FORM_CLOSE_DATE', {
+                                                onFormClosedChange: onFormClosedChange,
+                                                closeDate: form?.settings?.formCloseDate
+                                            });
+                                        }}
+                                    >
+                                        {t(formPage.schedule)}
+                                    </Button>
+                                )}
+                                {form?.settings?.formCloseDate && moment(form?.settings?.formCloseDate).isAfter(moment.utc()) && (
+                                    <div className="bg-black-200 mb-4 flex w-full justify-between rounded-md p-5">
+                                        <div>
+                                            {t(formPage.automaticallyCloseOn)} {utcToLocalDateTIme(form?.settings?.formCloseDate)}
+                                        </div>
+                                        <div>
+                                            <div onClick={reopenForm}>
+                                                <Close width="24px" height="24px" className="text-black-800" />
                                             </div>
                                         </div>
-                                    )}
-                                    <Divider className={'my-2 w-full'} />
-                                </div>
-                            </FormSettingsCard>
+                                    </div>
+                                )}
+                            </div>
                         )}
-                        <div className="mt-6">
-                            <Button
-                                data-umami-event="Delete Form From Preview Section"
-                                data-umami-event-email={auth.email}
-                                onClick={() => {
-                                    openModal('DELETE_FORM_MODAL', { form, redirectToDashboard: true });
-                                }}
-                                variant="danger"
-                            >
-                                {t(buttonConstant.deleteForm)}
-                            </Button>
-                        </div>
                     </div>
                 );
             default:
@@ -510,6 +441,26 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
 
     return <>{showSettingsTabView(view)}</>;
 }
+
+/**
+ * One settings row: label + description on the left, control on the right.
+ * Rows are separated by the parent's divide-y — a divider never cuts a
+ * setting in half (the old layout drew the hairline between a setting's
+ * label and its own control).
+ */
+export const SettingRow = ({ title, titleExtra, description, children, hint }: { title: React.ReactNode; titleExtra?: React.ReactNode; description: React.ReactNode; children: React.ReactNode; hint?: React.ReactNode }) => (
+    <div className="flex w-full items-start justify-between gap-6 py-5">
+        <div className="flex max-w-[560px] flex-col gap-1">
+            <div className="text-black-900 flex items-center gap-2 text-[15px] font-semibold">
+                {title}
+                {titleExtra}
+            </div>
+            <div className="text-black-700 text-sm leading-relaxed">{description}</div>
+            {hint}
+        </div>
+        <div className="pt-1">{children}</div>
+    </div>
+);
 
 const FormGroups = ({ groups }: { groups: ResponderGroupDto[] }) => {
     const { openBottomSheetModal } = useBottomSheetModal();

--- a/webapp/src/components/dashboard/form-tab-content.tsx
+++ b/webapp/src/components/dashboard/form-tab-content.tsx
@@ -1,53 +1,106 @@
+'use client';
 
-import { StandardFormDto } from '@app/models/dtos/form';
+import { useEffect, useState } from 'react';
+
+import { Play } from 'lucide-react';
+
+import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
+import { StandardFormDto, StandardFormFieldDto } from '@app/models/dtos/form';
+import { Button } from '@app/shadcn/components/ui/button';
 import FormSlidePreview from '@app/views/organism/form-preview/form-slide-preview';
 import WelcomePage from '@app/views/organism/form/welcome-page';
 import LayoutWrapper from '@app/views/organism/layout/layout-wrapper';
 
+const computeContainerWidth = () => {
+    if (typeof window === 'undefined') return 0;
+    const windowWidth = window.innerWidth;
+    let padding = 5 * 4 * 2;
+    if (windowWidth > 768) padding = 10 * 4 * 2;
+    if (windowWidth > 1024) padding = 28 * 4 * 2 + 4 * 4;
+    let containerWidth = windowWidth - padding;
+    if (windowWidth > 1024) containerWidth = containerWidth / 2;
+    return containerWidth;
+};
+
 export const FormTabContent = ({ form }: { form: StandardFormDto }) => {
-    const getContainerWidth = () => {
-        if (typeof window !== 'undefined') {
-            const windowWidth = window.innerWidth;
-            let padding = 5 * 4 * 2;
-            if (windowWidth > 768) padding = 10 * 4 * 2;
-            if (windowWidth > 1024) padding = 28 * 4 * 2 + 4 * 4;
-            let containerWidth = windowWidth - padding;
-            if (windowWidth > 1024) containerWidth = containerWidth / 2;
-            return containerWidth;
-        }
-        return 0;
-    };
-    const getPreviewStyles = () => {
-        const containerWidth = getContainerWidth();
-        return {
-            scale: (containerWidth / 1440).toString(),
-            transformOrigin: 'top left'
-        };
+    const { openModal: openFullScreenModal } = useFullScreenModal();
+
+    // Track the width so the grid survives a window resize (it used to be
+    // computed once at mount).
+    const [containerWidth, setContainerWidth] = useState(computeContainerWidth);
+    useEffect(() => {
+        const onResize = () => setContainerWidth(computeContainerWidth());
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, []);
+
+    const previewStyles = {
+        scale: (containerWidth / 1440).toString(),
+        transformOrigin: 'top left' as const
     };
 
-    if (form?.builderVersion === 'v2') {
-        return (
-            <>
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                    <div className=" border-black-300 relative aspect-video overflow-hidden rounded-md border" style={{ width: getContainerWidth() }}>
-                        <div className=" pointer-events-none h-[810px] w-[1440px]" style={getPreviewStyles()}>
-                            <LayoutWrapper showDesktopLayout theme={form?.theme} disabled layout={form.welcomePage?.layout} imageUrl={form?.welcomePage?.imageUrl}>
-                                <WelcomePage isPreviewMode theme={form?.theme} welcomePageData={form?.welcomePage} />
-                            </LayoutWrapper>
-                        </div>
+    const openPreview = () => openFullScreenModal('PREVIEW_MODAL');
+
+    const isSlideEmpty = (slide: StandardFormFieldDto) => !slide?.properties?.fields?.length;
+
+    if (form?.builderVersion !== 'v2') return null;
+
+    return (
+        <div className="flex w-full flex-col gap-4">
+            <div className="flex items-center justify-between">
+                <span className="text-black-600 text-xs font-semibold uppercase tracking-wide">Pages</span>
+                <Button variant="v2Button" icon={<Play className="h-4 w-4" />} onClick={openPreview}>
+                    Open preview
+                </Button>
+            </div>
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <PreviewCard label="Welcome page" width={containerWidth} onClick={openPreview}>
+                    <div className="pointer-events-none h-[810px] w-[1440px]" style={previewStyles}>
+                        <LayoutWrapper showDesktopLayout theme={form?.theme} disabled layout={form.welcomePage?.layout} imageUrl={form?.welcomePage?.imageUrl}>
+                            <WelcomePage isPreviewMode theme={form?.theme} welcomePageData={form?.welcomePage} />
+                        </LayoutWrapper>
                     </div>
-                    {form?.fields?.map((slide) => (
-                        <div className="mb-2 flex w-min cursor-pointer flex-col  rounded-lg border border-transparent" key={slide?.id}>
-                            <div className="border-black-300 relative aspect-video overflow-hidden rounded-md border" style={{ width: getContainerWidth() }}>
-                                <div className="pointer-events-none h-[810px] w-[1440px]" style={getPreviewStyles()}>
-                                    <FormSlidePreview slide={slide} theme={form.theme} />
-                                </div>
-                            </div>
+                </PreviewCard>
+                {form?.fields?.map((slide, index) => (
+                    <PreviewCard key={slide?.id} label={`Page ${index + 1}`} empty={isSlideEmpty(slide)} width={containerWidth} onClick={openPreview}>
+                        <div className="pointer-events-none h-[810px] w-[1440px]" style={previewStyles}>
+                            <FormSlidePreview slide={slide} theme={form.theme} />
                         </div>
-                    ))}
-                </div>
-            </>
-        );
-    }
-    return null;
+                    </PreviewCard>
+                ))}
+            </div>
+        </div>
+    );
 };
+
+/**
+ * A labelled page thumbnail that actually does something on click: it opens
+ * the full-screen preview (the scaled-down card itself is unreadable by
+ * design — it is a map, not the territory).
+ */
+const PreviewCard = ({ label, empty, width, onClick, children }: { label: string; empty?: boolean; width: number; onClick: () => void; children: React.ReactNode }) => (
+    // div-with-button-role, NOT a <button>: the thumbnail renders the real
+    // slide markup, which contains buttons/inputs of its own — interactive
+    // elements can't nest inside a button.
+    <div
+        role="button"
+        tabIndex={0}
+        onClick={onClick}
+        onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onClick();
+            }
+        }}
+        className="group flex w-min cursor-pointer flex-col gap-1.5 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#2456CC]"
+        aria-label={`Open preview at ${label}`}
+    >
+        <span className="text-black-700 flex items-center gap-2 text-[13px] font-medium">
+            {label}
+            {empty && <span className="bg-black-200 text-black-600 rounded-full px-2 py-0.5 text-xs">Empty</span>}
+        </span>
+        <span className="border-black-300 group-hover:border-black-500 relative block aspect-video overflow-hidden rounded-md border transition-colors" style={{ width }}>
+            {children}
+        </span>
+    </div>
+);

--- a/webapp/src/components/datatable/form-responses.tsx
+++ b/webapp/src/components/datatable/form-responses.tsx
@@ -100,11 +100,11 @@ export default function FormResponsesTable({ props }: any) {
     return (
         <div>
             <CSVLink data={csvDatas} filename={`${form.title}.csv`} className="btn btn-primary" target="_blank" id="csv_link" />
-            <div className={`mb-12 flex flex-col gap-2 px-2 md:px-28 lg:flex-row lg:justify-between`}>
+            <div className={`mb-6 flex flex-col gap-2 lg:flex-row lg:justify-between`}>
                 <div className="flex w-full flex-row justify-between">
                     {(isSubmission && form.responses) || (!isSubmission && form.deletionRequests) ? (
                         <div className="flex w-full flex-row items-center gap-4 ">
-                            <SearchInput handleSearch={handleSearch} placeholder={'Search Responses'} className="md:w-[282px]" />
+                            <SearchInput handleSearch={handleSearch} placeholder={'Search responses'} className="md:w-[282px]" />
                         </div>
                     ) : (
                         <></>
@@ -119,18 +119,29 @@ export default function FormResponsesTable({ props }: any) {
             {data && Array.isArray(data.items) && data.items.length ? (
                 <>{data && requestForDeletion ? <ResponsesTable formId={form.formId} requestForDeletion={requestForDeletion} page={page} setPage={setPage} submissions={data} /> : <TabularResponses form={form} />}</>
             ) : (
-                <EmptyTabularResponseComponent />
+                <EmptyTabularResponseComponent requestForDeletion={requestForDeletion} />
             )}
         </div>
     );
 }
 
-const EmptyTabularResponseComponent = () => {
+const EmptyTabularResponseComponent = ({ requestForDeletion }: { requestForDeletion?: boolean }) => {
+    // Deletion requests are a GDPR feature — the empty state should teach that,
+    // not borrow the responses copy (which can be factually wrong here).
+    if (requestForDeletion) {
+        return (
+            <div className={'flex flex-col items-center gap-2 py-10'}>
+                <EmptyResponseIcon />
+                <span className={'p3-new text-black'}>No deletion requests</span>
+                <span className={'p4-new text-black-600 max-w-[420px] text-center'}>When a responder asks for their response to be deleted, it shows up here for you to act on.</span>
+            </div>
+        );
+    }
     return (
-        <div className={'flex flex-col items-center gap-2 py-6'}>
+        <div className={'flex flex-col items-center gap-2 py-10'}>
             <EmptyResponseIcon />
             <span className={'p3-new text-black'}>No responses yet</span>
-            <span className={'p4-new text-black-600'}>This form doesn&apos;t have any responses yet.</span>
+            <span className={'p4-new text-black-600'}>Responses appear here as soon as someone fills out your form.</span>
         </div>
     );
 };

--- a/webapp/src/components/form/integrations.tsx
+++ b/webapp/src/components/form/integrations.tsx
@@ -41,7 +41,7 @@ export default function FormIntegrations() {
     };
 
     return (
-        <div className="mb-5 px-4 md:px-10 lg:px-28">
+        <div className="mb-5">
             {addedActions && addedActions.length > 0 && (
                 <div className="mb-10 flex flex-col gap-2">
                     <div className="h3-new text-black-800 mb-5">Integrations added to form</div>
@@ -124,7 +124,6 @@ export default function FormIntegrations() {
             )}
             {data && Array.isArray(data) && data?.length !== addedActions?.length && (
                 <div className="flex w-full flex-col gap-2">
-                    <div className="h3-new mb-8">Integrations</div>
                     {data?.map((integration, index) => (
                         <>
                             {(!addedActions || !addedActions.includes(integration.id)) && (

--- a/webapp/src/components/form/response-segments.tsx
+++ b/webapp/src/components/form/response-segments.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import Link from 'next/link';
+import { useParams, usePathname } from 'next/navigation';
+
+import { selectForm } from '@app/store/forms/slice';
+import { useAppSelector } from '@app/store/hooks';
+import { cn } from '@app/shadcn/util/lib';
+
+/**
+ * Segmented control shared by /responses and /deletion-requests — deletion
+ * requests are a view over the same submissions, not a separate destination,
+ * so they live under the single "Responses" tab.
+ */
+export default function ResponseSegments() {
+    const pathname = usePathname();
+    const params = useParams();
+    const form = useAppSelector(selectForm);
+
+    const base = `/${params?.workspace_name}/dashboard/forms/${params?.form_id}`;
+    const segments = [
+        { label: 'All responses', count: form?.responses ?? 0, href: `${base}/responses`, active: !!pathname?.endsWith('/responses') },
+        { label: 'Deletion requests', count: (form as any)?.deletionRequests ?? 0, href: `${base}/deletion-requests`, active: !!pathname?.endsWith('/deletion-requests') }
+    ];
+
+    return (
+        <div className="border-black-300 mb-6 inline-flex rounded-lg border bg-white p-0.5">
+            {segments.map((segment) => (
+                <Link
+                    key={segment.href}
+                    href={segment.href}
+                    aria-current={segment.active ? 'page' : undefined}
+                    className={cn('flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm', segment.active ? 'bg-black-100 text-black-900 font-semibold' : 'text-black-600 hover:text-black-900 font-medium')}
+                >
+                    {segment.label}
+                    <span className="bg-black-200 text-black-700 rounded-full px-1.5 py-0.5 text-xs font-medium tabular-nums">{segment.count}</span>
+                </Link>
+            ))}
+        </div>
+    );
+}

--- a/webapp/src/components/form/settings.tsx
+++ b/webapp/src/components/form/settings.tsx
@@ -1,18 +1,69 @@
-
 import { useTranslation } from 'next-i18next';
 
 import FormSettingsTab from '@app/components/dashboard/form-settings';
-import { localesCommon } from '@app/constants/locales/common';
+import FormIntegrations from '@app/components/form/integrations';
+import { useModal } from '@app/components/modal-views/context';
 import { formPage } from '@app/constants/locales/form-page';
+import { Button } from '@app/shadcn/components/ui/button';
+import { selectForm } from '@app/store/forms/slice';
+import { useAppSelector } from '@app/store/hooks';
 
+/** 12px-caps section header — same rhythm as the builder's panel headers. */
+const SectionHeader = ({ children }: { children: React.ReactNode }) => <h2 className="text-black-600 text-xs font-semibold uppercase tracking-wide">{children}</h2>;
 
+/**
+ * The Settings tab hosts everything about how the form behaves and who can
+ * see it: general settings, visibility, integrations, and the danger zone.
+ * Visibility and Integrations were separate top-level tabs before — the tab
+ * bar overflowed and hid entire features.
+ */
 export default function FormSettings() {
     const { t } = useTranslation();
+    const form = useAppSelector(selectForm);
+    const { openModal } = useModal();
+
+    const showIntegrations = form?.settings?.provider === 'self' && form?.builderVersion === 'v2' && form?.isPublished;
+
     return (
-        <div className="md:max-w-[740px]">
-            <p className="sh1 !text-black-800 !leading-none">{t(localesCommon.settings)}</p>
-            <p className="w-full body4 mt-4 mb-12 !text-black-700">{t(formPage.defaultDescription)}</p>
-            <FormSettingsTab view="DEFAULT" />
+        <div className="flex flex-col gap-12 pb-6 md:max-w-[760px]">
+            <section className="flex flex-col gap-2">
+                <SectionHeader>General</SectionHeader>
+                <FormSettingsTab view="DEFAULT" />
+            </section>
+
+            <section className="flex flex-col gap-2">
+                <SectionHeader>Visibility</SectionHeader>
+                <p className="text-black-700 text-sm">{t(formPage.visibilityDescription)}</p>
+                <FormSettingsTab view="VISIBILITY" />
+            </section>
+
+            {showIntegrations && (
+                <section className="flex flex-col gap-2">
+                    <SectionHeader>Integrations</SectionHeader>
+                    <FormIntegrations />
+                </section>
+            )}
+
+            <section className="flex flex-col gap-2">
+                <SectionHeader>Danger zone</SectionHeader>
+                <div className="flex items-start justify-between gap-6 rounded-lg border border-[#E5B9B9] p-5">
+                    <div className="flex max-w-[520px] flex-col gap-1">
+                        <div className="text-black-900 text-[15px] font-semibold">Delete this form</div>
+                        <div className="text-black-700 text-sm leading-relaxed">
+                            Permanently deletes the form{typeof form?.responses === 'number' && form.responses > 0 ? ` and all ${form.responses} responses` : ' and any responses'}. This cannot be undone.
+                        </div>
+                    </div>
+                    <Button
+                        data-umami-event="Delete Form From Settings"
+                        variant="danger"
+                        onClick={() => {
+                            openModal('DELETE_FORM_MODAL', { form, redirectToDashboard: true });
+                        }}
+                    >
+                        Delete form
+                    </Button>
+                </div>
+            </section>
         </div>
     );
 }

--- a/webapp/src/components/form/tabular-responses.tsx
+++ b/webapp/src/components/form/tabular-responses.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import StyledPagination from '@Components/common/pagination';
 import cn from 'classnames';
 import DataTable from 'react-data-table-component';
+import { Shield as ShieldIcon } from 'lucide-react';
 
 import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
 import globalConstants from '@app/constants/global';
@@ -108,9 +109,16 @@ export default function TabularResponses({ form }: TabularResponsesProps) {
 
     const responseDataOwnerField = (response: StandardFormResponseDto) => (
         <div aria-hidden className="flex w-fit flex-col gap-1 ">
-            <p className={cn('!text-black-800 p2-new w-fit truncate')}>
-                {response?.dataOwnerIdentifier || '- -'}
-            </p>
+            {response?.dataOwnerIdentifier ? (
+                <p className={cn('!text-black-800 p2-new w-fit truncate')}>{response.dataOwnerIdentifier}</p>
+            ) : (
+                // Anonymity is the product's promise — show it as a state, not
+                // as missing data ("- -").
+                <span className="flex w-fit items-center gap-1 rounded-full bg-[#E7F4EE] px-2 py-0.5 text-xs font-medium text-[#0E8A5F]">
+                    <ShieldIcon className="h-3 w-3" strokeWidth={2} />
+                    Anonymous
+                </span>
+            )}
             <span className="text-black-600 text-[10px] font-normal">{utcToLocalDateTIme(response?.createdAt)}</span>
         </div>
     );

--- a/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
@@ -132,6 +132,17 @@ export const IndividualFormResponse = ({ formFields, response, form }: { formFie
                     </div>
                 );
             })}
+            {response.hiddenFields && Object.keys(response.hiddenFields).length > 0 && (
+                <div className="flex flex-col gap-3 border-t pt-4">
+                    <span className="p4-new text-black-500">Hidden fields (from the share link)</span>
+                    {Object.entries(response.hiddenFields).map(([name, value]) => (
+                        <div className="flex flex-col gap-1" key={name}>
+                            <span className="p4-new text-black-500 font-mono">{name}</span>
+                            <span className="p2-new text-black-700">{value}</span>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 };

--- a/webapp/src/constants/theme.ts
+++ b/webapp/src/constants/theme.ts
@@ -1,8 +1,11 @@
+// Default = the trust palette (Design-Language.md §1): calm neutral surface,
+// ink for words, one confident blue for actions. Saturated full-bleed colour
+// stays available through the other themes — it's opt-in, not the default.
 export const ThemeColor = {
-    accent: '#F2F7FF',
-    tertiary: '#A2C5F8',
-    secondary: '#0764EB',
-    primary: '#2E2E2E'
+    accent: '#F6F8FC',
+    tertiary: '#CBD5E6',
+    secondary: '#2456CC',
+    primary: '#101826'
 };
 
 export interface FormTheme {
@@ -16,10 +19,10 @@ export interface FormTheme {
 export const ThemeColors: Array<FormTheme> = [
     {
         title: 'Default',
-        primary: '#2E2E2E',
-        secondary: '#0764EB',
-        tertiary: '#A2C5F8',
-        accent: '#F2F7FF'
+        primary: '#101826',
+        secondary: '#2456CC',
+        tertiary: '#CBD5E6',
+        accent: '#F6F8FC'
     },
     {
         title: 'Blue',

--- a/webapp/src/models/dtos/form.ts
+++ b/webapp/src/models/dtos/form.ts
@@ -118,6 +118,8 @@ export interface StandardFormDto {
     isPublished?: boolean;
     importerDetails?: UserStatus;
     fields: Array<StandardFormFieldDto>;
+    /** Declared hidden-field (URL parameter) names — see utils/answer-piping.ts. */
+    hiddenFields?: string[];
     createdTime?: string | Date;
     modifiedTime?: string | Date;
     coverImage?: string;
@@ -135,6 +137,8 @@ export interface StandardFormResponseDto {
     answers: {
         [fieldId: string]: AnswerDto;
     };
+    /** Captured hidden-field (URL parameter) values for this submission. */
+    hiddenFields?: Record<string, string>;
     responseId: string;
     formId?: string;
     formTitle?: string;

--- a/webapp/src/shadcn/components/ui/input.tsx
+++ b/webapp/src/shadcn/components/ui/input.tsx
@@ -16,10 +16,13 @@ const ShadCNInput = React.forwardRef<HTMLInputElement, InputProps>(({ className,
     return (
         <input
             style={{
-                color: theme?.secondary
+                // The answer is the responder's own words — it wears ink (theme
+                // primary), never the accent/action colour. 16px floor, and never
+                // larger than the 24px question (Design-Language §2).
+                color: theme?.primary
             }}
             type={type}
-            className={cn(`w-full rounded-xl border px-4 py-3 text-[28px] outline-none transition-shadow disabled:cursor-not-allowed disabled:opacity-50 lg:text-[32px]`, className)}
+            className={cn(`w-full rounded-xl border bg-white px-4 py-3 text-base outline-none transition-shadow disabled:cursor-not-allowed disabled:opacity-50 lg:text-lg`, className)}
             ref={ref}
             // Coerce null -> '' so a controlled input never receives a null value.
             value={value === null ? '' : value}
@@ -51,10 +54,14 @@ const FieldInput = styled(ShadCNInput)<{
     const themeColor = $formTheme?.tertiary;
     const secondaryColor = $formTheme?.secondary;
     return {
-        background: 'inherit',
+        // White field on the page surface gives the input real figure/ground —
+        // the bordered box, not a wash, is what reads as "type here".
+        background: '#ffffff',
         borderColor: themeColor,
         '&::placeholder': {
-            color: `${themeColor} !important`
+            // Legible neutral (ink-3), not the theme tint — placeholders are
+            // text people read, not decoration.
+            color: '#657085 !important'
         },
         '&:focus': {
             borderColor: secondaryColor,

--- a/webapp/src/store/jotai/field-selectors.ts
+++ b/webapp/src/store/jotai/field-selectors.ts
@@ -7,6 +7,7 @@ import { v4 } from 'uuid';
 import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
 import { FormSlideLayout } from '@app/models/enums/form';
 import { FieldConditionalLogic, NodePosition, PageJump } from '@app/models/types/form-builder-shared';
+import { pruneOrphanedPipes } from '@app/utils/answer-piping';
 import { pruneOrphanedConditions } from '@app/utils/conditional-logic';
 import { useActiveFieldComponent, useActiveSlideComponent } from '@app/store/jotai/active-builder-component';
 import { reorder } from '@app/utils/array-utils';
@@ -144,8 +145,10 @@ export default function useFormFieldsAtom() {
             slide.index = index;
             return slide;
         });
-        // Deleting a page removes its questions too — sweep conditions that pointed at them.
+        // Deleting a page removes its questions too — sweep conditions and
+        // piping chips that pointed at them.
         pruneOrphanedConditions(updatedFormFields);
+        pruneOrphanedPipes(updatedFormFields);
         if (activeSlideComponent?.index === formFields.length) {
             setActiveSlideComponent({
                 id: 'welcome-page',
@@ -369,8 +372,9 @@ export default function useFormFieldsAtom() {
             ...field,
             index
         }));
-        // Sweep any logic that referenced the removed question.
+        // Sweep any logic or piping chips that referenced the removed question.
         pruneOrphanedConditions(formFields);
+        pruneOrphanedPipes(formFields);
         setFormFields([...formFields]);
         setTimeout(() => {
             setActiveFieldComponent(null);

--- a/webapp/src/store/jotai/form.ts
+++ b/webapp/src/store/jotai/form.ts
@@ -29,6 +29,12 @@ export interface IFormState {
         tertiary: string;
         accent: string;
     };
+    /**
+     * Declared hidden-field (URL parameter) names, e.g. ['utm_source', 'name'].
+     * Captured from the share link at fill time and stored with the response;
+     * available to answer piping in question text.
+     */
+    hiddenFields?: string[];
 }
 
 export interface IThemeState {
@@ -62,76 +68,82 @@ export const initialFormState: IFormState = {
 }
 export const formStateAtom = atom<IFormState>(initialFormState);
 
+/** Immutable update of one thank-you page entry against the CURRENT state. */
+function patchThankYouPage(prev: IFormState, index: number, patch: Partial<NonNullable<IFormState['thankyouPage']>[number]>): IFormState {
+    const thankyouPage = (prev.thankyouPage ?? []).map((page, i) => (i === index ? { ...page, ...patch } : page));
+    return { ...prev, thankyouPage };
+}
+
 export function useFormState() {
+    // Every setter below uses the FUNCTIONAL form. Several components fire
+    // these from mount effects (FormDispatcher sets the theme, WelcomeSlide
+    // the description, the editor page seeds the loaded form) — spreading the
+    // render-time `formState` closure instead of `prev` let whichever effect
+    // ran last resurrect stale state and silently drop the others' writes.
     const [formState, setFormState] = useAtom(formStateAtom);
     const { activeThankYouPageComponent } = useActiveThankYouPageComponent();
 
     const setFormTitle = (title: string) => {
-        setFormState({ ...formState, title: title });
+        setFormState((prev) => ({ ...prev, title }));
     };
 
     const setFormDescription = (description?: string) => {
-        setFormState({
-            ...formState,
+        setFormState((prev) => ({
+            ...prev,
             welcomePage: {
-                ...(formState?.welcomePage || {}),
+                ...(prev?.welcomePage || {}),
                 description: description
             }
-        });
+        }));
     };
 
     const setThankYouPageDescription = (thankyouPageIndex: number, description?: string) => {
-        formState.thankyouPage && (formState.thankyouPage[thankyouPageIndex].message = description);
-        setFormState({ ...formState });
+        setFormState((prev) => patchThankYouPage(prev, thankyouPageIndex, { message: description }));
     };
 
     const setThankYouPageButtonText = (thankyouPageIndex: number, btnText?: string) => {
-        formState.thankyouPage![thankyouPageIndex].buttonText = btnText;
-        setFormState({ ...formState });
+        setFormState((prev) => patchThankYouPage(prev, thankyouPageIndex, { buttonText: btnText }));
     };
 
     const setThankYouPageButtonLink = (thankyouPageIndex: number, btnLink?: string) => {
-        formState.thankyouPage && (formState.thankyouPage[thankyouPageIndex].buttonLink = btnLink);
-        setFormState({ ...formState });
+        setFormState((prev) => patchThankYouPage(prev, thankyouPageIndex, { buttonLink: btnLink }));
     };
 
     const setWelcomePageButtonText = (btnText: string) => {
-        setFormState({
-            ...formState,
-            welcomePage: { ...formState.welcomePage, buttonText: btnText }
-        });
+        setFormState((prev) => ({
+            ...prev,
+            welcomePage: { ...prev.welcomePage, buttonText: btnText }
+        }));
     };
 
     const updateFormTheme = (theme: { title: string; primary: string; secondary: string; tertiary: string; accent: string }) => {
-        setFormState({ ...formState, theme });
+        setFormState((prev) => ({ ...prev, theme }));
+    };
+
+    const setHiddenFields = (hiddenFields: string[]) => {
+        setFormState((prev) => ({ ...prev, hiddenFields }));
     };
 
     const updateWelcomePageImage = (imageUrl: string) => {
-        formState.welcomePage && (formState.welcomePage.imageUrl = imageUrl);
-        setFormState({
-            ...formState
-        });
+        setFormState((prev) => ({
+            ...prev,
+            welcomePage: { ...(prev.welcomePage || {}), imageUrl }
+        }));
     };
 
     const updateWelcomePageLayout = (layout: FormSlideLayout) => {
-        if (formState.welcomePage) {
-            formState.welcomePage.layout = layout;
-        }
-        setFormState({
-            ...formState
-        });
+        setFormState((prev) => ({
+            ...prev,
+            welcomePage: { ...(prev.welcomePage || {}), layout }
+        }));
     };
 
     const updateThankYouPageImage = (imageUrl: string) => {
-        formState.thankyouPage && (formState.thankyouPage![activeThankYouPageComponent?.index || 0].imageUrl = imageUrl);
-        setFormState({ ...formState });
+        setFormState((prev) => patchThankYouPage(prev, activeThankYouPageComponent?.index || 0, { imageUrl }));
     };
 
     const updateThankYouPageLayout = (layout: FormSlideLayout) => {
-        if (formState.thankyouPage) {
-            formState.thankyouPage![activeThankYouPageComponent?.index || 0].layout = layout;
-        }
-        setFormState({ ...formState });
+        setFormState((prev) => patchThankYouPage(prev, activeThankYouPageComponent?.index || 0, { layout }));
     };
 
     return {
@@ -144,6 +156,7 @@ export function useFormState() {
         setThankYouPageButtonLink,
         setFormTitle,
         updateFormTheme,
+        setHiddenFields,
         theme: formState.theme,
         updateWelcomePageImage,
         updateThankYouPageImage,

--- a/webapp/src/store/jotai/navbar.ts
+++ b/webapp/src/store/jotai/navbar.ts
@@ -3,11 +3,17 @@ import { atom, useAtom } from 'jotai';
 interface INavbar {
     insertClicked: boolean;
     multiplePages: boolean;
+    /**
+     * Whether the navbar's Insert dropdown is open. Lives here (not local
+     * navbar state) so empty-canvas affordances can open it too.
+     */
+    insertMenuOpen?: boolean;
 }
 
 const initialNavbarState = atom<INavbar>({
     insertClicked: false,
-    multiplePages: true
+    multiplePages: true,
+    insertMenuOpen: false
 });
 
 export function useNavbarState() {

--- a/webapp/src/store/jotai/responder-form-response.ts
+++ b/webapp/src/store/jotai/responder-form-response.ts
@@ -62,8 +62,11 @@ export interface FormResponse {
 
 const initialFormResponse: FormResponse = {
     formId: '',
-    answers: {},
-    anonymize: false
+    answers: {}
+    // `anonymize` starts UNDEFINED (not false): identity sharing is opt-in
+    // (Design-Language §5), so until the responder touches the checkbox, the
+    // effective value is decided at submit time — anonymous when identity is
+    // optional, attached when the form requires a verified identity.
 };
 
 const formResponseAtom = atom<FormResponse>(initialFormResponse);

--- a/webapp/src/store/jotai/responder-hidden-fields.ts
+++ b/webapp/src/store/jotai/responder-hidden-fields.ts
@@ -1,0 +1,14 @@
+import { atom, useAtom } from 'jotai';
+
+/**
+ * Hidden-field (URL parameter) values captured when the public form loaded —
+ * only names the form declares are ever captured (see utils/answer-piping.ts
+ * `captureHiddenFieldValues`). Submitted with the response and used by answer
+ * piping in question text.
+ */
+const hiddenFieldValuesAtom = atom<Record<string, string>>({});
+
+export function useHiddenFieldValues() {
+    const [hiddenValues, setHiddenValues] = useAtom(hiddenFieldValuesAtom);
+    return { hiddenValues, setHiddenValues };
+}

--- a/webapp/src/utils/answer-piping.test.ts
+++ b/webapp/src/utils/answer-piping.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { captureHiddenFieldValues, getPrefillEntries, pruneOrphanedPipes, resolvePipesInText, resolvePipesInTitle, resolvePipeValue, titleHasPipes } from './answer-piping';
+
+const slide = (index: number, fields: Array<Partial<StandardFormFieldDto>>): StandardFormFieldDto =>
+    ({
+        id: `slide-${index}`,
+        index,
+        type: FieldTypes.SLIDE,
+        properties: { fields: fields as Array<StandardFormFieldDto> }
+    }) as StandardFormFieldDto;
+
+const SLIDES = [
+    slide(0, [
+        { id: 'name-field', index: 0, type: FieldTypes.SHORT_TEXT },
+        { id: 'email-field', index: 1, type: FieldTypes.EMAIL },
+        { id: 'toppings-field', index: 2, type: FieldTypes.MULTIPLE_CHOICE, properties: { allowMultipleSelection: true } as any }
+    ]),
+    slide(1, [{ id: 'rating-field', index: 0, type: FieldTypes.RATING }])
+];
+
+const ANSWERS = {
+    'name-field': { text: 'Ada' },
+    'email-field': { email: 'ada@example.com' },
+    'toppings-field': { choices: { values: ['Olives', 'Feta'] } },
+    'rating-field': { number: 4 }
+};
+
+const CTX = { slides: SLIDES, answers: ANSWERS, hiddenValues: { utm_source: 'newsletter' } };
+
+describe('resolvePipeValue', () => {
+    it('resolves field answers using the field type', () => {
+        expect(resolvePipeValue('field', 'name-field', CTX)).toBe('Ada');
+        expect(resolvePipeValue('field', 'rating-field', CTX)).toBe('4');
+    });
+
+    it('joins multi-choice answers with commas', () => {
+        expect(resolvePipeValue('field', 'toppings-field', CTX)).toBe('Olives, Feta');
+    });
+
+    it('resolves hidden fields from captured URL values', () => {
+        expect(resolvePipeValue('hidden', 'utm_source', CTX)).toBe('newsletter');
+    });
+
+    it('returns undefined for unanswered, unknown, or empty values', () => {
+        expect(resolvePipeValue('field', 'missing-field', CTX)).toBeUndefined();
+        expect(resolvePipeValue('hidden', 'nope', CTX)).toBeUndefined();
+        expect(resolvePipeValue('field', 'name-field', { ...CTX, answers: {} })).toBeUndefined();
+    });
+});
+
+describe('resolvePipesInText', () => {
+    it('replaces field and hidden tokens', () => {
+        expect(resolvePipesInText('Thanks, {{field:name-field}}! Came from {{hidden:utm_source}}.', CTX)).toBe('Thanks, Ada! Came from newsletter.');
+    });
+
+    it('uses the fallback when there is no value, empty string otherwise', () => {
+        expect(resolvePipesInText('Hi {{field:missing|there}}!', CTX)).toBe('Hi there!');
+        expect(resolvePipesInText('Hi {{field:missing}}!', CTX)).toBe('Hi !');
+    });
+
+    it('leaves text without tokens untouched', () => {
+        expect(resolvePipesInText('No tokens here', CTX)).toBe('No tokens here');
+        expect(resolvePipesInText(undefined, CTX)).toBeUndefined();
+    });
+});
+
+describe('resolvePipesInTitle', () => {
+    const title = {
+        type: 'doc',
+        content: [
+            {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Thanks, ' }, { type: 'answerPipe', attrs: { kind: 'field', pipeKey: 'name-field', label: 'Name', fallback: '' } }, { type: 'text', text: '!' }]
+            }
+        ]
+    };
+
+    it('replaces pipe nodes with the resolved answer text', () => {
+        const resolved = resolvePipesInTitle(title, CTX) as any;
+        expect(resolved.content[0].content.map((n: any) => n.text).join('')).toBe('Thanks, Ada!');
+        expect(resolved.content[0].content.every((n: any) => n.type === 'text')).toBe(true);
+    });
+
+    it('keeps marks from the pipe node on the replacement text', () => {
+        const boldPipe = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'answerPipe', attrs: { kind: 'hidden', pipeKey: 'utm_source' }, marks: [{ type: 'bold' }] }] }]
+        };
+        const resolved = resolvePipesInTitle(boldPipe, CTX) as any;
+        expect(resolved.content[0].content[0]).toEqual({ type: 'text', text: 'newsletter', marks: [{ type: 'bold' }] });
+    });
+
+    it('drops the node entirely when unresolved with no fallback (tiptap forbids empty text nodes)', () => {
+        const orphan = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hi ' }, { type: 'answerPipe', attrs: { kind: 'field', pipeKey: 'missing' } }] }]
+        };
+        const resolved = resolvePipesInTitle(orphan, CTX) as any;
+        expect(resolved.content[0].content).toHaveLength(1);
+    });
+
+    it('does not mutate the stored title', () => {
+        const before = JSON.stringify(title);
+        resolvePipesInTitle(title, CTX);
+        expect(JSON.stringify(title)).toBe(before);
+    });
+
+    it('resolves text tokens in legacy plain-string titles', () => {
+        expect(resolvePipesInTitle('Hello {{field:name-field}}', CTX)).toBe('Hello Ada');
+    });
+});
+
+describe('titleHasPipes', () => {
+    it('detects pipe nodes and text tokens', () => {
+        expect(titleHasPipes({ type: 'doc', content: [{ type: 'answerPipe' }] })).toBe(true);
+        expect(titleHasPipes('Hi {{hidden:x}}')).toBe(true);
+        expect(titleHasPipes({ type: 'doc', content: [{ type: 'text', text: 'plain' }] })).toBe(false);
+        expect(titleHasPipes('plain')).toBe(false);
+    });
+});
+
+describe('pruneOrphanedPipes', () => {
+    const makeSlides = () => [
+        slide(0, [
+            { id: 'a', index: 0, type: FieldTypes.SHORT_TEXT },
+            {
+                id: 'b',
+                index: 1,
+                type: FieldTypes.SHORT_TEXT,
+                title: {
+                    type: 'doc',
+                    content: [
+                        {
+                            type: 'paragraph',
+                            content: [
+                                { type: 'answerPipe', attrs: { kind: 'field', pipeKey: 'a' } },
+                                { type: 'answerPipe', attrs: { kind: 'field', pipeKey: 'deleted' } },
+                                { type: 'answerPipe', attrs: { kind: 'hidden', pipeKey: 'utm_source' } },
+                                { type: 'text', text: 'question' }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ])
+    ];
+
+    it('removes pipes referencing deleted fields, keeps live ones', () => {
+        const slides = makeSlides();
+        pruneOrphanedPipes(slides);
+        const content = (slides[0].properties!.fields![1].title as any).content[0].content;
+        expect(content.map((n: any) => n.type)).toEqual(['answerPipe', 'answerPipe', 'text']);
+        expect(content[0].attrs.pipeKey).toBe('a');
+        expect(content[1].attrs.pipeKey).toBe('utm_source');
+    });
+
+    it('prunes hidden pipes only when the declared list is given', () => {
+        const slides = makeSlides();
+        pruneOrphanedPipes(slides, []);
+        const content = (slides[0].properties!.fields![1].title as any).content[0].content;
+        expect(content.map((n: any) => n.attrs?.pipeKey ?? n.type)).toEqual(['a', 'text']);
+    });
+});
+
+describe('captureHiddenFieldValues', () => {
+    it('captures only declared, non-empty parameters', () => {
+        const captured = captureHiddenFieldValues(['utm_source', 'utm_medium', 'name'], '?utm_source=x&utm_medium=&other=y&name=Ada');
+        expect(captured).toEqual({ utm_source: 'x', name: 'Ada' });
+    });
+
+    it('captures nothing when the form declares nothing', () => {
+        expect(captureHiddenFieldValues(undefined, '?utm_source=x')).toEqual({});
+    });
+});
+
+describe('getPrefillEntries', () => {
+    it('maps field_<id> params to real answerable fields', () => {
+        const entries = getPrefillEntries(SLIDES, '?field_name-field=Ada&field_unknown=x&name-field=nope');
+        expect(entries).toHaveLength(1);
+        expect(entries[0].field.id).toBe('name-field');
+        expect(entries[0].value).toBe('Ada');
+    });
+});

--- a/webapp/src/utils/answer-piping.ts
+++ b/webapp/src/utils/answer-piping.ts
@@ -1,0 +1,182 @@
+import { JSONContent } from '@tiptap/react';
+
+import { StandardFormFieldDto, V2InputFields } from '@app/models/dtos/form';
+import { getComparableAnswerValue } from '@app/utils/conditional-logic';
+
+/**
+ * Answer piping ("recall") — reference an earlier answer or a hidden field
+ * (URL parameter) inside later question text: "Thanks, {name}!".
+ *
+ * Two storage forms, one resolver:
+ *  - Field TITLES are TipTap JSON; a pipe is an inline atom node
+ *    (`answerPipe`, see utils/richTextEditorExtenstion/answer-pipe.ts) with
+ *    attrs {kind, pipeKey, label, fallback}. The builder inserts these as
+ *    chips; the responder runtime replaces them with resolved text before the
+ *    JSON is turned into HTML.
+ *  - DESCRIPTIONS and thank-you messages are plain strings; a pipe is the
+ *    text token `{{field:<fieldId>}}` / `{{hidden:<name>}}`, with an optional
+ *    `|fallback`: `{{hidden:name|there}}`.
+ *
+ * Values come from the same `getComparableAnswerValue` the conditional-logic
+ * evaluator uses, so piping and logic can never disagree about an answer.
+ * Hidden-field values are the URL parameters captured when the form loaded.
+ */
+
+export type PipeKind = 'field' | 'hidden';
+
+export const ANSWER_PIPE_NODE = 'answerPipe';
+
+export interface PipeContext {
+    /** The form's slides (`form.fields`), used to look up a field's type. */
+    slides?: Array<StandardFormFieldDto>;
+    /** In-progress responder answers, keyed by field id. */
+    answers?: Record<string, any>;
+    /** Captured hidden-field (URL parameter) values, keyed by declared name. */
+    hiddenValues?: Record<string, string>;
+}
+
+/** Flatten slides into an id → field map for answerable fields. */
+export function getInputFieldsById(slides?: Array<StandardFormFieldDto>): Record<string, StandardFormFieldDto> {
+    const byId: Record<string, StandardFormFieldDto> = {};
+    (slides ?? []).forEach((slide) => {
+        slide?.properties?.fields?.forEach((field) => {
+            if (field?.id) byId[field.id] = field;
+        });
+    });
+    return byId;
+}
+
+/** Render a comparable answer value as display text. Empty-ish → undefined. */
+function formatPipeValue(value: any): string | undefined {
+    if (value === undefined || value === null) return undefined;
+    if (Array.isArray(value)) {
+        const parts = value.map((v) => String(v)).filter((v) => v !== '');
+        return parts.length ? parts.join(', ') : undefined;
+    }
+    const text = String(value);
+    return text === '' ? undefined : text;
+}
+
+/** Resolve one pipe to display text, or undefined when there's no value yet. */
+export function resolvePipeValue(kind: PipeKind | string, pipeKey: string, context: PipeContext): string | undefined {
+    if (!pipeKey) return undefined;
+    if (kind === 'hidden') {
+        return formatPipeValue(context.hiddenValues?.[pipeKey]);
+    }
+    const field = getInputFieldsById(context.slides)[pipeKey];
+    if (!field) return undefined;
+    return formatPipeValue(getComparableAnswerValue(context.answers?.[pipeKey], field.type));
+}
+
+// `{{field:<id>}}` / `{{hidden:<name>|fallback}}` — key stops at `|` or `}`.
+const TEXT_PIPE_PATTERN = /\{\{\s*(field|hidden)\s*:\s*([^}|]+?)\s*(?:\|([^}]*))?\}\}/g;
+
+/** Resolve text-token pipes in a plain string (descriptions, thank-you text). */
+export function resolvePipesInText(text: string | null | undefined, context: PipeContext): string | null | undefined {
+    if (!text || typeof text !== 'string') return text;
+    return text.replace(TEXT_PIPE_PATTERN, (_match, kind, key, fallback) => {
+        return resolvePipeValue(kind, key.trim(), context) ?? (fallback ?? '').trim();
+    });
+}
+
+function resolveNode(node: JSONContent, context: PipeContext): JSONContent | null {
+    if (node?.type === ANSWER_PIPE_NODE) {
+        const attrs = node.attrs ?? {};
+        const value = resolvePipeValue(attrs.kind, attrs.pipeKey, context) ?? (attrs.fallback || '');
+        // TipTap text nodes must be non-empty — drop the node entirely when
+        // there's nothing to show.
+        if (!value) return null;
+        const textNode: JSONContent = { type: 'text', text: value };
+        if (node.marks?.length) textNode.marks = node.marks;
+        return textNode;
+    }
+    if (!node?.content?.length) return node;
+    return {
+        ...node,
+        content: node.content.map((child) => resolveNode(child, context)).filter((child): child is JSONContent => child !== null)
+    };
+}
+
+/**
+ * Resolve pipes in a field title (TipTap JSON or legacy plain string).
+ * Returns the same shape it was given; the input is never mutated.
+ */
+export function resolvePipesInTitle(title: JSONContent | string | undefined, context: PipeContext): JSONContent | string | undefined {
+    if (!title) return title;
+    if (typeof title === 'string') return resolvePipesInText(title, context) ?? title;
+    return resolveNode(title, context) ?? title;
+}
+
+/** Does a title contain any pipe nodes? (Cheap check to skip resolution.) */
+export function titleHasPipes(title: JSONContent | string | undefined): boolean {
+    if (!title) return false;
+    if (typeof title === 'string') {
+        TEXT_PIPE_PATTERN.lastIndex = 0;
+        return TEXT_PIPE_PATTERN.test(title);
+    }
+    if (title.type === ANSWER_PIPE_NODE) return true;
+    return (title.content ?? []).some((child) => titleHasPipes(child));
+}
+
+/**
+ * Remove pipe nodes that reference deleted fields or undeclared hidden fields
+ * (builder-side hygiene, the piping counterpart of `pruneOrphanedConditions`).
+ * Mutates field titles in place, like the conditions pruner does.
+ */
+export function pruneOrphanedPipes(slides: Array<StandardFormFieldDto>, hiddenFieldNames?: string[]): Array<StandardFormFieldDto> {
+    const fieldIds = new Set<string>();
+    slides.forEach((slide) => slide?.properties?.fields?.forEach((f) => fieldIds.add(f.id)));
+    const hiddenNames = hiddenFieldNames ? new Set(hiddenFieldNames) : null;
+
+    const isOrphan = (node: JSONContent): boolean => {
+        if (node?.type !== ANSWER_PIPE_NODE) return false;
+        const attrs = node.attrs ?? {};
+        if (attrs.kind === 'hidden') return hiddenNames !== null && !hiddenNames.has(attrs.pipeKey);
+        return !fieldIds.has(attrs.pipeKey);
+    };
+
+    const pruneNode = (node: JSONContent): void => {
+        if (!node?.content?.length) return;
+        node.content = node.content.filter((child) => !isOrphan(child));
+        node.content.forEach(pruneNode);
+    };
+
+    slides.forEach((slide) => {
+        slide?.properties?.fields?.forEach((field) => {
+            if (field?.title && typeof field.title !== 'string') pruneNode(field.title);
+        });
+    });
+
+    return slides;
+}
+
+/**
+ * Pick the declared hidden-field values out of a share link's query string.
+ * Only declared names are captured — arbitrary URL parameters are never stored.
+ */
+export function captureHiddenFieldValues(declaredNames: string[] | undefined, search: string | URLSearchParams): Record<string, string> {
+    const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+    const captured: Record<string, string> = {};
+    (declaredNames ?? []).forEach((name) => {
+        const value = params.get(name);
+        if (value !== null && value !== '') captured[name] = value;
+    });
+    return captured;
+}
+
+/**
+ * URL prefill for visible input fields: `?field_<fieldId>=value`.
+ * Returns {fieldId, field, value} for every param that addresses a real
+ * answerable field; the caller applies them with the typed answer setters.
+ */
+export function getPrefillEntries(slides: Array<StandardFormFieldDto> | undefined, search: string | URLSearchParams): Array<{ field: StandardFormFieldDto; value: string }> {
+    const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+    const byId = getInputFieldsById(slides);
+    const entries: Array<{ field: StandardFormFieldDto; value: string }> = [];
+    params.forEach((value, key) => {
+        if (!key.startsWith('field_') || value === '') return;
+        const field = byId[key.slice('field_'.length)];
+        if (field && V2InputFields.includes(field.type)) entries.push({ field, value });
+    });
+    return entries;
+}

--- a/webapp/src/utils/richTextEditorExtenstion/answer-pipe-suggestion.test.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/answer-pipe-suggestion.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterPipeSuggestionItems, PipeSuggestionItem } from './answer-pipe-suggestion';
+
+const ITEMS: PipeSuggestionItem[] = [
+    { kind: 'field', pipeKey: 'f1', label: 'Page 1 · What is your name?', group: 'Answers' },
+    { kind: 'field', pipeKey: 'f2', label: 'Page 1 · Company size', group: 'Answers' },
+    { kind: 'hidden', pipeKey: 'utm_source', label: 'utm_source', group: 'Hidden fields' }
+];
+
+describe('filterPipeSuggestionItems', () => {
+    it('returns everything for an empty query', () => {
+        expect(filterPipeSuggestionItems(ITEMS, '')).toHaveLength(3);
+        expect(filterPipeSuggestionItems(ITEMS, '  ')).toHaveLength(3);
+    });
+
+    it('matches case-insensitively on the label', () => {
+        expect(filterPipeSuggestionItems(ITEMS, 'NAME').map((i) => i.pipeKey)).toEqual(['f1']);
+        expect(filterPipeSuggestionItems(ITEMS, 'utm').map((i) => i.pipeKey)).toEqual(['utm_source']);
+    });
+
+    it('returns empty when nothing matches', () => {
+        expect(filterPipeSuggestionItems(ITEMS, 'zzz')).toEqual([]);
+    });
+});

--- a/webapp/src/utils/richTextEditorExtenstion/answer-pipe-suggestion.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/answer-pipe-suggestion.ts
@@ -1,0 +1,163 @@
+import { Extension } from '@tiptap/core';
+import Suggestion, { SuggestionKeyDownProps, SuggestionProps } from '@tiptap/suggestion';
+
+/**
+ * Typing `@` in a title opens an inline picker of pipeable values (earlier
+ * answers + hidden fields) at the caret — the UX people know from mentions.
+ * Selecting an item replaces the typed `@query` with an answerPipe node
+ * (see answer-pipe.ts). The "@ Answer" toolbar button remains as the
+ * discoverable entry point; both insert the same node.
+ */
+
+export interface PipeSuggestionItem {
+    kind: 'field' | 'hidden';
+    pipeKey: string;
+    label: string;
+    /** Section header the item renders under. */
+    group: 'Answers' | 'Hidden fields';
+}
+
+/** Case-insensitive filter of pipeable items against the typed query. */
+export function filterPipeSuggestionItems(items: PipeSuggestionItem[], query: string): PipeSuggestionItem[] {
+    const needle = query.trim().toLowerCase();
+    if (!needle) return items;
+    return items.filter((item) => item.label.toLowerCase().includes(needle));
+}
+
+/** The floating list itself — plain DOM so it can follow the caret rect. */
+class PipeSuggestionList {
+    private container: HTMLDivElement;
+    private items: PipeSuggestionItem[] = [];
+    private selectedIndex = 0;
+    private command: (item: PipeSuggestionItem) => void = () => undefined;
+
+    constructor() {
+        this.container = document.createElement('div');
+        this.container.className = 'answer-pipe-suggestions fixed z-[9999] max-h-64 w-72 overflow-auto rounded-lg border bg-white py-1 shadow-lg';
+        this.container.style.display = 'none';
+        document.body.appendChild(this.container);
+    }
+
+    update(props: SuggestionProps<PipeSuggestionItem>) {
+        this.items = props.items;
+        this.command = (item) => props.command(item);
+        this.selectedIndex = 0;
+        this.renderItems();
+        this.position(props.clientRect?.());
+    }
+
+    private position(rect?: DOMRect | null) {
+        if (!rect) return;
+        this.container.style.display = this.items.length ? 'block' : 'none';
+        // Below the caret; flip above when there's no room.
+        const height = Math.min(this.container.scrollHeight, 256);
+        const top = rect.bottom + height > window.innerHeight ? rect.top - height - 4 : rect.bottom + 4;
+        this.container.style.top = `${top}px`;
+        this.container.style.left = `${Math.min(rect.left, window.innerWidth - 296)}px`;
+    }
+
+    private renderItems() {
+        this.container.innerHTML = '';
+        let lastGroup: string | null = null;
+        this.items.forEach((item, index) => {
+            if (item.group !== lastGroup) {
+                lastGroup = item.group;
+                const header = document.createElement('div');
+                header.className = 'text-black-500 px-3 py-1 text-xs uppercase tracking-wide';
+                header.textContent = item.group;
+                this.container.appendChild(header);
+            }
+            const row = document.createElement('div');
+            row.setAttribute('role', 'option');
+            row.setAttribute('aria-selected', String(index === this.selectedIndex));
+            row.className = `text-black-800 cursor-pointer truncate px-3 py-1.5 text-sm ${index === this.selectedIndex ? 'bg-gray-100' : ''}`;
+            row.textContent = item.label;
+            // mousedown (not click) so the editor never loses focus/selection.
+            row.addEventListener('mousedown', (event) => {
+                event.preventDefault();
+                this.command(item);
+            });
+            row.addEventListener('mouseenter', () => {
+                this.selectedIndex = index;
+                this.renderItems();
+            });
+            this.container.appendChild(row);
+        });
+    }
+
+    onKeyDown(props: SuggestionKeyDownProps): boolean {
+        if (!this.items.length) return false;
+        if (props.event.key === 'ArrowDown') {
+            this.selectedIndex = (this.selectedIndex + 1) % this.items.length;
+            this.renderItems();
+            return true;
+        }
+        if (props.event.key === 'ArrowUp') {
+            this.selectedIndex = (this.selectedIndex - 1 + this.items.length) % this.items.length;
+            this.renderItems();
+            return true;
+        }
+        if (props.event.key === 'Enter' || props.event.key === 'Tab') {
+            this.command(this.items[this.selectedIndex]);
+            return true;
+        }
+        return false;
+    }
+
+    destroy() {
+        this.container.remove();
+    }
+}
+
+export interface AnswerPipeSuggestionOptions {
+    /** Called on every keystroke after `@` — returns the (filtered) items. */
+    getItems: (query: string) => PipeSuggestionItem[];
+}
+
+export const AnswerPipeSuggestion = Extension.create<AnswerPipeSuggestionOptions>({
+    name: 'answerPipeSuggestion',
+
+    addOptions() {
+        return { getItems: () => [] };
+    },
+
+    addProseMirrorPlugins() {
+        return [
+            Suggestion<PipeSuggestionItem>({
+                editor: this.editor,
+                char: '@',
+                allowSpaces: false,
+                items: ({ query }) => this.options.getItems(query),
+                command: ({ editor, range, props }) => {
+                    editor
+                        .chain()
+                        .focus()
+                        .insertContentAt(range, [{ type: 'answerPipe', attrs: { kind: props.kind, pipeKey: props.pipeKey, label: props.label } }, { type: 'text', text: ' ' }])
+                        .run();
+                },
+                render: () => {
+                    let list: PipeSuggestionList | null = null;
+                    return {
+                        onStart: (props) => {
+                            list = new PipeSuggestionList();
+                            list.update(props);
+                        },
+                        onUpdate: (props) => list?.update(props),
+                        onKeyDown: (props) => {
+                            if (props.event.key === 'Escape') {
+                                list?.destroy();
+                                list = null;
+                                return true;
+                            }
+                            return list?.onKeyDown(props) ?? false;
+                        },
+                        onExit: () => {
+                            list?.destroy();
+                            list = null;
+                        }
+                    };
+                }
+            })
+        ];
+    }
+});

--- a/webapp/src/utils/richTextEditorExtenstion/answer-pipe.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/answer-pipe.ts
@@ -1,0 +1,61 @@
+import { mergeAttributes, Node } from '@tiptap/core';
+
+/**
+ * Inline atom node for answer piping — a chip inside a field title that
+ * stands for "the answer to an earlier question" (kind: 'field') or "a hidden
+ * URL parameter" (kind: 'hidden'). Stored in the title's TipTap JSON as
+ * {type: 'answerPipe', attrs: {kind, pipeKey, label, fallback}}.
+ *
+ * The builder renders the chip; the responder runtime never renders this node
+ * — `resolvePipesInTitle` (utils/answer-piping.ts) replaces it with the
+ * resolved answer text before the JSON becomes HTML.
+ *
+ * The DOM round-trip matters: the builder feeds the editor HTML generated
+ * from the stored JSON, so parseHTML/renderHTML must preserve every attr.
+ */
+export const AnswerPipe = Node.create({
+    name: 'answerPipe',
+    group: 'inline',
+    inline: true,
+    atom: true,
+    selectable: true,
+
+    addAttributes() {
+        return {
+            kind: {
+                default: 'field',
+                parseHTML: (element) => element.getAttribute('data-pipe-kind') || 'field'
+            },
+            pipeKey: {
+                default: '',
+                parseHTML: (element) => element.getAttribute('data-pipe-key') || ''
+            },
+            label: {
+                default: '',
+                parseHTML: (element) => element.getAttribute('data-pipe-label') || ''
+            },
+            fallback: {
+                default: '',
+                parseHTML: (element) => element.getAttribute('data-pipe-fallback') || ''
+            }
+        };
+    },
+
+    parseHTML() {
+        return [{ tag: 'span[data-pipe-key]' }];
+    },
+
+    renderHTML({ node, HTMLAttributes }) {
+        return [
+            'span',
+            mergeAttributes(HTMLAttributes, {
+                'data-pipe-kind': node.attrs.kind,
+                'data-pipe-key': node.attrs.pipeKey,
+                'data-pipe-label': node.attrs.label,
+                'data-pipe-fallback': node.attrs.fallback,
+                class: 'answer-pipe-chip'
+            }),
+            `@${node.attrs.label || node.attrs.pipeKey}`
+        ];
+    }
+});

--- a/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.test.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.test.ts
@@ -36,4 +36,33 @@ describe('extractTextfromJSON', () => {
         expect(extractTextfromJSON(field({ type: FieldTypes.EMAIL }))).toBe('Enter Your Email Address');
         expect(extractTextfromJSON(field({ type: FieldTypes.YES_NO }))).toBe('Are you sure?');
     });
+
+    it('renders answerPipe chips as their label, not editor syntax', () => {
+        const title = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'Hello ' },
+                        { type: 'answerPipe', attrs: { kind: 'field', pipeKey: 'abc', label: 'Page 1 · Name' } },
+                        { type: 'text', text: ' — welcome ' },
+                        { type: 'answerPipe', attrs: { kind: 'hidden', pipeKey: 'utm_source' } }
+                    ]
+                }
+            ]
+        };
+        expect(extractTextfromJSON(field({ title: title as any }))).toBe('Hello Page 1 · Name — welcome utm_source');
+    });
+
+    it('separates paragraphs with a space', () => {
+        const title = {
+            type: 'doc',
+            content: [
+                { type: 'paragraph', content: [{ type: 'text', text: 'Line one' }] },
+                { type: 'paragraph', content: [{ type: 'text', text: 'line two' }] }
+            ]
+        };
+        expect(extractTextfromJSON(field({ title: title as any }))).toBe('Line one line two');
+    });
 });

--- a/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.ts
@@ -13,8 +13,26 @@ export function getHtmlFromJson(value: JSONContent | string | undefined) {
     return generateHTML(value, Extenstions);
 }
 
+/**
+ * Plain-text rendering of a field title for creator-facing labels (table
+ * headers, CSV columns, logic-source lists, "Used Fields"). Walks the TipTap
+ * JSON directly instead of round-tripping through HTML, so answerPipe chips
+ * render as their human label ("Page 1 · Enter Question") rather than leaking
+ * editor syntax ("@Page 1 · Enter Question").
+ */
 export function extractTextfromJSON(field: StandardFormFieldDto): string {
-    const htmlValue = getHtmlFromJson(field.title) || getPlaceholderValueForTitle(field.type || FieldTypes.TEXT);
-    // .replace(/<[^>]+>/g, ' ')
-    return htmlValue.replace(/<\/?[^>]+(>|$)/g, '');
+    const title = field.title;
+    if (!title) return getPlaceholderValueForTitle(field.type || FieldTypes.TEXT);
+    if (typeof title === 'string') return title;
+
+    const walk = (node: any): string => {
+        if (!node) return '';
+        if (node.type === 'text') return node.text ?? '';
+        if (node.type === 'answerPipe') return node.attrs?.label || node.attrs?.pipeKey || '';
+        const joined = (node.content ?? []).map(walk).join('');
+        // Space between block nodes (paragraphs) so lines don't run together.
+        return node.type === 'doc' ? joined : joined;
+    };
+    const text = (title.content ?? []).map(walk).join(' ').trim();
+    return text || getPlaceholderValueForTitle(field.type || FieldTypes.TEXT);
 }

--- a/webapp/src/views/molecules/form-builder/hidden-fields-editor.tsx
+++ b/webapp/src/views/molecules/form-builder/hidden-fields-editor.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+import { XIcon } from 'lucide-react';
+
+import { Button } from '@app/shadcn/components/ui/button';
+import useFormFieldsAtom from '@app/store/jotai/field-selectors';
+import { useFormState } from '@app/store/jotai/form';
+import { pruneOrphanedPipes } from '@app/utils/answer-piping';
+
+// URL-parameter-safe names only; these become `?name=value` on the share link.
+const VALID_NAME = /^[a-zA-Z0-9_-]+$/;
+
+/**
+ * Form-wide hidden fields: URL parameters (utm_source, name, …) the share
+ * link can carry. Captured at fill time, stored with each response, and
+ * available to answer piping in question text via the "@ Answer" menu.
+ */
+export default function HiddenFieldsEditor() {
+    const { formState, setHiddenFields } = useFormState();
+    const { formFields, setFormFields } = useFormFieldsAtom();
+    const [draft, setDraft] = useState('');
+    const [error, setError] = useState<string | null>(null);
+
+    const names = formState.hiddenFields ?? [];
+
+    const addName = () => {
+        const name = draft.trim();
+        if (!name) return;
+        if (!VALID_NAME.test(name)) {
+            setError('Use only letters, numbers, dashes and underscores.');
+            return;
+        }
+        if (names.includes(name)) {
+            setError('That hidden field already exists.');
+            return;
+        }
+        setHiddenFields([...names, name]);
+        setDraft('');
+        setError(null);
+    };
+
+    const removeName = (name: string) => {
+        setHiddenFields(names.filter((n) => n !== name));
+        // Sweep any piping chips that referenced the removed name.
+        setFormFields([...pruneOrphanedPipes(formFields, names.filter((n) => n !== name))]);
+    };
+
+    return (
+        <div className="px-4 py-6">
+            <div className="text-black-600 text-xs font-semibold uppercase tracking-wide">Hidden fields</div>
+            <div className="text-black-500 mt-1 text-xs">
+                Values passed in the share link (<span className="font-mono">?utm_source=…</span>) are saved with each response and can be piped into questions. Form-wide setting.
+            </div>
+            <div className="mt-3 flex flex-col gap-2">
+                {names.map((name) => (
+                    <div key={name} className="text-black-800 flex items-center justify-between rounded border px-2 py-1 text-xs">
+                        <span className="truncate font-mono">{name}</span>
+                        <div role="button" tabIndex={0} aria-label={`Remove hidden field ${name}`} className="cursor-pointer p-0.5 hover:text-red-500" onClick={() => removeName(name)}>
+                            <XIcon className="h-3.5 w-3.5" />
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <div className="mt-2 flex items-center gap-2">
+                <input
+                    type="text"
+                    placeholder="e.g. utm_source"
+                    value={draft}
+                    onChange={(e) => {
+                        setDraft(e.target.value);
+                        setError(null);
+                    }}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter') addName();
+                    }}
+                    className="border-black-300 focus:border-black-300 min-w-0 flex-1 rounded-lg border-[1px] p-2 text-xs"
+                />
+                <Button size="sm" variant="v2Button" onClick={addName} disabled={!draft.trim()}>
+                    Add
+                </Button>
+            </div>
+            {error && <div className="mt-1 text-xs text-amber-700">{error}</div>}
+        </div>
+    );
+}

--- a/webapp/src/views/molecules/form-builder/page-jump-editor.tsx
+++ b/webapp/src/views/molecules/form-builder/page-jump-editor.tsx
@@ -44,7 +44,7 @@ export default function PageJumpEditor() {
     if (sources.length === 0) {
         return (
             <div className="flex flex-col gap-1 px-4 py-4">
-                <div className="text-black-700 text-xs font-medium">Logic</div>
+                <div className="text-black-600 text-xs font-semibold uppercase tracking-wide">Logic</div>
                 <div className="text-black-500 text-xs">Add questions to this page (or an earlier one) to send people to another page based on their answers.</div>
             </div>
         );
@@ -53,7 +53,7 @@ export default function PageJumpEditor() {
     return (
         <div className="flex flex-col gap-3 px-4 py-4">
             <div>
-                <div className="text-black-700 text-xs font-medium">Logic</div>
+                <div className="text-black-600 text-xs font-semibold uppercase tracking-wide">Logic</div>
                 <div className="text-black-500 text-[11px]">Send people to another page based on their answers.{jumps.length > 1 ? ' Checked top to bottom — first match wins.' : ''}</div>
             </div>
 

--- a/webapp/src/views/molecules/form/trust-layer.tsx
+++ b/webapp/src/views/molecules/form/trust-layer.tsx
@@ -13,6 +13,8 @@ export interface TrustLayerProps {
     privacyUrl?: string;
     /** Human-readable retention, e.g. "kept for 90 days". */
     retention?: string;
+    /** Link to the responder portal where a submission can be viewed/deleted. */
+    portalUrl?: string;
 }
 
 /**
@@ -23,7 +25,7 @@ export interface TrustLayerProps {
  *
  * Presentational only: pass in data (see the wired usage on the fill page).
  */
-export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl, retention }: TrustLayerProps) {
+export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl, retention, portalUrl }: TrustLayerProps) {
     const items: React.ReactNode[] = [];
 
     if (ownerName) {
@@ -32,12 +34,12 @@ export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl,
                 {ownerImage ? (
                     <img src={ownerImage} alt="" className="h-4 w-4 rounded-full object-cover" />
                 ) : null}
-                Collected by <span className="text-black-900 font-medium">{ownerName}</span>
+                Collected by <span className="text-black-900 font-semibold">{ownerName}</span>
             </span>
         );
     }
     if (purpose) {
-        items.push(<span key="purpose" className="text-black-600">{purpose}</span>);
+        items.push(<span key="purpose" className="text-black-700">{purpose}</span>);
     }
     if (privacyUrl) {
         items.push(
@@ -46,16 +48,25 @@ export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl,
             </a>
         );
     }
-    // Deletion is a right responders always have (post-submission); state it plainly.
+    // Deletion is a right responders always have (post-submission); when we know
+    // where to exercise it, say so with a link — otherwise state it plainly.
     items.push(
-        <span key="delete" className="text-black-600">
-            You can view or delete your response anytime{retention ? ` · ${retention}` : ''}
-        </span>
+        portalUrl ? (
+            <a key="delete" href={portalUrl} target="_blank" rel="noopener noreferrer" className="text-black-700 pointer-events-auto underline decoration-dotted underline-offset-2 hover:text-black-900">
+                View or delete your response anytime{retention ? ` · ${retention}` : ''}
+            </a>
+        ) : (
+            <span key="delete" className="text-black-700">
+                You can view or delete your response anytime{retention ? ` · ${retention}` : ''}
+            </span>
+        )
     );
 
     return (
-        <div className="border-t-black-200 bg-white/85 flex w-full flex-wrap items-center justify-center gap-x-3 gap-y-1.5 border-t px-4 py-2.5 text-xs backdrop-blur-sm">
-            <Shield className="text-brand-500 h-3.5 w-3.5 shrink-0" strokeWidth={1.8} aria-hidden="true" />
+        // 13px legible ink-2 — the strip that carries the product's differentiator
+        // shouldn't be the smallest text on screen (Design-Language §4).
+        <div className="border-t-black-200 bg-white/85 flex w-full flex-wrap items-center justify-center gap-x-3 gap-y-1.5 border-t px-4 py-2.5 text-[13px] backdrop-blur-sm">
+            <Shield className="text-brand-500 h-4 w-4 shrink-0" strokeWidth={1.8} aria-hidden="true" />
             {items.map((item, i) => (
                 <span key={i} className="inline-flex items-center gap-3">
                     {i > 0 && <span className="bg-black-200 h-3 w-px" aria-hidden="true" />}

--- a/webapp/src/views/molecules/responder-form-fields/date-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/date-field.tsx
@@ -65,12 +65,13 @@ function DateFieldSection({ field, isBuilder }: IDateField) {
                     <button
                         type="button"
                         className={cn(
-                            'flex w-full cursor-pointer items-center gap-2 border-0 border-b-[1px] bg-inherit px-0 py-2 text-[28px] outline-none lg:text-[32px]',
+                            'flex w-full cursor-pointer items-center gap-2 rounded-xl border bg-white px-4 py-3 text-base outline-none transition-shadow focus-visible:ring-2 lg:text-lg',
                             isBuilder && 'pointer-events-none'
                         )}
                         style={{
                             borderColor: tertiaryColor,
-                            color: date ? secondaryColor : tertiaryColor
+                            // Chosen date is content (ink); empty state a legible neutral.
+                            color: date ? theme?.primary : '#657085'
                         }}
                     >
                         <CalendarIcon

--- a/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
@@ -52,10 +52,12 @@ export default function DropDownField({ field, slideIndex }: { field: StandardFo
         if (choiceValue) {
             return {
                 borderColor: theme?.secondary,
-                color: theme?.secondary
+                // The chosen answer is content — ink, not the action colour.
+                color: theme?.primary
             };
         }
-        return { borderColor: theme?.tertiary, color: theme?.tertiary };
+        // Placeholder state: legible neutral (ink-3), not the theme tint.
+        return { borderColor: theme?.tertiary, color: '#657085' };
     };
 
     return (

--- a/webapp/src/views/molecules/responder-form-fields/input-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/input-field.tsx
@@ -72,7 +72,6 @@ export default function InputField({ field }: { field: StandardFormFieldDto }) {
                     multiple={field.type === FieldTypes.LONG_TEXT}
                     value={getFieldValue()}
                     onChange={(value: any) => handleChange(value)}
-                    style={{ color: theme?.secondary }}
                 />
             </form>
         </QuestionWrapper>

--- a/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
@@ -54,19 +54,20 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                     country={'np'}
                     buttonStyle={{
                         border: '0px',
-                        borderBottom: `1px solid ${theme?.tertiary}`,
-                        background: theme?.accent,
+                        borderRight: `1px solid ${theme?.tertiary}`,
+                        background: '#ffffff',
                         height: '100%'
                     }}
-                    dropdownStyle={{ background: theme?.accent }}
+                    dropdownStyle={{ background: '#ffffff' }}
                     inputStyle={{
-                        border: '0px',
-                        borderBottom: `1px solid ${theme?.tertiary}`,
-                        color: theme?.secondary
+                        border: `1px solid ${theme?.tertiary}`,
+                        borderRadius: '12px',
+                        background: '#ffffff',
+                        color: theme?.primary
                     }}
                     placeholder={field?.properties?.placeholder || getPlaceholderValueForField(field.type)}
                     inputProps={{
-                        className: 'text-[28px] lg:text-[32px] bg-opacity-50 mx-14 border-0 border-b-[1px] w-[93%] ',
+                        className: 'text-base lg:text-lg py-3 mx-14 w-[93%] ',
                         id: `input-field-${field.id}`
                     }}
                 />

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.test.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'jotai';
+import { Provider as ReduxProvider } from 'react-redux';
 import { describe, expect, it, vi } from 'vitest';
 
 // RenderImage drags in the whole builder field registry — irrelevant here.
@@ -12,28 +13,36 @@ vi.mock('@app/views/organism/form-builder/fields/render-field', () => ({
 
 import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
+import { store } from '@app/store/store';
 import QuestionWrapper from './question-wrapper';
 
 const field = (overrides: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({ id: 'f1', index: 0, type: FieldTypes.SHORT_TEXT, title: 'Your name?', ...overrides });
 
-/** Renders QuestionWrapper with optional pre-seeded invalid fields. */
-const renderWrapper = (f: StandardFormFieldDto, invalid?: Record<string, any[]>) => {
+/** Renders QuestionWrapper with optional pre-seeded invalid fields / answers / hidden values. */
+const renderWrapper = (f: StandardFormFieldDto, opts: { invalid?: Record<string, any[]>; answers?: Record<string, any>; hiddenValues?: Record<string, string> } = {}) => {
+    const { invalid, answers, hiddenValues } = opts;
+    const needsSetup = !!(invalid || answers || hiddenValues);
     const Harness = () => {
-        const { setInvalidFields } = useFormResponse();
-        const [ready, setReady] = React.useState(!invalid);
+        const { setInvalidFields, setFormResponse, formResponse } = useFormResponse();
+        const { setHiddenValues } = useHiddenFieldValues();
+        const [ready, setReady] = React.useState(!needsSetup);
         React.useEffect(() => {
-            if (invalid) {
-                setInvalidFields(invalid as any);
-                setReady(true);
-            }
+            if (!needsSetup) return;
+            if (invalid) setInvalidFields(invalid as any);
+            if (answers) setFormResponse({ ...formResponse, answers });
+            if (hiddenValues) setHiddenValues(hiddenValues);
+            setReady(true);
             // eslint-disable-next-line react-hooks/exhaustive-deps
         }, []);
         return ready ? <QuestionWrapper field={f} /> : null;
     };
     return render(
-        <Provider>
-            <Harness />
-        </Provider>
+        <ReduxProvider store={store}>
+            <Provider>
+                <Harness />
+            </Provider>
+        </ReduxProvider>
     );
 };
 
@@ -59,12 +68,37 @@ describe('QuestionWrapper — no-dark-patterns contracts (Design-Language §5)',
     });
 
     it('shows calm, instructive validation copy when the field is invalid', () => {
-        renderWrapper(field({ validations: { required: true } }), { f1: [0] });
+        renderWrapper(field({ validations: { required: true } }), { invalid: { f1: [0] } });
         expect(screen.getByText('Please answer this question to continue.')).toBeInTheDocument();
     });
 
     it('shows no validation message when the field is valid', () => {
         renderWrapper(field());
         expect(screen.queryByText(/Please answer/)).not.toBeInTheDocument();
+    });
+});
+
+describe('QuestionWrapper — answer piping', () => {
+    it('resolves hidden-field pipes in the title', () => {
+        const title = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hi ' }, { type: 'answerPipe', attrs: { kind: 'hidden', pipeKey: 'name', label: 'name', fallback: 'there' } }] }]
+        };
+        renderWrapper(field({ title }), { hiddenValues: { name: 'Ada' } });
+        expect(screen.getByText(/Hi Ada/)).toBeInTheDocument();
+    });
+
+    it('falls back when the pipe has no value yet', () => {
+        const title = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hi ' }, { type: 'answerPipe', attrs: { kind: 'hidden', pipeKey: 'name', label: 'name', fallback: 'there' } }] }]
+        };
+        renderWrapper(field({ title }));
+        expect(screen.getByText(/Hi there/)).toBeInTheDocument();
+    });
+
+    it('resolves text tokens in the description', () => {
+        renderWrapper(field({ description: 'You came from {{hidden:utm_source|somewhere}}.' }), { hiddenValues: { utm_source: 'newsletter' } });
+        expect(screen.getByText('You came from newsletter.')).toBeInTheDocument();
     });
 });

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -1,7 +1,11 @@
 import parse from 'html-react-parser';
 
 import { FieldTypes, StandardFormFieldDto, V2InputFields } from '@app/models/dtos/form';
+import { selectForm } from '@app/store/forms/slice';
+import { useAppSelector } from '@app/store/hooks';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
+import { resolvePipesInText, resolvePipesInTitle } from '@app/utils/answer-piping';
 import { getHtmlFromJson } from '@app/utils/richTextEditorExtenstion/get-html-from-json';
 import RequiredIcon from '@Components/icons/required';
 
@@ -10,6 +14,8 @@ import { getPlaceholderValueForTitle } from '../rich-text-editor';
 
 export default function QuestionWrapper({ field, children }: { field: StandardFormFieldDto; children?: React.ReactNode }) {
     const { formResponse } = useFormResponse();
+    const { hiddenValues } = useHiddenFieldValues();
+    const standardForm = useAppSelector(selectForm);
 
     const { invalidFields } = formResponse;
     const hasError = !!(invalidFields && invalidFields[field.id] && invalidFields[field.id].length);
@@ -22,6 +28,12 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
     const isAnswerable = field?.type ? V2InputFields.includes(field.type) : false;
     const isRequired = !!field?.validations?.required;
 
+    // Answer piping: swap pipe tokens for the responder's earlier answers (or
+    // captured hidden-field values) before the title/description hit the DOM.
+    const pipeContext = { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues };
+    const resolvedTitle = resolvePipesInTitle(field?.title, pipeContext);
+    const resolvedDescription = resolvePipesInText(field?.description, pipeContext);
+
     return (
         <div className="relative flex flex-col gap-1 lg:gap-2" id={field.id}>
             {isRequired && (
@@ -31,10 +43,12 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
             )}
             <div className="">
                 <div className="flex flex-wrap items-baseline gap-x-2">
-                    <div className="text-base font-semibold lg:text-lg">{parse(getHtmlFromJson(field?.title) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}</div>
-                    {isAnswerable && !isRequired && <span className="text-black-500 text-xs font-normal tracking-wide">Optional</span>}
+                    {/* The question owns the screen: 24px/600 ink (Design-Language §2) —
+                        bigger and darker than anything else, including the answer. */}
+                    <div className="text-xl font-semibold leading-snug lg:text-2xl">{parse(getHtmlFromJson(resolvedTitle) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}</div>
+                    {isAnswerable && !isRequired && <span className="text-black-700 text-xs font-normal tracking-wide">Optional</span>}
                 </div>
-                {field?.description && <div className="text-black-700 mt-1">{field?.description}</div>}
+                {resolvedDescription && <div className="text-black-700 mt-1.5 max-w-[62ch] text-[15px] leading-relaxed">{resolvedDescription}</div>}
             </div>
             <RenderImage field={field} />
             {children}

--- a/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
@@ -23,14 +23,19 @@ const StyledAutoSizeTextArea = styled(AutosizeTextarea)<{
     const themeColor = $formTheme?.tertiary;
     const secondaryColor = $formTheme?.secondary;
     return {
-        background: 'inherit',
+        // Same bordered treatment as every other input (see shadcn/ui/input.tsx):
+        // white field, ink answer text, legible placeholder, visible focus ring.
+        // Short/long text previously opted back into an underline-only look,
+        // which fragmented the input language and had no focus indicator.
+        background: '#ffffff',
         borderColor: themeColor,
-        color: secondaryColor,
+        color: $formTheme?.primary,
         '&::placeholder': {
-            color: `${themeColor} !important`
+            color: '#657085 !important'
         },
         '&:focus': {
-            borderColor: secondaryColor
+            borderColor: secondaryColor,
+            boxShadow: secondaryColor ? `0 0 0 3px ${secondaryColor}33` : undefined
         }
     };
 });
@@ -66,7 +71,7 @@ export default function TextAreaField({ field }: { field: StandardFormFieldDto }
                     rows={1}
                     value={inputVal}
                     onChange={(e) => setInputVal(e.target.value)}
-                    className="rounded-none border-0 border-b-[1px] px-0 py-2 text-[28px] leading-tight lg:text-[32px]"
+                    className="rounded-xl border px-4 py-3 text-base leading-normal outline-none transition-shadow lg:text-lg"
                     style={{
                         resize: 'none'
                     }}

--- a/webapp/src/views/molecules/rich-text-editor/index.tsx
+++ b/webapp/src/views/molecules/rich-text-editor/index.tsx
@@ -4,14 +4,18 @@ import Underline from '@tiptap/extension-underline';
 import { Editor, EditorProvider, JSONContent, useCurrentEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 
-import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { FieldTypes, StandardFormFieldDto, V2InputFields } from '@app/models/dtos/form';
 import { cn } from '@app/shadcn/util/lib';
 import useFormFieldsAtom from '@app/store/jotai/field-selectors';
+import { useFormState } from '@app/store/jotai/form';
+import { AnswerPipe } from '@app/utils/richTextEditorExtenstion/answer-pipe';
+import { AnswerPipeSuggestion, filterPipeSuggestionItems, PipeSuggestionItem } from '@app/utils/richTextEditorExtenstion/answer-pipe-suggestion';
 import { FontSize } from '@app/utils/richTextEditorExtenstion/font-size';
 import { getHtmlFromJson } from '@app/utils/richTextEditorExtenstion/get-html-from-json';
+import { buildSourceFields } from '@app/views/molecules/form-builder/condition-editor-shared';
 import { ArrowDown } from '@Components/icons/arrow-down';
 import RequiredIcon from '@Components/icons/required';
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDebounceValue } from 'usehooks-ts';
 
 export function getPlaceholderValueForTitle(fieldType: FieldTypes) {
@@ -51,7 +55,26 @@ export function getPlaceholderValueForTitle(fieldType: FieldTypes) {
     }
 }
 
-export const Extenstions = [StarterKit, TextStyle, FontSize, Underline, Color];
+export const Extenstions = [StarterKit, TextStyle, FontSize, Underline, Color, AnswerPipe];
+
+/**
+ * Everything pipeable into `field`'s title: answers the responder will already
+ * have given (earlier pages, or earlier on this page — same scoping as
+ * conditional logic) plus the form's declared hidden fields. Shared by the
+ * "@ Answer" toolbar menu and the inline `@` suggestion picker.
+ */
+function buildPipeItems(formFields: StandardFormFieldDto[], hiddenNames: string[], field: StandardFormFieldDto, slide: StandardFormFieldDto): PipeSuggestionItem[] {
+    const sources = buildSourceFields(formFields, (sourceSlide, slideIndex, sourceField) => {
+        if (!V2InputFields.includes(sourceField.type)) return false;
+        if (sourceField.id === field.id) return false;
+        if (slideIndex < slide.index) return true;
+        return slideIndex === slide.index && sourceField.index < field.index;
+    });
+    return [
+        ...sources.map(({ field: sourceField, label }): PipeSuggestionItem => ({ kind: 'field', pipeKey: sourceField.id, label, group: 'Answers' })),
+        ...hiddenNames.map((name): PipeSuggestionItem => ({ kind: 'hidden', pipeKey: name, label: name, group: 'Hidden fields' }))
+    ];
+}
 
 function usePreviousState(value: any) {
     const ref = useRef(value);
@@ -63,7 +86,28 @@ function usePreviousState(value: any) {
 }
 
 export function RichTextEditor({ field, slide, autofocus = false, isRequired = false }: { field: StandardFormFieldDto; slide: StandardFormFieldDto; autofocus?: boolean; isRequired?: boolean }) {
-    const { updateTitle } = useFormFieldsAtom();
+    const { updateTitle, formFields } = useFormFieldsAtom();
+    const { formState } = useFormState();
+
+    // The `@` suggestion needs the CURRENT builder state on every keystroke,
+    // but the extension list must keep a stable identity (a new array would
+    // recreate the editor per render). A ref bridges the two.
+    const pipeContextRef = useRef({ formFields, hiddenNames: formState.hiddenFields ?? [], field, slide });
+    pipeContextRef.current = { formFields, hiddenNames: formState.hiddenFields ?? [], field, slide };
+
+    const editorExtensions = useMemo(
+        () => [
+            ...Extenstions,
+            AnswerPipeSuggestion.configure({
+                getItems: (query: string) => {
+                    const { formFields: fields, hiddenNames, field: currentField, slide: currentSlide } = pipeContextRef.current;
+                    return filterPipeSuggestionItems(buildPipeItems(fields, hiddenNames, currentField, currentSlide), query);
+                }
+            })
+        ],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        []
+    );
 
     const getContentForEditor = () => {
         return field.title
@@ -90,13 +134,15 @@ export function RichTextEditor({ field, slide, autofocus = false, isRequired = f
         <div className="tiptap group relative flex w-full justify-between">
             <EditorProvider
                 content={getContentForEditor()}
-                extensions={Extenstions}
+                extensions={editorExtensions}
                 immediatelyRender={false}
-                slotBefore={<TiptapMenuBar />}
+                slotBefore={<TiptapMenuBar field={field} slide={slide} />}
                 autofocus={autofocus}
                 editorProps={{
                     attributes: {
-                        class: 'outline-none font-medium w-full max-w-full min-w-[300px]',
+                        // Match the responder's question scale (24px/600) so the
+                        // canvas is honest about what responders will see.
+                        class: 'outline-none text-2xl font-semibold leading-snug w-full max-w-full min-w-[300px]',
                         style: 'word-break: break-word'
                     }
                 }}
@@ -129,7 +175,63 @@ const getActiveFontSize = (editor?: Editor) => {
     return fontSizeInNum;
 };
 
-const TiptapMenuBar = () => {
+// "Insert answer" dropdown: pipes an earlier question's answer (or a hidden
+// URL parameter) into this title at the cursor, as an answerPipe chip. The
+// inline `@` suggestion (AnswerPipeSuggestion) is the fast path; this button
+// is the discoverable one.
+const InsertPipeMenu = ({ editor, field, slide }: { editor: Editor; field: StandardFormFieldDto; slide: StandardFormFieldDto }) => {
+    const { formFields } = useFormFieldsAtom();
+    const { formState } = useFormState();
+    const [open, setOpen] = useState(false);
+
+    const items = buildPipeItems(formFields, formState.hiddenFields ?? [], field, slide);
+    if (items.length === 0) return null;
+
+    const insertPipe = (item: PipeSuggestionItem) => {
+        editor
+            .chain()
+            .focus()
+            .insertContent([{ type: 'answerPipe', attrs: { kind: item.kind, pipeKey: item.pipeKey, label: item.label } }, { type: 'text', text: ' ' }])
+            .run();
+        setOpen(false);
+    };
+
+    let lastGroup: string | null = null;
+
+    return (
+        <div className="relative">
+            {/* mousedown is swallowed so the editor keeps focus (the floating bar is focus-within-gated). */}
+            <div
+                role="button"
+                tabIndex={0}
+                title="Insert an earlier answer — or just type @ in the question"
+                className="cursor-pointer whitespace-nowrap rounded px-1 text-sm font-medium text-blue-600 hover:bg-gray-100"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => setOpen(!open)}
+            >
+                @ Answer
+            </div>
+            {open && (
+                <div className="absolute left-0 top-full z-50 mt-1 max-h-64 w-72 overflow-auto rounded-lg border bg-white py-1 text-left shadow-lg" onMouseDown={(e) => e.preventDefault()}>
+                    {items.map((item) => {
+                        const header = item.group !== lastGroup ? item.group : null;
+                        lastGroup = item.group;
+                        return (
+                            <React.Fragment key={`${item.kind}:${item.pipeKey}`}>
+                                {header && <div className="text-black-500 px-3 py-1 text-xs uppercase tracking-wide">{header}</div>}
+                                <div role="button" tabIndex={0} className="text-black-800 cursor-pointer truncate px-3 py-1.5 text-sm hover:bg-gray-100" onClick={() => insertPipe(item)}>
+                                    {item.label}
+                                </div>
+                            </React.Fragment>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+const TiptapMenuBar = ({ field, slide }: { field: StandardFormFieldDto; slide: StandardFormFieldDto }) => {
     const editorRef = useCurrentEditor();
     // Constrain label sizing to the type scale (Design-Language.md §2) so creators
     // stay on a coherent hierarchy: Meta 12 · Helper/Consent 15 · Body/Input 16 ·
@@ -149,12 +251,11 @@ const TiptapMenuBar = () => {
     };
 
     return (
-        <button
+        // A div, not a <button>: the bar hosts interactive children (the insert-
+        // answer dropdown), and interactive elements can't nest inside a button.
+        <div
             className={cn(`shadow-tooltip absolute -top-14 mb-2 hidden items-center rounded-lg bg-white px-4 py-1`, 'group-focus-within:flex')}
             tabIndex={0}
-            onClick={() => {
-                return true;
-            }}
         >
             <div className="flex flex-row items-center justify-center gap-4">
                 <span className="p3-new font-medium">Text</span>
@@ -203,7 +304,8 @@ const TiptapMenuBar = () => {
                 <div onClick={() => editor?.chain().focus().toggleUnderline().run()} className={cn('cursor-pointer rounded', editor?.isActive('underline') && 'bg-gray-200')}>
                     <u className="px-1 text-xl">U</u>
                 </div>
+                <InsertPipeMenu editor={editor} field={field} slide={slide} />
             </div>
-        </button>
+        </div>
     );
 };

--- a/webapp/src/views/organism/field-settings.tsx
+++ b/webapp/src/views/organism/field-settings.tsx
@@ -38,7 +38,7 @@ export default function FieldSettings() {
 
     return (
         <div className="flex flex-col gap-4 px-4 py-6">
-            <div className="p2-new text-black-700 !font-medium">Settings</div>
+            <div className="text-black-600 text-xs font-semibold uppercase tracking-wide">Settings</div>
             <div className="flex w-full items-center justify-between">
                 <div className="text-black-700 text-xs">Description</div>
                 <Switch

--- a/webapp/src/views/organism/form-builder/page-properties-tab.tsx
+++ b/webapp/src/views/organism/form-builder/page-properties-tab.tsx
@@ -24,6 +24,7 @@ import SlideLayoutRightImage from '@Components/icons/slide-layout-right-image';
 import { SwitchIcon } from '@Components/icons/switch-icon';
 import { PlusIcon } from 'lucide-react';
 import Image from 'next/image';
+import HiddenFieldsEditor from '@app/views/molecules/form-builder/hidden-fields-editor';
 import PageJumpEditor from '@app/views/molecules/form-builder/page-jump-editor';
 
 export default function PagePropertiesTab({ }: {}) {
@@ -167,7 +168,7 @@ export default function PagePropertiesTab({ }: {}) {
         <>
             {
                 <>
-                    <div className="p2-new text-black-700 mb-4 mt-6 px-4 !font-medium">Layout</div>
+                    <div className="text-black-600 px-4 pb-3 pt-6 text-xs font-semibold uppercase tracking-wide">Layout</div>
                     <div className="grid grid-cols-2 gap-2 border-b px-4 pb-6">
                         {getLayoutList().map((item: { style: FormSlideLayout; Icon: any }) => (
                             <button key={item.style} data-umami-event={`${item.style} Layout`} data-umami-event-email={authState.email}>
@@ -188,7 +189,7 @@ export default function PagePropertiesTab({ }: {}) {
             }
             {(activeSlideComponent?.id === 'welcome-page' || activeSlideComponent?.id === 'thank-you-page') && (
                 <>
-                    <div className="p2-new text-black-700 mb-4 mt-6 px-4 !font-medium">Settings</div>
+                    <div className="text-black-600 px-4 pb-3 pt-6 text-xs font-semibold uppercase tracking-wide">Settings</div>
 
                     <div className="flex w-full items-center justify-between border-b px-4 pb-4">
                         {activeSlideComponent?.id === 'welcome-page' || activeSlideComponent?.id === 'thank-you-page' ? (
@@ -265,7 +266,7 @@ export default function PagePropertiesTab({ }: {}) {
                 </>
             )}
             <div className={cn('border-black-200 flex justify-between border-b px-4 py-6 hover:bg-inherit', slide?.imageUrl ? 'flex-col items-start gap-2' : 'flex-row items-center ')}>
-                <span className="p3-new text-black-700">Layout Image</span>
+                <span className="text-black-600 text-xs font-semibold uppercase tracking-wide">Layout Image</span>
                 {slide?.imageUrl ? (
                     <div className={`group relative my-4 max-h-[168px] w-full`}>
                         <div className={cn('absolute hidden h-full w-full items-start justify-start gap-2 p-2 group-hover:flex')}>
@@ -291,7 +292,7 @@ export default function PagePropertiesTab({ }: {}) {
                 <></>
             ) : (
                 <>
-                    <div className="p2-new text-black-700 mb-6 mt-6 px-4 !font-medium">Used Fields</div>
+                    <div className="text-black-600 px-4 pb-3 pt-6 text-xs font-semibold uppercase tracking-wide pb-6">Used Fields</div>
                     <div className="mb-4 flex flex-col gap-6 px-4">
                         {activeSlideComponent?.index !== undefined &&
                             formFields[activeSlideComponent.index]?.properties?.fields?.map((field) => {
@@ -330,9 +331,14 @@ export default function PagePropertiesTab({ }: {}) {
                 </>
             )}
             {activeSlideComponent?.id !== 'welcome-page' && activeSlideComponent?.id !== 'thank-you-page' && (activeSlideComponent?.index ?? -1) >= 0 && (
-                <div className="border-t">
-                    <PageJumpEditor />
-                </div>
+                <>
+                    <div className="border-t">
+                        <PageJumpEditor />
+                    </div>
+                    <div className="border-t">
+                        <HiddenFieldsEditor />
+                    </div>
+                </>
             )}
         </>
     );

--- a/webapp/src/views/organism/form-builder/slide-builder.tsx
+++ b/webapp/src/views/organism/form-builder/slide-builder.tsx
@@ -24,7 +24,7 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
     const { setActiveFieldComponent, activeFieldComponent } = useActiveFieldComponent();
     const { activeSlideComponent } = useActiveSlideComponent();
     const { theme } = useFormState();
-    const { navbarState } = useNavbarState();
+    const { navbarState, setNavbarState } = useNavbarState();
 
     return (
         <SlideLayoutWrapper showDesktopLayout slide={slide} disabled={disabled} theme={theme} scrollDivId={!disabled ? 'scroll-div' : undefined}>
@@ -107,6 +107,23 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                                     </motion.div>
                                 );
                             })
+                        ) : !disabled && !isScaledDown ? (
+                            // An empty page shouldn't be a dead rectangle — give
+                            // first-run creators a direct way in (audit B4).
+                            <div className="flex h-full w-full items-center justify-center">
+                                <button
+                                    type="button"
+                                    className="border-black-400 text-black-700 hover:border-black-600 hover:text-black-900 flex flex-col items-center gap-2 rounded-xl border border-dashed bg-white/60 px-10 py-8 text-sm font-medium transition-colors"
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        setNavbarState({ ...navbarState, insertMenuOpen: true });
+                                    }}
+                                >
+                                    <span className="text-2xl leading-none">＋</span>
+                                    Add a question
+                                    <span className="text-black-500 text-xs font-normal">Pick a field type from the Insert menu</span>
+                                </button>
+                            </div>
                         ) : (
                             <></>
                         )}

--- a/webapp/src/views/organism/form/form-slide.tsx
+++ b/webapp/src/views/organism/form/form-slide.tsx
@@ -11,6 +11,7 @@ import { cn } from '@app/shadcn/util/lib';
 import { selectAuth } from '@app/store/auth/slice';
 import useFormAtom from '@app/store/jotai/form-file';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
 import { useSendFlowEventMutation, useSubmitResponseMutation } from '@app/store/redux/form-api';
 import { getFlowSessionId } from '@app/utils/flow-session';
@@ -41,6 +42,7 @@ import MatrixField from '../form-builder/fields/matrix';
 import VideoField from '../form-builder/fields/video-field';
 import TabularInputResponderField from '@app/views/molecules/responder-form-fields/tabular-input-responder-field';
 import SlideLayoutWrapper from '../layout/slide-layout-wrapper';
+import { Shield } from 'lucide-react';
 
 export function FormFieldComponent({ field, slideIndex }: { field: StandardFormFieldDto; slideIndex: number }) {
     switch (field.type) {
@@ -98,10 +100,18 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
     const { currentSlide, setCurrentSlideToThankyouPage, nextSlide, goToSlide, previousSlide, setResponderState, responderState, setCurrentSlideToWelcomePage } = useResponderState();
 
     const { formResponse, setInvalidFields, setFormResponse } = useFormResponse();
+    const { hiddenValues } = useHiddenFieldValues();
     const workspace = useAppSelector(selectWorkspace);
     const [submitResponse, { isLoading }] = useSubmitResponseMutation();
     const { files } = useFormAtom();
     const authState = useAppSelector(selectAuth);
+
+    // Identity sharing is opt-in (Design-Language §5 — "leave consent unchecked;
+    // the person opts in"): until the responder touches the checkbox, a logged-in
+    // responder on an identity-optional form stays anonymous. Forms that require
+    // a verified identity keep it attached, as they state up front.
+    const identityOptional = !!authState.id && !standardForm?.settings?.requireVerifiedIdentity;
+    const effectiveAnonymize = formResponse.anonymize ?? identityOptional;
 
     const submitFormResponse = async () => {
         const formData = new FormData();
@@ -109,7 +119,9 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
         const postBody = {
             form_id: standardForm?.formId,
             answers: formResponse.answers ?? {},
-            anonymize: formResponse.anonymize ?? false,
+            // Hidden-field (URL parameter) values captured when the form loaded.
+            ...(Object.keys(hiddenValues).length ? { hidden_fields: hiddenValues } : {}),
+            anonymize: effectiveAnonymize,
             form_version: standardForm?.version || 1
         };
 
@@ -126,6 +138,11 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
         });
         if (!response.data) {
             throw new Error(response?.error);
+        }
+        // Reflect what was actually submitted, so the thank-you page reports
+        // the anonymity state truthfully.
+        if (formResponse.anonymize === undefined) {
+            setFormResponse({ ...formResponse, anonymize: effectiveAnonymize });
         }
         return response.data;
     };
@@ -202,7 +219,7 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
             <SlideLayoutWrapper showDesktopLayout={showDesktopLayout} scrollDivId={'questions-container'} theme={standardForm.theme} slide={formSlide} disabled>
                 <div className="absolute left-0 right-0 top-5 z-10 mx-auto w-full ">
                     <div className="px-5 md:px-8 xl:px-10 2xl:px-20">
-                        <div className={`w-full max-w-[800px] px-4 ${formSlide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? '' : 'mx-auto'}`}>
+                        <div className={`flex w-full max-w-[800px] items-center justify-between gap-3 px-4 ${formSlide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? '' : 'mx-auto'}`}>
                             <BackButton
                                 handleClick={() => {
                                     currentSlide > 0 ? previousSlide() : setCurrentSlideToWelcomePage();
@@ -212,6 +229,19 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                                     background: standardForm?.theme?.accent
                                 }}
                             />
+                            {/* Provenance + progress where the eye starts (Design-Language §3):
+                                who is asking, and how much is left — no surprises. */}
+                            <div className="text-black-700 flex items-center gap-3 text-[13px]">
+                                {(workspace?.title || workspace?.workspaceName) && (
+                                    <span className="border-black-300 text-black-800 hidden items-center gap-1.5 rounded-full border bg-white/85 px-2.5 py-0.5 font-medium sm:inline-flex">
+                                        <Shield className="text-brand-500 h-3.5 w-3.5" strokeWidth={1.8} aria-hidden="true" />
+                                        {workspace?.title || workspace?.workspaceName}
+                                    </span>
+                                )}
+                                <span className="whitespace-nowrap tabular-nums">
+                                    Page {currentSlide + 1} of {standardForm?.fields?.length || 1}
+                                </span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -224,9 +254,12 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                             {(standardForm?.fields?.length || 0) - 1 === currentSlide && currentSlide === index && (
                                 <div className="flex flex-col lg:mb-4 ">
                                     {authState.id && !standardForm.settings?.requireVerifiedIdentity && (
-                                        <div className="flex flex-row gap-2 ">
+                                        // Consent gets a calm, legible home of its own (Design-Language §2/§4):
+                                        // 15px/1.5, high contrast, green-tinted container — and unchecked by
+                                        // default, so sharing identity is a choice the person makes.
+                                        <label className="flex w-fit max-w-[560px] cursor-pointer flex-row items-start gap-3 rounded-lg border border-[#BFE0D2] bg-[#F2FAF6] p-4">
                                             <FieldInput
-                                                checked={!formResponse.anonymize}
+                                                checked={!effectiveAnonymize}
                                                 onChange={(e: any) => {
                                                     setFormResponse({
                                                         ...formResponse,
@@ -234,13 +267,15 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                                                     });
                                                 }}
                                                 type="checkbox"
-                                                className="h-4 w-4 border focus:border-0 focus:outline-none"
+                                                className="mt-0.5 h-5 w-5 shrink-0 cursor-pointer border accent-[#0E8A5F] focus:outline-none"
                                             />
-                                            <div className="flex flex-col ">
-                                                <span className="text-black-800 text-xs font-medium">Show your identity(email) to form collector</span>
-                                                <span className={`p4-new text-black-600 `}>{authState?.email} </span>
-                                            </div>
-                                        </div>
+                                            <span className="flex flex-col gap-0.5">
+                                                <span className="text-black-900 text-[15px] font-medium leading-relaxed">Share my email with the form collector</span>
+                                                <span className="text-black-700 text-[13px]">
+                                                    {authState?.email} — leave unchecked and your response stays anonymous.
+                                                </span>
+                                            </span>
+                                        </label>
                                     )}
                                 </div>
                             )}
@@ -250,11 +285,11 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                                     color: 'white'
                                 }}
                                 isLoading={isLoading}
-                                className=" rounded px-8 py-3 mt-4"
+                                className="mt-4 rounded-lg px-8 py-3 text-base font-semibold"
                                 onClick={onNext}
                                 size="medium"
                             >
-                                {(standardForm?.fields?.length || 0) - 1 === currentSlide && currentSlide === index ? 'Submit' : 'Next'}
+                                {(standardForm?.fields?.length || 0) - 1 === currentSlide && currentSlide === index ? 'Submit response' : 'Continue'}
                             </Button>
                         </div>
                     </div>

--- a/webapp/src/views/organism/form/thankyou-page.tsx
+++ b/webapp/src/views/organism/form/thankyou-page.tsx
@@ -10,8 +10,10 @@ import { selectAuth } from '@app/store/auth/slice';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
+import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
 import { selectWorkspace } from '@app/store/workspaces/slice';
+import { resolvePipesInText } from '@app/utils/answer-piping';
 import UserAvatarDropDown from '@app/views/molecules/user-avatar-dropdown';
 import { Copy } from 'lucide-react';
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard';
@@ -25,9 +27,12 @@ export default function ThankyouPage({ isPreviewMode }: { isPreviewMode: boolean
     const { responderId } = useResponderState();
     const [_, copyToClipboard] = useCopyToClipboard();
     const { formResponse } = useFormResponse();
+    const { hiddenValues } = useHiddenFieldValues();
 
     function getThankYouMessage() {
-        return standardForm?.thankyouPage?.[0]?.message ? standardForm?.thankyouPage?.[0]?.message : formResponse.anonymize ? 'Your response is anonymously submitted.' : 'Your response is successfully submitted.';
+        const message = standardForm?.thankyouPage?.[0]?.message ? standardForm?.thankyouPage?.[0]?.message : formResponse.anonymize ? 'Your response is anonymously submitted.' : 'Your response is successfully submitted.';
+        // Thank-you text supports text-token piping: "Thanks, {{field:<id>}}!"
+        return resolvePipesInText(message, { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues });
     }
 
     const handleOnCopy = (copyValue: string) => {

--- a/webapp/src/views/organism/form/welcome-page.tsx
+++ b/webapp/src/views/organism/form/welcome-page.tsx
@@ -114,7 +114,7 @@ export default function WelcomePage({
                         <div>
                             <Button
                                 style={{ background: formTheme?.secondary }}
-                                className="z-10 mt-2 rounded px-8 py-3"
+                                className="z-10 mt-2 rounded-lg px-8 py-3 text-base font-semibold"
                                 size="medium"
                                 onClick={() => {
                                     if (!auth.id && standardForm?.settings?.requireVerifiedIdentity) {

--- a/webapp/src/views/organism/navbar.tsx
+++ b/webapp/src/views/organism/navbar.tsx
@@ -14,6 +14,7 @@ import { selectAuth } from '@app/store/auth/slice';
 import { useActiveSlideComponent } from '@app/store/jotai/active-builder-component';
 import useFormFieldsAtom from '@app/store/jotai/field-selectors';
 import { useFormState } from '@app/store/jotai/form';
+import { useNavbarState } from '@app/store/jotai/navbar';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
 import { useResponderState } from '@app/store/jotai/responder-form-state';
 import { useCreateTemplateFromFormMutation } from '@app/store/redux/template-api';
@@ -44,8 +45,12 @@ const Navbar = () => {
     const { activeSlideComponent } = useActiveSlideComponent();
     const { formState, setFormTitle } = useFormState();
     const { toast } = useToast();
+    const { navbarState, setNavbarState } = useNavbarState();
 
-    const [insertDropdownOpen, setInsertDropdownOpen] = useState(false);
+    // In jotai (navbarState) so the empty-canvas "Add a question" affordance
+    // can open the same menu (see slide-builder.tsx).
+    const insertDropdownOpen = !!navbarState.insertMenuOpen;
+    const setInsertDropdownOpen = (open: boolean) => setNavbarState({ ...navbarState, insertMenuOpen: open });
     const [flowViewOpen, setFlowViewOpen] = useState(false);
 
     const [createTemplateFromForm, { isLoading: isCreatingTemplate }] = useCreateTemplateFromFormMutation();

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -2094,6 +2094,11 @@
     "@tiptap/extension-text-style" "^2.27.2"
     "@tiptap/pm" "^2.27.2"
 
+"@tiptap/suggestion@^2.7.2":
+  version "2.27.2"
+  resolved "https://registry.yarnpkg.com/@tiptap/suggestion/-/suggestion-2.27.2.tgz#901c1bbb5f12002cfe78a1ad40577727c23c374e"
+  integrity sha512-dQyvCIg0hcAVeh4fCIVCxogvbp+bF+GpbUb8sNlgnGrmHXnapGxzkvrlHnvneXZxLk/j7CxmBPKJNnm4Pbx4zw==
+
 "@tokenizer/inflate@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@tokenizer/inflate/-/inflate-0.4.1.tgz#fa6cdb8366151b3cc8426bf9755c1ea03a2fba08"


### PR DESCRIPTION
## What

Three bodies of work that build on each other (2 commits):

1. **Answer piping / recall + hidden fields** — roadmap "NOW" item #2
2. **Trust-first design pass** on the responder form, builder, and the dashboard form-details page (per the measured design audits)
3. **Consent & anonymity integrity** — identity sharing is opt-in and, for the first time, anonymity is actually enforced server-side

## 1 · Answer piping + hidden fields

- Question titles can reference earlier answers or hidden fields: type `@` in the title editor for an inline suggestion picker (filter + keyboard nav), or use the "@ Answer" toolbar menu. Pipes are inline TipTap nodes, resolved live in the responder runtime through the **same value extractor conditional logic uses** — one variables namespace, designed to host calculations/scoring next.
- Plain-text surfaces (descriptions, thank-you message) support `{{field:<id>}}` / `{{hidden:<name>|fallback}}` tokens.
- **Hidden fields**: declare URL parameter names form-wide in the builder; values are captured from the share link (declared names only — arbitrary query params are never stored), submitted with the response, **encrypted at rest exactly like answers**, and shown in the response detail view. `?field_<id>=value` prefills text-like inputs.
- Orphaned pipes are pruned when fields or hidden names are deleted. PATCHes from older bundles that omit hidden fields preserve the stored list (`[]` clears explicitly).

## 2 · Trust-first design pass

**Responder form** (audit: measured type sizes + WCAG contrast on the live page):
- Hierarchy fixed: 24px/600 ink questions, 16–18px ink answers — previously the placeholder rendered at 32px in link-blue, out-shouting the 18px question.
- One bordered white input with a visible themed focus ring across all field types (short/long text had regressed to an underline with **no focus indicator**).
- Default theme is the calm trust palette (surface `#F6F8FC`, ink `#101826`, trust blue `#2456CC`); saturated full-bleed themes remain opt-in.
- Buttons say what happens ("Continue", "Submit response"); provenance chip + "Page x of y" meta on every step; the trust strip is legible and links the responder portal.

**Builder**: canvas on a neutral mat as a bordered white card; title editor matches the responder's 24px scale (honest WYSIWYG); one panel-header rhythm; empty pages get an "Add a question" affordance that opens the Insert menu.

**Form details page (dashboard)** — the 8-tab bar silently overflowed on desktop and **hid the Form Link and Analytics tabs entirely** (1159px of tabs in a 914px strip, no scroll affordance):
- Consolidated to 5 always-visible tabs: Preview · Responses · Analytics · Share · Settings. Deletion requests are a segment inside Responses; Visibility + Integrations are Settings sections (old URLs redirect).
- Header: real breadcrumb, plain-words meta line (Published chip · response count · provenance) instead of an unlabeled provider glyph, one primary action.
- Settings: label/description + control grid with dividers *between* settings, locked state for Pro-gated toggles, danger zone that states consequences; fixed the "bettercolleceted" typo.
- Responses: anonymous rows show a shield "Anonymous" chip instead of "--"; column headers no longer leak piping syntax (`extractTextfromJSON` walks TipTap JSON now — fixes CSV headers too); table sits on the page grid.
- Preview: labelled page cards that actually open the full-screen preview (they had a pointer cursor and no click handler); deletion-requests empty state no longer shows borrowed "No responses yet" copy.

## 3 · Consent & anonymity integrity

- The identity-sharing checkbox arrived **pre-checked** (violating the no-dark-patterns rule) — it now starts unchecked in a legible 15px consent container; sharing is opt-in.
- **The backend accepted the `anonymize` flag but never enforced it**: "anonymously submitted" responses still stored the signed-in email as `dataOwnerIdentifier` (verified against stored documents). Anonymous responses now store no identifier and no email — only a one-way hash (`anonymous_identity`) so responders can still find and delete their own submission.
- Also fixed a builder state-loss race: `useFormState` setters spread a stale render-time snapshot, letting mount-effect writers wipe keys written between render and effect (it ate the form title and the hidden-fields list). All setters use functional updates now.

## Verification

- **Backend**: 149 pytest pass (8 new: hidden-field encryption round-trip, PATCH preserve/clear semantics, publish detection, anonymity enforcement both ways).
- **Webapp**: 148 vitest pass (23 new), `tsc --noEmit` clean.
- **Browser, end-to-end**: built pipes in the real builder → published → filled via share link with `?name=Ada&field_<id>=Grace` → title rendered "Hello Grace — welcome Ada" at question scale → submitted anonymously → Mongo shows encrypted `hidden_fields`, `dataOwnerIdentifier: null` + hash → dashboard shows the Anonymous chip and decrypted hidden fields. All five dashboard tabs and both merged-route redirects walked live.

Design audits (measured findings + before/after mockups) behind this PR:
form page: https://claude.ai/code/artifact/780aece5-a5ff-4dac-ba2b-a4a2ad06931e · details page: https://claude.ai/code/artifact/bdf284b2-1f5a-4f2a-b06e-b328ca82a362

**Deferred / follow-ups**: choice/rating/matrix prefill (needs option matching), hidden fields as logic-condition sources, hidden fields in CSV export (temporal worker owns CSV), Enter-to-continue on slides (button hint deliberately omitted until the behavior exists), integrations catalog CTA (roadmap #10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)