### PR TITLE
Responder journey overhaul: trust-first portal, working deletion flow, honest anonymity + builder/flow fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,12 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   language ("My response" · "Privacy & deletion"), and the deletion section
   restated as a calm trust surface — shield statement of the right, a muted
   "Request deletion" button with an expectation-setting caption, and an
-  amber "Deletion requested · Pending" state instead of a red warning.
+  amber "Deletion requested · Pending" state instead of a red warning. The
+  page also stopped wearing the platform's brand: the bettercollected
+  wordmark header (a jarring brand switch inside the workspace's own
+  branded space, especially on custom domains) gave way to the workspace's
+  avatar + name linking back to the portal, with the platform down in the
+  same quiet "Powered by" caption the portal uses.
 - **Anonymous responders can finally exercise their deletion right** (bug):
   requesting deletion authorized only `dataOwnerIdentifier == user` (plus
   admins) — an anonymous response has no owner identifier, so the very

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,20 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   branded space, especially on custom domains) gave way to the workspace's
   avatar + name linking back to the portal, with the platform down in the
   same quiet "Powered by" caption the portal uses.
+- **Anonymity now holds at the account level**: verifying your email no
+  longer links anonymous submissions to your account — My submissions and
+  Deletion requests list only identified responses, and an anonymous
+  response is reachable solely through its submission number, which is what
+  the portal copy promises ("that's what keeps it anonymous"). A caption
+  under the list says where anonymous submissions live. Also from this
+  feedback round: confirm dialogs' dismiss action is a quiet outline button
+  (the filled near-black "No" read as a second primary), the deletion
+  confirmation says what it does ("Ask the workspace to delete this
+  response?" · Cancel / Request deletion — no more Yes/No) and states the
+  consequence; and opening a submission no longer hops through a redirect
+  (receipts and number-search link straight to the response tab) nor
+  flashes a white full-screen loader (the workspace-branded shell stays up
+  with a skeleton while loading).
 - **Anonymous responders can finally exercise their deletion right** (bug):
   requesting deletion authorized only `dataOwnerIdentifier == user` (plus
   admins) — an anonymous response has no owner identifier, so the very

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Submission detail joins the portal's design**: opening a receipt (and
+  requesting deletion) landed on a bare white page with its own tab style —
+  a different product right where responders exercise their data rights. It
+  now wears the portal's clothes: surface wash, a white receipt card with
+  the same identity as the list (form title, mono receipt number, exact
+  time, Anonymous chip, deletion status), portal tabs renamed to responder
+  language ("My response" · "Privacy & deletion"), and the deletion section
+  restated as a calm trust surface — shield statement of the right, a muted
+  "Request deletion" button with an expectation-setting caption, and an
+  amber "Deletion requested · Pending" state instead of a red warning.
 - **Anonymous responders can finally exercise their deletion right** (bug):
   requesting deletion authorized only `dataOwnerIdentifier == user` (plus
   admins) — an anonymous response has no owner identifier, so the very

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,14 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Responder form transitions unified**: every page type declared its own
+  animation — different easings, and no exit motion at all, so the old page
+  froze in place while the new one slid over it — and the ±100% fly-in was
+  never clipped, flashing a horizontal scrollbar on every step. One
+  direction-aware transition now covers welcome/pages/thank-you (entering
+  page slides the full width, exiting page drifts a quarter-width the other
+  way while fading), the container clips the motion, and
+  `prefers-reduced-motion` gets a plain cross-fade.
 - **Builder canvas works on large screens**: the canvas mat collapsed to a
   content-height band floating in white void on tall viewports (the layout
   row centres its children and the mat, unlike the drawer, never stretched)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,19 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Anonymous responders can finally exercise their deletion right** (bug):
+  requesting deletion authorized only `dataOwnerIdentifier == user` (plus
+  admins) — an anonymous response has no owner identifier, so the very
+  people the product promised anonymity to were 403'd out of deleting their
+  own response; the check now accepts the anonymous identity hash. Deletion
+  requests also store that hash, so anonymous requests actually appear in
+  the responder's Deletion requests tab (they used to vanish after
+  creation). My submissions now surfaces "Deletion requested / Deleted"
+  status on the affected receipts (the list previously looked unchanged
+  after a request), deletion-request cards carry the receipt number and an
+  honest "Requested:" timestamp, the request button no longer nests a
+  button inside a tooltip's button (hydration error), and the danger button
+  uses the design language's muted red instead of washed pink.
 - **Responder portal redesigned as the trust surface it links from**: the
   workspace portal (where every form's "view or delete your response
   anytime" promise lands) was an admin-dashboard reskin. Form cards now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,18 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Flow view feedback round**: the Insights header no longer contradicts the
+  node chips — it now labels its two instruments apart ("17 responses"
+  behind the node/edge counts vs "journeys: 13 started · 11 finished" from
+  anonymous navigation tracking, with tooltips explaining each); the side
+  panel shows the selected page's full question (it was CSS-truncated to one
+  line); the "Edit content" overlay was rebuilt on the main canvas's
+  measured-scale layout — exactly centred sheet on the mat, page-number
+  eyebrow + full-title header, live Saving…/Saved status instead of a static
+  "changes save automatically" claim, and the standard 300px drawer; and
+  edges are now set one frame after nodes when the graph re-derives —
+  React Flow silently drops edges whose handles aren't mounted yet, which
+  intermittently rendered the whole graph unlinked.
 - **Flow (Logic) view brought onto the design language**: the `brand-*`
   Tailwind ramp — which still peaked at the old bright blue and leaked into
   every "tokenized" surface using brand classes — was retuned to trust blue,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,20 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **The builder now loads the draft it edits** (data-trust bug): the edit
+  page's loader requested the form with `published=true&draft=true`, and the
+  API returns the latest *published* version whenever one exists — so
+  autosaved changes (theme, welcome description, …) looked lost on every
+  reload while the draft in the database was actually correct. The builder
+  loader now fetches the draft.
+- **One form footer**: "Powered by bettercollected" moved into the trust
+  strip as its last item (gated by the existing disable-branding setting,
+  which the old footer never honoured) — the thank-you page's own floating
+  footer sat underneath the fixed strip and the two overlapped.
+- **Thank-you heading is customizable**: the hardcoded "Thank You! 🎉" is now
+  an editable (and pipeable) title on the thank-you page — edited inline in
+  the builder like the welcome title, persisted on the form, with the
+  classic greeting as the default when unset.
 - **Responder form transitions unified**: every page type declared its own
   animation — different easings, and no exit motion at all, so the old page
   froze in place while the new one slid over it — and the ±100% fly-in was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,20 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Responder portal redesigned as the trust surface it links from**: the
+  workspace portal (where every form's "view or delete your response
+  anytime" promise lands) was an admin-dashboard reskin. Form cards now
+  speak responder language — the form's purpose and question count instead
+  of a provider glyph and a tautological "Public" chip. Submission receipts
+  are finally identifiable: mono receipt number, exact time, and an
+  Anonymous shield chip (they used to show only title + date, so repeat
+  submissions were indistinguishable). The workspace card carries the trust
+  anchor; search-by-submission-number reads as the right-of-access feature
+  it is (trust treatment, labeled controls) instead of clip-art; the
+  deletion-requests empty state explains the right and the path to exercise
+  it; tabs, wash, avatar fallback and body ink moved onto the design
+  tokens; "Terms Of Services" typo fixed; the pink submission-detail title
+  and the "Form Page ‹ My response" breadcrumb cleaned up.
 - **The builder now loads the draft it edits** (data-trust bug): the edit
   page's loader requested the form with `published=true&draft=true`, and the
   API returns the latest *published* version whenever one exists — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,13 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
   policy link with a live preview of the responder-facing trust strip; the
   values persist as workspace-form settings and render on every step of the
   published form.
+- **Builder canvas works on large screens**: the canvas mat collapsed to a
+  content-height band floating in white void on tall viewports (the layout
+  row centres its children and the mat, unlike the drawer, never stretched)
+  — and the collapsed height fed back into the Fit computation, shrinking
+  the slide further. The mat now stretches to the workspace, and Fit no
+  longer caps at true size, so on big monitors Fit fills the mat while 100%
+  shows the true 1440×810 — the toggle was a no-op there before.
 - **Flow view feedback round**: the Insights header no longer contradicts the
   node chips — it now labels its two instruments apart ("17 responses"
   behind the node/edge counts vs "journeys: 13 started · 11 finished" from

--- a/backend/backend/app/repositories/deletion_requests_repository.py
+++ b/backend/backend/app/repositories/deletion_requests_repository.py
@@ -42,6 +42,18 @@ class DeletionRequestsRepository:
             },
             {"$set": {"form_imported_by": "$workspace_form.user_id"}},
             {"$unwind": "$form_imported_by"},
+            # Carry the response's receipt number so a deletion request is
+            # cross-referenceable with the submission it covers.
+            {
+                "$lookup": {
+                    "from": "form_responses",
+                    "localField": "response_id",
+                    "foreignField": "response_id",
+                    "as": "response_doc",
+                },
+            },
+            {"$set": {"submission_uuid": {"$arrayElemAt": ["$response_doc.submission_uuid", 0]}}},
+            {"$unset": "response_doc"},
         ]
 
         aggregate_query.extend(

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -56,6 +56,19 @@ class FormResponseRepository(BaseRepository):
             },
             {"$set": {"form_title": "$form.title"}},
             {"$unwind": "$form_title"},
+            # Surface any deletion request's status on the response itself —
+            # without it, requesting deletion changed nothing visible in the
+            # responder's submissions list.
+            {
+                "$lookup": {
+                    "from": "responses_deletion_requests",
+                    "localField": "response_id",
+                    "foreignField": "response_id",
+                    "as": "deletion_request",
+                },
+            },
+            {"$set": {"status": {"$arrayElemAt": ["$deletion_request.status", 0]}}},
+            {"$unset": "deletion_request"},
             {"$sort": {"created_at": -1}},
         ]
 

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -27,7 +27,6 @@ from backend.app.schemas.standard_form_response import (
     DeletionRequestStatus,
 )
 from backend.app.utils.aggregation_query_builder import create_filter_pipeline
-from backend.app.utils.hash import hash_string
 
 
 class FormResponseRepository(BaseRepository):
@@ -187,12 +186,11 @@ class FormResponseRepository(BaseRepository):
     async def get_user_submissions(
         self, form_ids, user: User, request_for_deletion: bool = False
     ):
-        extra_find_query = {
-            "$or": [
-                {"dataOwnerIdentifier": user.sub},
-                {"anonymous_identity": hash_string(user.sub)},
-            ]
-        }
+        # Deliberately NOT matching anonymous_identity here: anonymity means a
+        # signed-in account listing must not link anonymous submissions back to
+        # the account. The submission number (receipt) is the only key to an
+        # anonymous response — which is exactly what the portal promises.
+        extra_find_query = {"dataOwnerIdentifier": user.sub}
         if request_for_deletion:
             return await DeletionRequestsRepository.get_deletion_requests(
                 form_ids=form_ids, extra_find_query=extra_find_query

--- a/backend/backend/app/schemas/standard_form_response.py
+++ b/backend/backend/app/schemas/standard_form_response.py
@@ -28,6 +28,10 @@ class FormResponseDeletionRequest(MongoDocument):
     response_id: str
     provider: Optional[str] = None
     dataOwnerIdentifier: Optional[str] = None
+    # Anonymous responses are attributable only via this hash — without it a
+    # request created for an anonymous response could never be listed back to
+    # its owner.
+    anonymous_identity: Optional[str] = None
     status: DeletionRequestStatus = DeletionRequestStatus.PENDING
     deleted_at: Optional[str] = None
 

--- a/backend/backend/app/services/form_response_service.py
+++ b/backend/backend/app/services/form_response_service.py
@@ -232,7 +232,15 @@ class FormResponseService:
         # TODO : Handle case for multiple form import by other user
         response = await FormResponseDocument.find_one({"response_id": response_id})
 
-        if not (is_admin or response.dataOwnerIdentifier == user.sub):
+        # Anonymous responses carry no dataOwnerIdentifier — their owner is
+        # recognisable only by the anonymous identity hash. Without this check
+        # the people the product promised anonymity to were the only ones who
+        # couldn't exercise their deletion right (403).
+        if not (
+            is_admin
+            or response.dataOwnerIdentifier == user.sub
+            or (response.anonymous_identity is not None and response.anonymous_identity == hash_string(user.sub))
+        ):
             raise HTTPException(403, "You are not authorized to perform this action.")
 
         deletion_request = await FormResponseDeletionRequest.find_one(
@@ -249,6 +257,7 @@ class FormResponseService:
             form_id=response.form_id,
             response_id=response_id,
             dataOwnerIdentifier=response.dataOwnerIdentifier,
+            anonymous_identity=response.anonymous_identity,
             provider=response.provider,
             deleted_at=None,
         ).save()
@@ -428,6 +437,7 @@ class FormResponseService:
             form_id=response.form_id,
             response_id=response_id,
             dataOwnerIdentifier=response.dataOwnerIdentifier,
+            anonymous_identity=response.anonymous_identity,
             provider=response.provider,
             deleted_at=None,
         ).save()

--- a/backend/tests/app/services/test_hidden_fields.py
+++ b/backend/tests/app/services/test_hidden_fields.py
@@ -181,3 +181,41 @@ async def test_anonymous_owner_can_request_deletion(workspace, published_form):
     # submissions listing matches on.
     assert request.anonymous_identity == stored_response.anonymous_identity
     assert request.dataOwnerIdentifier is None
+
+
+async def test_anonymous_submissions_are_not_listed_under_the_account(
+    workspace, published_form
+):
+    """Anonymity has to mean something at the account level: verifying your
+    email must not link anonymous submissions back to you in the portal
+    listing. The submission number (receipt) is the only key to an anonymous
+    response — exactly what the portal copy promises responders."""
+    from backend.app.models.dtos.response_dtos import StandardFormResponseCamelModel
+    from tests.app.controllers.data import testUser2
+
+    identified = await container.workspace_form_service().submit_response(
+        workspace.id,
+        published_form.form_id,
+        StandardFormResponseCamelModel(answers={}, anonymize=False),
+        testUser2,
+    )
+    anonymous = await container.workspace_form_service().submit_response(
+        workspace.id,
+        published_form.form_id,
+        StandardFormResponseCamelModel(answers={}, anonymize=True),
+        testUser2,
+    )
+
+    from fastapi_pagination import Page, Params
+    from fastapi_pagination.api import set_page, set_params
+
+    # In the app these come from the route context (response_model +
+    # add_pagination); set them explicitly for a direct service call.
+    set_page(Page[StandardFormResponseCamelModel])
+    set_params(Params(page=1, size=50))
+    page = await container.form_response_service().get_user_submissions(
+        workspace.id, testUser2
+    )
+    listed_ids = [item.response_id for item in page.items]
+    assert identified.response_id in listed_ids
+    assert anonymous.response_id not in listed_ids

--- a/backend/tests/app/services/test_hidden_fields.py
+++ b/backend/tests/app/services/test_hidden_fields.py
@@ -146,3 +146,38 @@ async def test_trust_layer_settings_patch_roundtrip(workspace, workspace_form):
     )
     assert cleared.settings.purpose is None
     assert cleared.settings.retention_text == "kept for 90 days"
+
+
+async def test_anonymous_owner_can_request_deletion(workspace, published_form):
+    """The deletion right must survive anonymity: an anonymous response has no
+    dataOwnerIdentifier, so the owner is recognisable only through the
+    anonymous identity hash. Before the fix, non-admin anonymous responders
+    were 403'd out of deleting their own response, and the created request
+    carried no identity at all — it could never be listed back to them."""
+    from backend.app.models.dtos.response_dtos import StandardFormResponseCamelModel
+    from backend.app.schemas.standard_form_response import FormResponseDeletionRequest
+    from tests.app.controllers.data import testUser2
+
+    # testUser2 is not a member of the workspace — pure responder.
+    response = await container.workspace_form_service().submit_response(
+        workspace.id,
+        published_form.form_id,
+        StandardFormResponseCamelModel(answers={}, anonymize=True),
+        testUser2,
+    )
+
+    await container.form_response_service().request_for_response_deletion(
+        workspace.id, response.response_id, testUser2
+    )
+
+    stored_response = await FormResponseDocument.find_one(
+        {"response_id": response.response_id}
+    )
+    request = await FormResponseDeletionRequest.find_one(
+        {"response_id": response.response_id}
+    )
+    assert request is not None
+    # Attribution survives: the request carries the same anonymous hash the
+    # submissions listing matches on.
+    assert request.anonymous_identity == stored_response.anonymous_identity
+    assert request.dataOwnerIdentifier is None

--- a/common/common/models/standard_form.py
+++ b/common/common/models/standard_form.py
@@ -448,6 +448,9 @@ class WelcomePageField(BaseModel):
 
 
 class ThankYouPageField(BaseModel):
+    # Heading shown above the message; the responder falls back to the classic
+    # "Thank You!" greeting when unset.
+    title: Optional[str] = None
     message: Optional[str] = None
     buttonText: Optional[str] = None
     buttonLink: Optional[str] = None

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -183,7 +183,7 @@
     "DELETION_REQUEST.DESCRIPTION": "When you ask for a response to be deleted, the request and its status show up here. Open one of your submitted forms and use its Settings tab to request deletion.",
     "DELETION_REQUESTS": "Deletion requests",
     "DELETION_RESPONSE.DESCRIPTION": "You have not submitted any response on the forms provided in this workspace.",
-    "DELETION_RESPONSE_WARNING_MESSAGE": "Are you sure you want to request your response to be deleted?",
+    "DELETION_RESPONSE_WARNING_MESSAGE": "Ask the workspace to delete this response?",
     "DRAFT": "Draft",
     "EMPTY": {
       "DESCRIPTION": "Import your Google Forms or Typeforms",

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -220,7 +220,7 @@
     "STATUS_PENDING": "Pending",
     "STATUS_EXPIRED": "Expired",
     "SUBMISSION_DATE": "Submission Date",
-    "SUBMITTED_FORMS": "Submitted forms",
+    "SUBMITTED_FORMS": "My submissions",
     "PREVIEW": "Preview",
     "URL": "Form URL",
     "IMPORTED_BY": "Imported By",
@@ -558,7 +558,7 @@
     "FOR_THIS_FEATURE": " for this feature"
   },
   "PRIVACY_POLICY": {
-    "TITLE": "Privacy Policy",
+    "TITLE": "Privacy policy",
     "DESCRIPTION": "Our Privacy Policy outlines how we handle, collect, and protect your personal information when you use our services."
   },
   "PROFILE_MENU": {

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -180,8 +180,8 @@
     "COLLECTED_RESPONSES": "Collected responses",
     "DELETE": "Delete form",
     "DELETE_DESCRIPTION": "Deleting this form will also remove all the responses and deletion requests.",
-    "DELETION_REQUEST.DESCRIPTION": "You have not requested any deletion for your filled responses.",
-    "DELETION_REQUESTS": "Deletion Requests",
+    "DELETION_REQUEST.DESCRIPTION": "When you ask for a response to be deleted, the request and its status show up here. Open one of your submitted forms and use its Settings tab to request deletion.",
+    "DELETION_REQUESTS": "Deletion requests",
     "DELETION_RESPONSE.DESCRIPTION": "You have not submitted any response on the forms provided in this workspace.",
     "DELETION_RESPONSE_WARNING_MESSAGE": "Are you sure you want to request your response to be deleted?",
     "DRAFT": "Draft",
@@ -655,7 +655,7 @@
   "STEP": "Step",
   "SUBMISSIONS": "Submissions",
   "TERMS_OF_SERVICES": {
-    "TITLE": "Terms Of Services",
+    "TITLE": "Terms of service",
     "DESCRIPTION": "Our Terms of Services establish the rules and guidelines for using our services."
   },
   "TEMPLATE": {

--- a/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/edit/_components/form-edit-page.tsx
+++ b/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/edit/_components/form-edit-page.tsx
@@ -68,7 +68,10 @@ export default function FormEditPage(props: { params: Promise<{ form_id: string 
             const cs = getComputedStyle(mat);
             const availableWidth = mat.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
             const availableHeight = mat.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
-            setFitScale(Math.min(availableWidth / CANVAS_WIDTH, availableHeight / CANVAS_HEIGHT, 1));
+            // No upper cap: on large screens Fit should fill the mat (upscale
+            // past true size), otherwise Fit and 100% are identical and the
+            // toggle reads as broken.
+            setFitScale(Math.min(availableWidth / CANVAS_WIDTH, availableHeight / CANVAS_HEIGHT));
         };
         compute();
         const observer = new ResizeObserver(compute);
@@ -142,9 +145,13 @@ export default function FormEditPage(props: { params: Promise<{ form_id: string 
                 <LeftDrawer formFields={formFields} activeSlideComponent={activeSlideComponent} />
                 {/* Neutral workspace mat behind the canvas, so the slide being edited
                     reads as the artefact and separates from the tool's chrome. */}
+                {/* self-stretch matters: the row is items-center, and without it
+                    the mat's height collapses to its content on tall viewports —
+                    a floating band in white void, whose collapsed height then
+                    feeds back into the Fit scale and shrinks the card. */}
                 <div
                     ref={canvasMatRef}
-                    className=" relative flex max-h-full max-w-full flex-1 overflow-auto bg-[#E9EEF5] px-8 py-10"
+                    className=" relative flex max-h-full max-w-full flex-1 self-stretch overflow-auto bg-[#E9EEF5] px-8 py-10"
                     onClick={() => {
                         setActiveFieldComponent(null);
                     }}

--- a/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/layout.tsx
+++ b/webapp/src/app/(admin-portal)/(no-layout)/[workspace_name]/dashboard/forms/[form_id]/layout.tsx
@@ -16,7 +16,11 @@ export default async function Layout(
     const workspace = await getWorkspaceByName(workspace_name);
     if (!workspace) return notFound();
 
-    const form = await fetchWithCookies(environments.INTERNAL_DOCKER_API_ENDPOINT_HOST + '/workspaces/' + workspace.id + '/forms/' + form_id + '?published=true&draft=true');
+    // The builder edits the DRAFT. With `published=true` the API returns the
+    // latest published version whenever one exists (`draft=true` is only a
+    // fallback for never-published forms) — so every autosaved change looked
+    // lost on reload while the draft in the database was actually correct.
+    const form = await fetchWithCookies(environments.INTERNAL_DOCKER_API_ENDPOINT_HOST + '/workspaces/' + workspace.id + '/forms/' + form_id);
 
     if (!form) return notFound();
 

--- a/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
+++ b/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/page.tsx
@@ -160,6 +160,7 @@ const FetchFormWrapper = ({ slug }: { slug: string }) => {
                         retention={data?.settings?.retentionText}
                         privacyUrl={data?.settings?.privacyPolicyUrl}
                         portalUrl={typeof window !== 'undefined' && window.PUBLIC_CONFIG ? `${window.PUBLIC_CONFIG.HTTP_SCHEME}${window.PUBLIC_CONFIG.FORM_DOMAIN}/${workspace?.workspaceName}` : undefined}
+                        poweredBy={!data?.settings?.disableBranding}
                     />
                 </div>
             )}

--- a/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/preview/page.tsx
+++ b/webapp/src/app/(user-portal)/(no-layout)/[workspace_name]/forms/[form_id]/preview/page.tsx
@@ -40,7 +40,7 @@ export default function FormPreview(props: { params: Promise<{ form_id: string }
         <Form isPreviewMode />
         {/* Preview shows exactly what responders will see, trust strip included. */}
         <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40">
-            <TrustLayer ownerName={workspace?.title || workspace?.workspaceName} ownerImage={workspace?.profileImage} purpose={data?.settings?.purpose} retention={data?.settings?.retentionText} privacyUrl={data?.settings?.privacyPolicyUrl} />
+            <TrustLayer ownerName={workspace?.title || workspace?.workspaceName} ownerImage={workspace?.profileImage} purpose={data?.settings?.purpose} retention={data?.settings?.retentionText} privacyUrl={data?.settings?.privacyPolicyUrl} poweredBy={!data?.settings?.disableBranding} />
         </div>
     </div>
 }

--- a/webapp/src/assets/css/globals.css
+++ b/webapp/src/assets/css/globals.css
@@ -34,9 +34,9 @@ body {
 }
 
 body {
-    background: #f2f7ff;
-    background-color: #f2f7ff;
-    color: #121212;
+    background: #f6f8fc;
+    background-color: #f6f8fc;
+    color: #101826;
 }
 
 [data-theme='dark'] body {

--- a/webapp/src/components/auth/account-profile-image.tsx
+++ b/webapp/src/components/auth/account-profile-image.tsx
@@ -31,7 +31,7 @@ export default function AuthAccountProfileImage({
             style={{ width: size, height: size, ...style }}
         >
             <AvatarImage src={image} className="object-cover" />
-            <AvatarFallback className={cn("bg-green-500 text-white font-semibold flex items-center justify-center h-full w-full", roundedClass)}>
+            <AvatarFallback className={cn("bg-[#E9EFFC] text-[#2456CC] font-semibold flex items-center justify-center h-full w-full", roundedClass)}>
                 <span className={cn(typography)}>{name?.[0]?.toUpperCase()}</span>
             </AvatarFallback>
         </Avatar>

--- a/webapp/src/components/common/generic-half-modal.tsx
+++ b/webapp/src/components/common/generic-half-modal.tsx
@@ -29,7 +29,10 @@ export default function GenericHalfModal({ headerTitle, title, subTitle, type, p
             {subTitle && <span className="p2-new text-sm mt-2 text-black-700">{subTitle}</span>}
             {children}
             <div className="flex w-full gap-4 mt-6">
-                <Button className="flex-1" size="medium" onClick={closeModal} variant="secondary">
+                {/* The dismiss action is quiet — a filled near-black "No" carried
+                    as much visual weight as the action itself and read like a
+                    second primary. */}
+                <Button className="flex-1" size="medium" onClick={closeModal} variant="v2Button">
                     {!negativeText ? t('BUTTON.CANCEL') : negativeText}
                 </Button>
                 <Button className="flex-1" size="medium" isLoading={loading} variant={type === 'danger' ? 'danger' : 'primary'} onClick={positiveAction}>

--- a/webapp/src/components/dashboard/form-cards.tsx
+++ b/webapp/src/components/dashboard/form-cards.tsx
@@ -29,6 +29,11 @@ const FormCards = ({ title, formsArray, workspace, showPinned = true, showVisibi
                         <Link
                             key={form.formId + idx}
                             href={pathname}
+                            // Filling a form is a fullscreen, focused journey with no
+                            // chrome back to the portal — open it in its own tab so
+                            // the portal stays exactly where the responder left it.
+                            target="_blank"
+                            rel="noopener"
                         >
                             <WorkspaceFormCard isResponderPortal showVisibility={showVisibility} showPinned={showPinned} form={form} hasCustomDomain={isCustomDomain} workspace={workspace} />
                         </Link>

--- a/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
@@ -85,7 +85,7 @@ export default function WorkspaceFormsTabContent({ workspace, isFormCreator = fa
             {pinnedForms?.items?.length !== 0 && <FormCards title={t(formConstant.pinnedforms)} showPinned={false} isFormCreator={isFormCreator} showVisibility={false} workspace={workspace} formsArray={pinnedForms?.items || []} />}
             {pinnedForms?.items?.length !== 0 && <Divider />}
             <div className={`w-full md:w-[282px]`}>
-                <SearchInput handleSearch={handleSearch} />
+                <SearchInput placeholder="Search forms" handleSearch={handleSearch} />
             </div>
             {allForms.length !== 0 && <FormCards title={pinnedForms?.items?.length !== 0 ? t(formConstant.all) : ''} isFormCreator={isFormCreator} formsArray={allForms} workspace={workspace} />}
         </div>

--- a/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
@@ -48,7 +48,7 @@ export default function WorkspaceResponsesTabContent({ workspace, deletionReques
 
     return (
         <>
-            {submissions?.length === 0 && <ZeroElement title={deletionRequests ? t(formConstant.empty.deletionRequest.title) : '0 submissions'} description={getEmptyMessage()} className="!pb-[20px]" />}
+            {submissions?.length === 0 && <ZeroElement title={deletionRequests ? t(formConstant.empty.deletionRequest.title) : 'No submissions yet'} description={getEmptyMessage()} className="!pb-[20px]" />}
 
             {submissions?.length !== 0 && (
                 <div className="w-full">

--- a/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
@@ -1,8 +1,10 @@
 
 "use client";
 import { useTranslation } from 'next-i18next';
+import { usePathname, useRouter } from 'next/navigation';
 
 import ZeroElement from '@Components/common/zero-elament';
+import { Button } from '@app/shadcn/components/ui/button';
 import WorkspaceFormResponseDeletionCard from '@Components/workspace-client/workspace-form-response-deletion-card';
 
 import Loader from '@app/components/ui/loader';
@@ -21,6 +23,8 @@ interface IWorkspaceResponsesTabContentProps {
 export default function WorkspaceResponsesTabContent({ workspace, deletionRequests = false }: IWorkspaceResponsesTabContentProps) {
     const { t } = useTranslation();
     const auth = useAppSelector(selectAuth);
+    const router = useRouter();
+    const pathname = usePathname();
     const { isLoading, data } = useGetWorkspaceSubmissionsQuery(
         {
             workspaceId: workspace.id,
@@ -41,14 +45,37 @@ export default function WorkspaceResponsesTabContent({ workspace, deletionReques
     const isCustomDomain = window?.location.host !== window.PUBLIC_CONFIG?.FORM_DOMAIN;
 
     const getEmptyMessage = () => {
-        if (!auth.id) return 'Verify your email or enter your submission number you to view all your form responses.';
         if (deletionRequests) return t(formConstant.deletionRequestDescription);
-        return 'You have not submitted any response on the forms provided in this workspace.';
+        return "You haven't submitted any responses to this workspace's forms yet.";
+    };
+
+    const handleVerify = () => {
+        const params = new URLSearchParams({
+            type: 'responder',
+            workspace_id: workspace.id,
+            redirect_to: pathname ?? ''
+        });
+        router.push(`/login?${params.toString()}`);
     };
 
     return (
         <>
-            {submissions?.length === 0 && <ZeroElement title={deletionRequests ? t(formConstant.empty.deletionRequest.title) : 'No submissions yet'} description={getEmptyMessage()} className="!pb-[20px]" />}
+            {/* Signed out we DON'T know there are no submissions — "No submissions
+                yet" would be a false claim to a responder with ten of them. Say
+                what's actually true: verify (or use a receipt number) to see them. */}
+            {submissions?.length === 0 && !auth.id && (
+                <div className="px-13 flex h-full min-h-[290px] w-full flex-col items-center justify-center gap-4 rounded-xl bg-white py-[60px] text-center">
+                    <div>
+                        <h1 className="h4-new mt-2">Find your submissions</h1>
+                        <p className="p2-new !text-black-700 mt-1 max-w-[290px] md:max-w-[360px]">Verify your email to see responses you&apos;ve submitted, or enter a submission number in the search panel.</p>
+                    </div>
+                    <Button size="sm" onClick={handleVerify}>
+                        Verify email
+                    </Button>
+                    <p className="text-black-500 max-w-[360px] text-xs">Submitted anonymously? Your submission number is the only way to find that response — that&apos;s what keeps it anonymous.</p>
+                </div>
+            )}
+            {submissions?.length === 0 && !!auth.id && <ZeroElement title={deletionRequests ? t(formConstant.empty.deletionRequest.title) : 'No submissions yet'} description={getEmptyMessage()} className="!pb-[20px]" />}
 
             {submissions?.length !== 0 && (
                 <div className="w-full">

--- a/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
@@ -84,6 +84,11 @@ export default function WorkspaceResponsesTabContent({ workspace, deletionReques
                             <WorkspaceFormResponseDeletionCard deletionRequests={deletionRequests} key={submission.responseId} response={submission} isCustomDomain={isCustomDomain} workspaceName={workspace.workspaceName} />
                         ))}
                     </div>
+                    {!deletionRequests && (
+                        <p className="text-black-600 mt-4 text-xs">
+                            Anonymous submissions aren&apos;t linked to your account — find them with their submission number. That&apos;s what keeps them anonymous.
+                        </p>
+                    )}
                 </div>
             )}
         </>

--- a/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
@@ -9,6 +9,7 @@ import { useAppSelector } from '@app/store/hooks';
 import { useDeleteResponseMutation } from '@app/store/workspaces/api';
 import { utcToLocalDateTIme } from '@app/utils/date-utils';
 import { downloadFile } from '@app/utils/file-utils';
+import { resolvePipesInTitle, titleHasPipes } from '@app/utils/answer-piping';
 import { getAnswerForField, getTitleForHeader } from '@app/utils/form-builder-block-utils';
 import DeleteIcon from '@Components/icons/delete';
 import { motion } from 'framer-motion';
@@ -58,10 +59,21 @@ export const IndividualFormResponse = ({ formFields, response, form, className }
 
     const reduxForm = useAppSelector(selectForm);
     const standardForm = form ? form : reduxForm;
+    // Questions may pipe earlier answers ("Hello @name…") — resolve them with
+    // THIS submission's answers so the question reads exactly as the responder
+    // saw it, instead of showing raw builder pipe labels.
+    const pipeContext = {
+        slides: standardForm?.fields,
+        answers: response?.answers ?? {},
+        hiddenValues: (response as any)?.hiddenFields ?? {}
+    };
     function getTitleForHeaderForTable(field: StandardFormFieldDto) {
-        const title = getTitleForHeader(field, standardForm);
+        const resolvedField = titleHasPipes(field?.title) ? ({ ...field, title: resolvePipesInTitle(field.title, pipeContext) } as StandardFormFieldDto) : field;
+        const title = getTitleForHeader(resolvedField, standardForm);
 
-        return <span className="p3-new !text-black-800 truncate md:w-[250px]">{title}</span>;
+        // The question is the label; the answer is the content. Muted medium
+        // label over full-size ink answer keeps the two unmistakable.
+        return <span className="text-black-600 text-[13px] font-medium leading-snug">{title}</span>;
     }
     const downloadFormFile = async (ans: any) => {
         try {
@@ -83,7 +95,7 @@ export const IndividualFormResponse = ({ formFields, response, form, className }
 
                     return (
                         <div className="flex flex-col gap-2" key={field.id}>
-                            <span className="p4-new text-black-500">{getTitleForHeaderForTable(field)}</span>
+                            {getTitleForHeaderForTable(field)}
                             <div className="overflow-x-auto rounded-md border border-gray-200">
                                 <Table className="min-w-full text-xs">
                                     <TableHeader>
@@ -116,18 +128,19 @@ export const IndividualFormResponse = ({ formFields, response, form, className }
 
                 if (field.type === FieldTypes.FILE_UPLOAD || field.type === FieldTypes.INPUT_FILE_UPLOAD) {
                     return (
-                        <div className="flex flex-col gap-1" key={field.id}>
-                            <span className="p4-new text-black-500">{getTitleForHeaderForTable(field)}</span>
+                        <div className="flex flex-col gap-1.5" key={field.id}>
+                            {getTitleForHeaderForTable(field)}
                             <div onClick={() => downloadFormFile(ans)} className={cn('!text-black-600 p2-new   w-[140px] cursor-default truncate rounded px-2 py-1', ans?.file_metadata?.url ? 'bg-black-300 active:bg-black-400 !cursor-pointer' : '')}>
                                 {getAnswerForField(response, field)}
                             </div>
                         </div>
                     );
                 }
+                const answerText = getAnswerForField(response, field);
                 return (
-                    <div className="flex flex-col gap-1" key={field.id}>
-                        <span className="p4-new text-black-500">{getTitleForHeaderForTable(field)}</span>
-                        <span className="p2-new text-black-700">{getAnswerForField(response, field) || '- -'}</span>
+                    <div className="flex flex-col gap-1.5" key={field.id}>
+                        {getTitleForHeaderForTable(field)}
+                        {answerText ? <span className="text-black-900 text-base leading-relaxed">{answerText}</span> : <span className="text-black-500 text-sm italic">No answer</span>}
                     </div>
                 );
             })}

--- a/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
@@ -47,12 +47,12 @@ const ViewResponseFullModalView = ({ response, formFields, formId, workspaceId }
                 </div>
             </div>
             <Separator />
-            <IndividualFormResponse formFields={formFields} response={response} />
+            <IndividualFormResponse className="h-[90vh] overflow-y-auto" formFields={formFields} response={response} />
         </motion.div>
     );
 };
 
-export const IndividualFormResponse = ({ formFields, response, form }: { formFields: Array<StandardFormFieldDto>; response: StandardFormResponseDto; form?: StandardFormDto }) => {
+export const IndividualFormResponse = ({ formFields, response, form, className }: { formFields: Array<StandardFormFieldDto>; response: StandardFormResponseDto; form?: StandardFormDto; className?: string }) => {
 
     const { toast } = useToast();
 
@@ -71,9 +71,8 @@ export const IndividualFormResponse = ({ formFields, response, form }: { formFie
             toast({ description: 'Error downloading file', variant: 'destructive' });
         }
     };
-    console.warn("The form fields: ", formFields);
     return (
-        <div className="flex h-[90vh]  w-full flex-col gap-8 overflow-y-auto p-4 pt-6 ">
+        <div className={cn('flex w-full flex-col gap-8 p-4 pt-6', className)}>
             {formFields.map((field) => {
                 const ans = response.answers[field.id];
 

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -74,7 +74,7 @@ export default function ResponderPortalLayoutClient({
     const basePath = hasCustomDomain ? '' : `/${workspace.workspaceName}`;
 
     return (
-        <div className={`!bg-new-white-200 max-w-screen flex h-screen max-h-screen w-screen flex-col overflow-auto p-5 opacity-100 md:flex-row md:p-10 ${!hasCustomDomain ? '!pb-20' : ''}`}>
+        <div className={`max-w-screen !bg-[#F6F8FC] flex h-screen max-h-screen w-screen flex-col overflow-auto p-5 opacity-100 md:flex-row md:p-10 ${!hasCustomDomain ? '!pb-20' : ''}`}>
             <div className="max-w-screen w-full md:sticky md:top-0 md:w-[320px] md:max-w-[320px]">
                 <WorkspaceDetailsCard workspace={workspace} />
                 {!auth.id && !auth.isLoading && (
@@ -107,7 +107,8 @@ export default function ResponderPortalLayoutClient({
                                             <AuthAccountProfileImage size={36} image={auth?.profileImage} name={getFullNameFromUser(auth) ?? ''} />
                                             <div className="!text-black-700 flex flex-col justify-center gap-2 pr-1 text-start">
                                                 <span className="body6 !leading-none">{getFullNameFromUser(auth)?.trim() || auth?.email || ''}</span>
-                                                <span className="body5 !leading-none">{auth?.email} </span>
+                                                {/* Only repeat the email when the first line is a real name. */}
+                                                {!!getFullNameFromUser(auth)?.trim() && getFullNameFromUser(auth)?.trim() !== auth?.email && <span className="body5 !leading-none">{auth?.email} </span>}
                                             </div>
                                         </div>
                                         <ChevronDown className={`${open ? 'rotate-180 transform' : ''} h-3 w-3 text-blue-900`} />
@@ -163,8 +164,8 @@ export default function ResponderPortalLayoutClient({
                                 className={cn(
                                     'flex items-center gap-2 px-4 py-2 text-sm font-medium mb-[-1px] cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap focus:outline-none',
                                     isActive
-                                        ? 'border-b-2 border-black-900 text-black-900'
-                                        : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                        ? 'text-black-900 border-b-2 border-[#2456CC]'
+                                        : 'text-black-600 hover:text-black-900 hover:border-black-300'
                                 )}
                             >
                                 {tab.icon}

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -179,9 +179,11 @@ export default function ResponderPortalLayoutClient({
                         );
                     })}
                 </div>
-                <div className="mt-4 flex flex-col gap-6 md:min-h-0 md:flex-1 md:overflow-y-auto md:[scrollbar-gutter:stable] xl:flex-row">
-                    {children}
-                    <SearchBySubmissionNumber className='hidden xl:block' />
+                <div className="mt-4 flex flex-col gap-6 md:min-h-0 md:flex-1 xl:flex-row">
+                    {/* Only the receipts/forms column scrolls — the search-by-number
+                        card is a persistent utility and stays in view. */}
+                    <div className="min-w-0 flex-1 md:min-h-0 md:overflow-y-auto md:[scrollbar-gutter:stable]">{children}</div>
+                    <SearchBySubmissionNumber className='hidden shrink-0 xl:block' />
                 </div>
             </div>
             <div className="lg:hidden">

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -78,8 +78,8 @@ export default function ResponderPortalLayoutClient({
                 <WorkspaceDetailsCard workspace={workspace} />
                 {!auth.id && !auth.isLoading && (
                     <div className="mt-6 flex flex-col rounded-xl bg-white p-6">
-                        <div className="h4-new">Check my data</div>
-                        <div className="p2-new text-black-600 mt-2">Verify your email address to view all the data associated with you.</div>
+                        <div className="h4-new">See your submissions</div>
+                        <div className="p2-new text-black-600 mt-2">Verify your email to see every response you&apos;ve submitted to this workspace — and request deletion of any of them.</div>
                         <Button
                             className="mt-6"
                             size="sm"
@@ -92,8 +92,9 @@ export default function ResponderPortalLayoutClient({
                                 router.push(`/login?${params.toString()}`);
                             }}
                         >
-                            Verify Now
+                            Verify email
                         </Button>
+                        <div className="p4-new text-black-500 mt-3">Submitted anonymously? Use your submission number instead.</div>
                     </div>
                 )}
                 {auth.id && (
@@ -117,9 +118,9 @@ export default function ResponderPortalLayoutClient({
                                             <>
                                                 <Divider className="text-black-200" />
                                                 <div className="p4-new text-black-600 p-4">
-                                                    You have 0 workspace associated with this email.{' '}
+                                                    No workspace is associated with this email yet.{' '}
                                                     <ActiveLink target="_blank" href="https://bettercollected.com" className="text-blue-500">
-                                                        Try Bettercollected{' '}
+                                                        Try bettercollected{' '}
                                                     </ActiveLink>
                                                 </div>
                                             </>

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -73,8 +73,12 @@ export default function ResponderPortalLayoutClient({
     const basePath = hasCustomDomain ? '' : `/${workspace.workspaceName}`;
 
     return (
-        <div className={`max-w-screen !bg-[#F6F8FC] flex h-screen max-h-screen w-screen flex-col overflow-auto p-5 opacity-100 md:flex-row md:p-10 ${!hasCustomDomain ? '!pb-20' : ''}`}>
-            <div className="max-w-screen w-full md:sticky md:top-0 md:w-[320px] md:max-w-[320px]">
+        // Desktop: the page itself doesn't scroll — the sidebars are short, so
+        // only the central content column scrolls, the tab bar stays affixed,
+        // and a stable scrollbar gutter stops the layout flicker that used to
+        // happen the moment content grew past a screenful.
+        <div className={`max-w-screen !bg-[#F6F8FC] flex h-screen max-h-screen w-screen flex-col overflow-auto p-5 opacity-100 md:flex-row md:overflow-hidden md:p-10 ${!hasCustomDomain ? '!pb-20' : ''}`}>
+            <div className="max-w-screen w-full md:max-h-full md:w-[320px] md:max-w-[320px] md:overflow-y-auto">
                 <WorkspaceDetailsCard workspace={workspace} />
                 {!auth.id && !auth.isLoading && (
                     <div className="mt-6 flex flex-col rounded-xl bg-white p-6">
@@ -154,7 +158,7 @@ export default function ResponderPortalLayoutClient({
                     </a>
                 )}
             </div>
-            <div className="flex-1 md:pl-12 !pb-4">
+            <div className="flex flex-1 flex-col !pb-4 md:min-h-0 md:min-w-0 md:pl-12">
                 <div className="flex space-x-1 border-b border-gray-200 overflow-x-auto pb-0">
                     {tabs.map((tab) => {
                         const isActive = pathname.includes(tab.path) || (tab.path === 'forms' && (pathname === basePath || pathname === `${basePath}/`));
@@ -175,7 +179,7 @@ export default function ResponderPortalLayoutClient({
                         );
                     })}
                 </div>
-                <div className="mt-4 flex gap-6 flex-col xl:flex-row">
+                <div className="mt-4 flex flex-col gap-6 md:min-h-0 md:flex-1 md:overflow-y-auto md:[scrollbar-gutter:stable] xl:flex-row">
                     {children}
                     <SearchBySubmissionNumber className='hidden xl:block' />
                 </div>

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -19,7 +19,6 @@ import { Logout } from '@app/components/icons/logout-icon';
 import { TrashIcon } from '@app/components/icons/trash';
 import { useModal } from '@app/components/modal-views/context';
 import ActiveLink from '@app/components/ui/links/active-link';
-import Logo from '@app/components/ui/logo';
 import PoweredBy from '@app/components/ui/powered-by';
 import { localesCommon } from '@app/constants/locales/common';
 import { formConstant } from '@app/constants/locales/form';
@@ -146,11 +145,12 @@ export default function ResponderPortalLayoutClient({
                     Search your form response by submission number
                 </div>
 
+                {/* Attribution, not advertisement: a quiet caption, not a card
+                    competing with the workspace's own identity. */}
                 {!hasCustomDomain && (
-                    <div className="shadow-powered-by mt-6 hidden w-full gap-2 rounded bg-white p-3 md:flex">
-                        <span className="body3 text-black-700">Powered by:</span>
-                        <Logo showProTag={false} isLink={false} isCustomDomain className="h-[14px] w-fit" />
-                    </div>
+                    <a href="https://bettercollected.com/" target="_blank" rel="noopener noreferrer" className="text-black-500 hover:text-black-700 mt-6 hidden w-full justify-center text-xs md:flex">
+                        Powered by&nbsp;<span className="font-semibold">bettercollected</span>
+                    </a>
                 )}
             </div>
             <div className="flex-1 md:pl-12 !pb-4">

--- a/webapp/src/components/responder-portal/search-by-submission-number.tsx
+++ b/webapp/src/components/responder-portal/search-by-submission-number.tsx
@@ -29,7 +29,7 @@ const SearchBySubmissionNumber = ({ className }: { className?: string }) => {
             submissionUUID: submissionNumber
         });
         if (response.data) {
-            const submissionUrl = isCustomDomain ? `/submissions/uuid/${submissionNumber}` : `/${workspace.workspaceName}/submissions/uuid/${submissionNumber}`;
+            const submissionUrl = isCustomDomain ? `/submissions/uuid/${submissionNumber}/form` : `/${workspace.workspaceName}/submissions/uuid/${submissionNumber}/form`;
             router.push(submissionUrl);
         }
         if (response.error) {

--- a/webapp/src/components/responder-portal/search-by-submission-number.tsx
+++ b/webapp/src/components/responder-portal/search-by-submission-number.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { FormEvent, useState } from 'react';
 
-import Image from 'next/legacy/image';
 import { useRouter } from 'next/navigation';
 
 import InfoIcon from '@Components/icons/info.icon';
@@ -41,11 +40,13 @@ const SearchBySubmissionNumber = ({ className }: { className?: string }) => {
     return (
         <form onSubmit={handleSubmit} className={className}>
             <div className="flex w-full max-w-[367px] flex-col items-center justify-center rounded-xl bg-white px-6 py-8 xl:w-[367px]">
-                <Image src={'/images/search_submission.png'} alt="Seacch by sub number" height={62} width={77} />
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#E9EFFC]" aria-hidden="true">
+                    <SearchIcon className="text-[#2456CC]" width={22} height={22} strokeWidth={2} />
+                </div>
 
                 <div className="mt-4">
-                    <div className="h4-new text-new-black-800 text-center font-medium">Search by submission number</div>
-                    <div className="p2-new text-black-700 mt-2 !text-center">Enter your submission number to see your form response.</div>
+                    <div className="h4-new text-new-black-800 text-center font-medium">Find a response by its number</div>
+                    <div className="p2-new text-black-700 mt-2 !text-center">Every submission gets a receipt number — enter it to view (or request deletion of) that response.</div>
                 </div>
                 <div className="mt-4 flex w-full gap-4">
                     <AppInput
@@ -56,19 +57,20 @@ const SearchBySubmissionNumber = ({ className }: { className?: string }) => {
                             setSubmissionNumber(event.target.value);
                         }}
                         placeholder="Enter submission number"
+                        aria-label="Submission number"
                         className="w-full flex-1"
                     />
 
-                    <button type="submit" className=" active:bg-black-300 bg-black-200 flex items-center justify-center rounded p-3">
-                        <SearchIcon className="text-black-700" width={16} height={16} strokeWidth={2} />
+                    <button type="submit" aria-label="Search" className="flex items-center justify-center rounded bg-[#2456CC] p-3 hover:bg-[#1E49AD]">
+                        <SearchIcon className="text-white" width={16} height={16} strokeWidth={2} />
                     </button>
                 </div>
-                <div className="mt-2 text-xs text-red-500">
+                <div className="mt-2 text-xs text-[#C43D3D]">
                     {error && (
                         <div className="flex gap-2">
                             {' '}
                             <span>
-                                <InfoIcon className="text-red-500" width={16} height={16} />
+                                <InfoIcon className="text-[#C43D3D]" width={16} height={16} />
                             </span>
                             The submission number does not match with any form responses
                         </div>

--- a/webapp/src/components/responder-portal/submission-layout-client.tsx
+++ b/webapp/src/components/responder-portal/submission-layout-client.tsx
@@ -4,27 +4,27 @@ import cn from 'classnames';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
-import Divider from '@Components/common/divider';
-import { DotIcon } from '@Components/icons/dot-icon';
-
-
-import { ChevronLeft, Eye, Settings } from 'lucide-react';
+import { ChevronLeft, Eye, Shield as ShieldIcon, Trash2 } from 'lucide-react';
 
 import FullScreenLoader from '@app/components/ui/fullscreen-loader';
-import { localesCommon } from '@app/constants/locales/common';
 import TopNavLayout from '@app/layouts/top-navbar-layout';
-import { utcToLocalDate } from '@app/utils/date-utils';
-import FormProviderIcon from '@Components/icons/form-provider-icon';
+import { utcToLocalDateTIme } from '@app/utils/date-utils';
 import { useSubmissionContext } from './submission-context';
 
+/**
+ * The submission detail is part of the responder portal journey (receipt →
+ * response → deletion), so it wears the same clothes: surface wash, white
+ * cards, receipt identity (number · time · anonymous), portal tab treatment.
+ * It used to be a bare white page with its own tab style — responders landed
+ * on what looked like a different product right when they were exercising
+ * their data rights.
+ */
 export default function SubmissionLayoutClient({ children }: { children: React.ReactNode }) {
     const { data, isLoading, isError, hasCustomDomain, workspaceName } = useSubmissionContext();
     const form: any = data ?? {};
     const router = useRouter();
     const pathname = usePathname();
-    const { t } = useTranslation();
 
     const goToSubmissions = () => {
         let pathName;
@@ -41,18 +41,15 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
     const isSettings = pathname?.endsWith('/settings');
     const basePath = isSettings ? pathname.replace('/settings', '') : pathname?.replace('/form', '');
 
-    // Check if we are at root (e.g. just [id]), then form/settings links need to append
-    // If pathname is .../[id], then basePath is pathname.
-
     const tabs = [
         {
             icon: <Eye className="h-5 w-5" />,
-            title: 'Form',
+            title: 'My response',
             path: 'form'
         },
         {
-            icon: <Settings className="h-5 w-5" />,
-            title: t(localesCommon.settings),
+            icon: <Trash2 className="h-5 w-5" />,
+            title: 'Privacy & deletion',
             path: 'settings'
         }
     ];
@@ -63,29 +60,40 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
         );
     }
 
-    return (
-        <TopNavLayout className="bg-white !px-0" showAuthAccount={false} isCustomDomain={hasCustomDomain} isClientDomain={!hasCustomDomain} showNavbar={true}>
-            <div className="mt-5 flex flex-col pb-6">
-                <div className="w-full px-5">
-                    <div className="flex w-fit items-center justify-start gap-2 " onClick={goToSubmissions}>
-                        <ChevronLeft className="cursor-pointer" strokeWidth={2} width={20} height={20} />
-                        <span className="text-black-800 cursor-pointer text-sm">My submissions</span>
-                        <span className="text-black-400 text-sm" aria-hidden="true">/</span>
-                        <span className="text-black-600  text-sm">My response</span>
-                    </div>
-                </div>
-                <div className="mt-12 flex w-full flex-col gap-2 px-5 md:px-10 lg:px-28">
-                    <span className="text-black-900 h2-new">{form?.form?.title || 'Untitled Form'}</span>
-                    <div className="text-black-600 flex flex-wrap items-center gap-2 text-sm">
-                        <FormProviderIcon provider={form?.form?.settings?.provider} />
-                        <DotIcon />
-                        <div className="min-w-fit">Submitted: {utcToLocalDate(form?.response?.createdAt)}</div>
-                    </div>
-                    <Divider className="mt-2" />
-                </div>
+    const response = form?.response ?? {};
+    const isAnonymous = !response?.dataOwnerIdentifier;
 
-                <div className="w-full mt-3 px-5 md:px-10 lg:px-28">
-                    <div className="flex space-x-1 border-b border-gray-200 overflow-x-auto pb-0">
+    return (
+        <TopNavLayout className="!bg-[#F6F8FC] !px-0" showAuthAccount={false} isCustomDomain={hasCustomDomain} isClientDomain={!hasCustomDomain} showNavbar={true}>
+            <div className="mx-auto mt-5 flex w-full max-w-[960px] flex-col gap-4 px-5 pb-10">
+                <button type="button" className="text-black-700 hover:text-black-900 flex w-fit items-center gap-1 text-sm" onClick={goToSubmissions}>
+                    <ChevronLeft strokeWidth={2} width={18} height={18} />
+                    My submissions
+                </button>
+
+                {/* The receipt header: the same identity the list card shows,
+                    so responders know they opened the right response. */}
+                <div className="w-full rounded-xl bg-white p-6">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="text-black-900 h3-new">{form?.form?.title || 'Untitled Form'}</span>
+                        {response?.submissionUuid && (
+                            <span className="bg-black-100 text-black-700 rounded px-2 py-0.5 font-mono text-xs" title="Your submission number — you can also search by it">
+                                #{response.submissionUuid}
+                            </span>
+                        )}
+                    </div>
+                    <div className="text-black-600 mt-2 flex flex-wrap items-center gap-2 text-sm">
+                        <span>Submitted: {utcToLocalDateTIme(response?.createdAt)}</span>
+                        {isAnonymous && (
+                            <span className="flex items-center gap-1 rounded-full bg-[#E7F4EE] px-2 py-0.5 text-xs font-medium text-[#0E8A5F]" title="Submitted without your identity attached">
+                                <ShieldIcon className="h-3 w-3" strokeWidth={2} />
+                                Anonymous
+                            </span>
+                        )}
+                        {!!response?.deletionStatus && <span className="rounded bg-[#FBF3E4] px-2 py-0.5 text-xs font-medium text-[#B26B00]">Deletion requested</span>}
+                    </div>
+
+                    <div className="border-b-black-200 mt-6 flex space-x-1 overflow-x-auto border-b pb-0">
                         {tabs.map((tab) => {
                             const isActive = pathname?.endsWith(`/${tab.path}`);
                             return (
@@ -93,10 +101,8 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
                                     key={tab.path}
                                     href={`${basePath}/${tab.path}`}
                                     className={cn(
-                                        'flex items-center border-b-2 gap-2 px-4 py-2 text-sm font-medium cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap focus:outline-none',
-                                        isActive
-                                            ? 'border-black-900 text-black-900'
-                                            : 'text-gray-500 border-transparent hover:text-gray-700'
+                                        'mb-[-1px] flex cursor-pointer items-center gap-2 whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium focus:outline-none',
+                                        isActive ? 'text-black-900 border-[#2456CC]' : 'text-black-600 hover:text-black-900 border-transparent'
                                     )}
                                 >
                                     {tab.icon}
@@ -106,7 +112,7 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
                         })}
                     </div>
 
-                    <div className="mt-4">
+                    <div className="mt-6">
                         {children}
                     </div>
                 </div>

--- a/webapp/src/components/responder-portal/submission-layout-client.tsx
+++ b/webapp/src/components/responder-portal/submission-layout-client.tsx
@@ -7,8 +7,10 @@ import React from 'react';
 
 import { ChevronLeft, Eye, Shield as ShieldIcon, Trash2 } from 'lucide-react';
 
+import AuthAccountProfileImage from '@app/components/auth/account-profile-image';
 import FullScreenLoader from '@app/components/ui/fullscreen-loader';
-import TopNavLayout from '@app/layouts/top-navbar-layout';
+import { useAppSelector } from '@app/store/hooks';
+import { selectWorkspace } from '@app/store/workspaces/slice';
 import { utcToLocalDateTIme } from '@app/utils/date-utils';
 import { useSubmissionContext } from './submission-context';
 
@@ -22,9 +24,11 @@ import { useSubmissionContext } from './submission-context';
  */
 export default function SubmissionLayoutClient({ children }: { children: React.ReactNode }) {
     const { data, isLoading, isError, hasCustomDomain, workspaceName } = useSubmissionContext();
+    const workspace = useAppSelector(selectWorkspace);
     const form: any = data ?? {};
     const router = useRouter();
     const pathname = usePathname();
+    const portalBase = hasCustomDomain ? '' : `/${workspaceName ?? ''}`;
 
     const goToSubmissions = () => {
         let pathName;
@@ -64,8 +68,18 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
     const isAnonymous = !response?.dataOwnerIdentifier;
 
     return (
-        <TopNavLayout className="!bg-[#F6F8FC] !px-0" showAuthAccount={false} isCustomDomain={hasCustomDomain} isClientDomain={!hasCustomDomain} showNavbar={true}>
-            <div className="mx-auto mt-5 flex w-full max-w-[960px] flex-col gap-4 px-5 pb-10">
+        // This page belongs to the WORKSPACE's branded space (possibly their
+        // custom domain). The platform wordmark up top read as a jarring brand
+        // switch mid-journey — the workspace's own identity leads instead, and
+        // bettercollected stays where the portal keeps it: a quiet caption.
+        <div className="flex min-h-screen w-full flex-col !bg-[#F6F8FC]">
+            <header className="border-b-black-200 sticky top-0 z-20 border-b bg-white">
+                <Link href={`${portalBase}/forms`} className="mx-auto flex w-full max-w-[960px] items-center gap-2.5 px-5 py-3">
+                    <AuthAccountProfileImage variant="circular" size={32} image={workspace?.profileImage} name={workspace?.title || workspaceName || 'W'} />
+                    <span className="text-black-900 text-sm font-semibold">{workspace?.title || workspaceName}</span>
+                </Link>
+            </header>
+            <div className="mx-auto mt-5 flex w-full max-w-[960px] flex-1 flex-col gap-4 px-5 pb-10">
                 <button type="button" className="text-black-700 hover:text-black-900 flex w-fit items-center gap-1 text-sm" onClick={goToSubmissions}>
                     <ChevronLeft strokeWidth={2} width={18} height={18} />
                     My submissions
@@ -117,6 +131,11 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
                     </div>
                 </div>
             </div>
-        </TopNavLayout>
+            {!hasCustomDomain && (
+                <a href="https://bettercollected.com/" target="_blank" rel="noopener noreferrer" className="text-black-500 hover:text-black-700 mx-auto pb-6 text-center text-xs">
+                    Powered by <span className="font-semibold">bettercollected</span>
+                </a>
+            )}
+        </div>
     );
 }

--- a/webapp/src/components/responder-portal/submission-layout-client.tsx
+++ b/webapp/src/components/responder-portal/submission-layout-client.tsx
@@ -68,14 +68,14 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
             <div className="mt-5 flex flex-col pb-6">
                 <div className="w-full px-5">
                     <div className="flex w-fit items-center justify-start gap-2 " onClick={goToSubmissions}>
-                        <ChevronLeft className="cursor-pointer" strokeWidth={2} width={24} height={24} />
-                        <span className="text-black-800 cursor-pointer text-sm">Form Page</span>
-                        <ChevronLeft className="text-black-600 " strokeWidth={1} width={24} height={24} />
-                        <span className="text-black-600  text-sm"> My response</span>
+                        <ChevronLeft className="cursor-pointer" strokeWidth={2} width={20} height={20} />
+                        <span className="text-black-800 cursor-pointer text-sm">My submissions</span>
+                        <span className="text-black-400 text-sm" aria-hidden="true">/</span>
+                        <span className="text-black-600  text-sm">My response</span>
                     </div>
                 </div>
                 <div className="mt-12 flex w-full flex-col gap-2 px-5 md:px-10 lg:px-28">
-                    <span className="!text-pink h2-new">{form?.form?.title || 'Untitled Form'}</span>
+                    <span className="text-black-900 h2-new">{form?.form?.title || 'Untitled Form'}</span>
                     <div className="text-black-600 flex flex-wrap items-center gap-2 text-sm">
                         <FormProviderIcon provider={form?.form?.settings?.provider} />
                         <DotIcon />

--- a/webapp/src/components/responder-portal/submission-layout-client.tsx
+++ b/webapp/src/components/responder-portal/submission-layout-client.tsx
@@ -8,7 +8,6 @@ import React from 'react';
 import { ChevronLeft, Eye, Shield as ShieldIcon, Trash2 } from 'lucide-react';
 
 import AuthAccountProfileImage from '@app/components/auth/account-profile-image';
-import FullScreenLoader from '@app/components/ui/fullscreen-loader';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import { utcToLocalDateTIme } from '@app/utils/date-utils';
@@ -59,8 +58,25 @@ export default function SubmissionLayoutClient({ children }: { children: React.R
     ];
 
     if (isLoading || isError || !data) {
+        // Keep the workspace-branded shell while loading — swapping the whole
+        // page for a white full-screen loader read as a flicker on every open.
         return (
-            <FullScreenLoader />
+            <div className="flex min-h-screen w-full flex-col !bg-[#F6F8FC]">
+                <header className="border-b-black-200 sticky top-0 z-20 border-b bg-white">
+                    <div className="mx-auto flex w-full max-w-[960px] items-center gap-2.5 px-5 py-3">
+                        <AuthAccountProfileImage variant="circular" size={32} image={workspace?.profileImage} name={workspace?.title || workspaceName || 'W'} />
+                        <span className="text-black-900 text-sm font-semibold">{workspace?.title || workspaceName}</span>
+                    </div>
+                </header>
+                <div className="mx-auto mt-5 flex w-full max-w-[960px] flex-1 flex-col gap-4 px-5 pb-10">
+                    <div className="bg-black-200 h-5 w-36 animate-pulse rounded" />
+                    <div className="w-full rounded-xl bg-white p-6">
+                        <div className="bg-black-100 h-7 w-64 animate-pulse rounded" />
+                        <div className="bg-black-100 mt-3 h-4 w-80 animate-pulse rounded" />
+                        <div className="bg-black-100 mt-8 h-40 w-full animate-pulse rounded" />
+                    </div>
+                </div>
+            </div>
         );
     }
 

--- a/webapp/src/components/responder-portal/submission-settings-context.tsx
+++ b/webapp/src/components/responder-portal/submission-settings-context.tsx
@@ -36,11 +36,11 @@ export default function SubmissionSettingsContent() {
             )}
             {!form?.response?.deletionStatus ? (
                 <div>
-                    <Tooltip label={deletionStatus ? t(toolTipConstant.alreadyRequestedForDeletion) : t(toolTipConstant.requestForDeletion)}>
-                        <Button className={`w-fit`} variant="danger" onClick={handleRequestForDeletionModal}>
-                            {t(buttonConstant.requestForDeletion)}
-                        </Button>
-                    </Tooltip>
+                    {/* No Tooltip wrapper: the shared Tooltip renders its own
+                        <button> trigger, nesting buttons (hydration error). */}
+                    <Button className={`w-fit`} variant="danger" title={deletionStatus ? t(toolTipConstant.alreadyRequestedForDeletion) : t(toolTipConstant.requestForDeletion)} onClick={handleRequestForDeletionModal}>
+                        {t(buttonConstant.requestForDeletion)}
+                    </Button>
                 </div>
             ) : (
                 <div className="flex flex-col gap-2">

--- a/webapp/src/components/responder-portal/submission-settings-context.tsx
+++ b/webapp/src/components/responder-portal/submission-settings-context.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import { useModal } from '@app/components/modal-views/context';
-import { buttonConstant } from '@app/constants/locales/button';
 import { toolTipConstant } from '@app/constants/locales/tooltip';
 import { Button } from '@app/shadcn/components/ui/button';
-import Tooltip from '@app/shadcn/components/ui/tooltip';
-import Divider from '@Components/common/divider';
+import { Shield } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useSubmissionContext } from './submission-context';
 
@@ -22,30 +20,28 @@ export default function SubmissionSettingsContent() {
     };
 
     return (
-        <div className="flex flex-col gap-[72px] px-5">
-            <div className="flex flex-col gap-2">
-                <span className="h3-new">Settings</span>
-                <span className="p2-new text-black-700"> Review your data usage permissions</span>
+        // The deletion right, stated in plain words and kept calm — this is a
+        // trust surface, not a danger zone (Design-Language §4/§5).
+        <div className="flex max-w-[640px] flex-col gap-4">
+            <div className="flex items-start gap-2 rounded-lg bg-[#F4F7FD] px-3 py-2.5">
+                <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#2456CC]" strokeWidth={1.8} aria-hidden="true" />
+                <span className="text-black-700 text-sm leading-relaxed">
+                    This response belongs to you. You can ask for it to be deleted at any time — the request and its status stay visible here and under Deletion requests.
+                </span>
             </div>
-            {form?.settings?.provider !== 'self' && (
-                <div className="flex max-w-[800px] flex-col gap-4">
-                    <Divider />
-                    <div className="h4-new">You can request for deletion of your data in this form.</div>
-                    <Divider />
-                </div>
-            )}
             {!form?.response?.deletionStatus ? (
-                <div>
+                <div className="flex flex-col gap-2">
                     {/* No Tooltip wrapper: the shared Tooltip renders its own
                         <button> trigger, nesting buttons (hydration error). */}
                     <Button className={`w-fit`} variant="danger" title={deletionStatus ? t(toolTipConstant.alreadyRequestedForDeletion) : t(toolTipConstant.requestForDeletion)} onClick={handleRequestForDeletionModal}>
-                        {t(buttonConstant.requestForDeletion)}
+                        Request deletion
                     </Button>
+                    <span className="text-black-600 text-xs">The workspace reviews deletion requests — you&apos;ll see the status change here once it&apos;s handled.</span>
                 </div>
             ) : (
                 <div className="flex flex-col gap-2">
-                    <span className="h4-new !text-red-500 ">You have requested for deletion of your response.</span>
-                    <span>Status: Pending</span>
+                    <span className="w-fit rounded bg-[#FBF3E4] px-2 py-1 text-sm font-medium text-[#B26B00]">Deletion requested · Pending</span>
+                    <span className="text-black-600 text-sm">The workspace has been asked to delete this response. Its status will update here and under Deletion requests.</span>
                 </div>
             )}
         </div>

--- a/webapp/src/components/responder-portal/submssion-form-content.tsx
+++ b/webapp/src/components/responder-portal/submssion-form-content.tsx
@@ -7,7 +7,7 @@ export default function SubmissionFormContent() {
     const { data } = useSubmissionContext();
     if (!data) return null;
     return (
-        <div className="mt-12 w-full">
+        <div className="w-full">
             <FormRenderer form={data.form} response={data.response} isDisabled />
         </div>
     );

--- a/webapp/src/components/responder-portal/workspace-details-card.tsx
+++ b/webapp/src/components/responder-portal/workspace-details-card.tsx
@@ -2,6 +2,7 @@ import AuthAccountProfileImage from '@app/components/auth/account-profile-image'
 import ActiveLink from '@app/components/ui/links/active-link';
 import { localesCommon } from '@app/constants/locales/common';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
+import { Shield } from 'lucide-react';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 
@@ -24,7 +25,13 @@ export default function WorkspaceDetailsCard({ workspace }: IWorkspaceDetailsCar
             <div className={`${workspace.bannerImage ? '-mt-8' : 'mt-4'}  p-6`}>
                 <div className="h4-new">{workspace?.title || 'Untitled Workspace'}</div>
                 {workspace?.description && <div className="p2-new text-black-600 mt-1">{workspace.description}</div>}
-                <div className="text-new-black-600 p4-new mt-8 flex justify-between gap-6">
+                {/* The trust anchor: this portal is where every form's "view or
+                    delete your response anytime" promise is kept. Say so here. */}
+                <div className="mt-4 flex items-start gap-2 rounded-lg bg-[#F4F7FD] px-3 py-2.5">
+                    <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#2456CC]" strokeWidth={1.8} aria-hidden="true" />
+                    <span className="text-black-700 text-sm leading-snug">You can view or delete your responses to this workspace&apos;s forms anytime.</span>
+                </div>
+                <div className="text-new-black-600 p4-new mt-6 flex justify-between gap-6">
                     <ActiveLink target="_blank" className="p4-new !text-black-600 !not-italic !leading-none" href={workspace.termsOfService ?? `https://bettercollected.com/terms-of-service/`}>
                         {t(localesCommon.termsOfServices.title)}
                     </ActiveLink>

--- a/webapp/src/components/submission-request-for-deletion/submission-request-for-deletion.tsx
+++ b/webapp/src/components/submission-request-for-deletion/submission-request-for-deletion.tsx
@@ -8,5 +8,16 @@ import { formConstant } from '@app/constants/locales/form';
 export default function RequestForDeletionView(props: any) {
     const { handleRequestForDeletion } = props;
     const { t } = useTranslation();
-    return <GenericHalfModal type="danger" headerTitle="Request for Deletion" title={t(formConstant.deletionResponseWarningMessage)} positiveAction={handleRequestForDeletion} positiveText="Yes" negativeText="No" />;
+    return (
+        // Buttons say what they do — "Yes/No" makes people re-read the question.
+        <GenericHalfModal
+            type="danger"
+            headerTitle="Request deletion"
+            title={t(formConstant.deletionResponseWarningMessage)}
+            subTitle="The workspace will be asked to delete this response. The request and its status stay visible to you here and under Deletion requests."
+            positiveAction={handleRequestForDeletion}
+            positiveText="Request deletion"
+            negativeText="Cancel"
+        />
+    );
 }

--- a/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
+++ b/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
@@ -34,7 +34,9 @@ export default function WorkspaceFormResponseDeletionCard({ response, deletionRe
 
     const Component = disabled ? DefaultDiv : Link;
 
-    const pathname = disabled ? '' : isCustomDomain ? `/submissions/${response.responseId}` : `/${workspaceName}/submissions/${response.responseId}`
+    // Link straight to the default tab: the bare id route only server-redirects
+    // to /form, which showed as a URL hop + reload flicker on every open.
+    const pathname = disabled ? '' : isCustomDomain ? `/submissions/${response.responseId}/form` : `/${workspaceName}/submissions/${response.responseId}/form`
 
     const isAnonymous = !response?.dataOwnerIdentifier;
 

--- a/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
+++ b/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
@@ -1,12 +1,11 @@
 "use client";
 import { useTranslation } from 'next-i18next';
 
-import { DotIcon } from '@Components/icons/dot-icon';
+import { Shield as ShieldIcon } from 'lucide-react';
 
 import { localesCommon } from '@app/constants/locales/common';
 import { StandardFormResponseDto } from '@app/models/dtos/form';
-import { utcToLocalDate } from '@app/utils/date-utils';
-import FormProviderIcon from '@Components/icons/form-provider-icon';
+import { utcToLocalDate, utcToLocalDateTIme } from '@app/utils/date-utils';
 import Link from 'next/link';
 
 
@@ -20,8 +19,15 @@ interface IWorkspaceFormResponseDeletionCardProps {
 
 const DefaultDiv = (props: any) => <div {...props} />;
 
+/**
+ * A submission receipt. Its whole job is to let a responder pick THEIR
+ * response out of a list — so it must carry what identifies one: the
+ * submission number, the exact time, and whether it was anonymous. (It used
+ * to show only the form title and a date, so three submissions to the same
+ * form were indistinguishable.)
+ */
 export default function WorkspaceFormResponseDeletionCard({ response, deletionRequests = false, className = '', workspaceName, isCustomDomain = false }: IWorkspaceFormResponseDeletionCardProps) {
-    const submittedAt = `${utcToLocalDate(response.updatedAt)}`;
+    const deletedAt = `${utcToLocalDate(response.updatedAt)}`;
     const { t } = useTranslation();
 
     const disabled = deletionRequests && response.status === 'success';
@@ -30,6 +36,7 @@ export default function WorkspaceFormResponseDeletionCard({ response, deletionRe
 
     const pathname = disabled ? '' : isCustomDomain ? `/submissions/${response.responseId}` : `/${workspaceName}/submissions/${response.responseId}`
 
+    const isAnonymous = !response?.dataOwnerIdentifier;
 
     return (
         <Component
@@ -37,19 +44,30 @@ export default function WorkspaceFormResponseDeletionCard({ response, deletionRe
             className={`relative flex flex-col items-start justify-between h-full bg-white border-[1px] border-brand-100 ${disabled ? 'opacity-60 !text-black-600' : 'shadow-formCardDefault hover:border-brand-200  hover:shadow-formCard'
                 } rounded ${className}`}
         >
-            <div className="rounded w-full px-5 py-4 flex flex-col gap-4 items-start justify-between">
-                <div>{response?.formTitle || t(localesCommon.untitled)}</div>
+            <div className="rounded w-full px-5 py-4 flex flex-col gap-3 items-start justify-between">
+                <div className="flex w-full flex-wrap items-center justify-between gap-2">
+                    <span className="text-black-800 font-medium">{response?.formTitle || t(localesCommon.untitled)}</span>
+                    {response?.submissionUuid && (
+                        // Mono per the design language: precise, sensitive identifiers.
+                        <span className="bg-black-100 text-black-700 rounded px-2 py-0.5 font-mono text-xs" title="Your submission number — you can also search by it">
+                            #{response.submissionUuid}
+                        </span>
+                    )}
+                </div>
                 <div className="text-black-600 text-sm flex items-center gap-2 flex-wrap">
-                    <FormProviderIcon provider={response?.provider} />
-                    <DotIcon />
                     <span>
-                        {t(localesCommon.lastSubmittedAt)} {utcToLocalDate(response.createdAt)}
+                        {t(localesCommon.lastSubmittedAt)} {utcToLocalDateTIme(response.createdAt)}
                     </span>
+                    {isAnonymous && (
+                        <span className="flex items-center gap-1 rounded-full bg-[#E7F4EE] px-2 py-0.5 text-xs font-medium text-[#0E8A5F]" title="Submitted without your identity attached">
+                            <ShieldIcon className="h-3 w-3" strokeWidth={2} />
+                            Anonymous
+                        </span>
+                    )}
                     {!!response?.status && (
-                        <>
-                            <DotIcon />
-                            <div className={`text-sm ${response?.status === 'pending' ? 'text-pink' : 'text-black-600'}`}>{response?.status === 'pending' ? 'Requested for deletion' : `Deleted (${submittedAt})`}</div>
-                        </>
+                        <span className={`rounded px-2 py-0.5 text-xs font-medium ${response?.status === 'pending' ? 'bg-[#FBF3E4] text-[#B26B00]' : 'bg-black-100 text-black-600'}`}>
+                            {response?.status === 'pending' ? 'Deletion requested' : `Deleted (${deletedAt})`}
+                        </span>
                     )}
                 </div>
             </div>

--- a/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
+++ b/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
@@ -56,7 +56,7 @@ export default function WorkspaceFormResponseDeletionCard({ response, deletionRe
                 </div>
                 <div className="text-black-600 text-sm flex items-center gap-2 flex-wrap">
                     <span>
-                        {t(localesCommon.lastSubmittedAt)} {utcToLocalDateTIme(response.createdAt)}
+                        {deletionRequests ? 'Requested:' : t(localesCommon.lastSubmittedAt)} {utcToLocalDateTIme(response.createdAt)}
                     </span>
                     {isAnonymous && (
                         <span className="flex items-center gap-1 rounded-full bg-[#E7F4EE] px-2 py-0.5 text-xs font-medium text-[#0E8A5F]" title="Submitted without your identity attached">

--- a/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
@@ -24,6 +24,7 @@ import { useGroupForm } from '@app/lib/hooks/use-group-form';
 import { StandardFormDto } from '@app/models/dtos/form';
 import { ResponderGroupDto } from '@app/models/dtos/groups';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
+import { getFormFields } from '@app/utils/form-builder-block-utils';
 import getFormShareURL from '@app/utils/form-utils';
 import { getEditFormURL } from '@app/utils/url-utils';
 import { validateFormOpen } from '@app/utils/vvalidation-utils';
@@ -95,7 +96,29 @@ export default function WorkspaceFormCard({ form, hasCustomDomain, group, worksp
                             </div>
                         )}
                     </div>
-                    <div className="flex max-w-full flex-wrap items-center gap-2">
+                    {/* Responders don't care which platform built the form or that a
+                        public form is "Public" — they care what it's for and how big
+                        it is. Creator metadata stays on the admin dashboard. */}
+                    {isResponderPortal && form?.settings?.purpose && <p className="text-black-600 line-clamp-2 text-sm">{form.settings.purpose}</p>}
+                    {isResponderPortal && (
+                        <div className="text-black-600 flex max-w-full flex-wrap items-center gap-2 text-sm">
+                            {(() => {
+                                const questionCount = Array.isArray(form?.fields) ? getFormFields(form).length : 0;
+                                return questionCount > 0 ? (
+                                    <span>
+                                        {questionCount} question{questionCount === 1 ? '' : 's'}
+                                    </span>
+                                ) : null;
+                            })()}
+                            {showPinned && form?.settings?.pinned && (
+                                <>
+                                    <DotIcon />
+                                    <span className="text-sm font-medium text-[#B26B00]">{t('FORM.PINNED')}</span>
+                                </>
+                            )}
+                        </div>
+                    )}
+                    <div className={`flex max-w-full flex-wrap items-center gap-2 ${isResponderPortal ? 'hidden' : ''}`}>
                         <FormProviderIcon provider={form.settings?.provider === 'self' && form.importedFormId && form.settings.showOriginalForm ? 'google' : form?.settings?.provider} />
                         {showVisibility && (
                             <Tooltip label={form?.settings?.private ? t(toolTipConstant.hideForm) : ''}>

--- a/webapp/src/models/dtos/form.ts
+++ b/webapp/src/models/dtos/form.ts
@@ -90,6 +90,7 @@ export interface StandardFormDto {
         buttonText?: string;
     };
     thankyouPage?: Array<{
+        title?: string;
         message?: string;
         buttonText?: string;
         buttonLink?: string;

--- a/webapp/src/models/dtos/form.ts
+++ b/webapp/src/models/dtos/form.ts
@@ -153,6 +153,10 @@ export interface StandardFormResponseDto {
     updatedAt: string | Date;
     formImportedBy?: string;
     status?: string;
+    /** The receipt number responders use to find/delete this response. */
+    submissionUuid?: string;
+    /** Set (instead of dataOwnerIdentifier) when submitted anonymously. */
+    anonymousIdentity?: string;
     requestForDeletion?: boolean;
     expiration?: string;
     expirationType?: any;

--- a/webapp/src/shadcn/components/ui/button.tsx
+++ b/webapp/src/shadcn/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva('rounded-lg gap-2 min-w-fit flex justify-center items
     variants: {
         variant: {
             primary: 'bg-brand-500 text-white hover:bg-brand-600 active:bg-brand-800 focus:ring ' + 'disabled:bg-black-300 disabled:text-black-500',
-            danger: 'bg-red-400 text-white hover:bg-red-500 disabled:bg-black-300 disabled:text-black-500',
+            danger: 'bg-[#C43D3D] text-white hover:bg-[#A83434] disabled:bg-black-300 disabled:text-black-500',
             tertiary: 'text-blue-500 border border-brand-500 hover:bg-brand-100 focus:ring focus:ring-blue-500 ' + 'active:bg-brand-600 disabled:bg-transparent disabled:border disabled:text-black-500 ' + 'disabled:border-black-300',
             secondary: 'bg-black-800 text-white hover:bg-black-900 focus:ring-blue-500 focus-ring active:bg-black-900' + 'disabled:bg-black-300 disabled:text-black-500',
             ghost: 'text-brand-500 border border-transparent hover:bg-black-200 outline-none ' + 'active:border-brand-500 active:bg-black-300 disabled:bg-black-300 disabled:text-black-500',

--- a/webapp/src/store/jotai/form.ts
+++ b/webapp/src/store/jotai/form.ts
@@ -16,6 +16,7 @@ export interface IFormState {
         buttonText?: string;
     };
     thankyouPage?: Array<{
+        title?: string;
         message?: string;
         buttonText?: string;
         buttonLink?: string;
@@ -97,6 +98,10 @@ export function useFormState() {
         }));
     };
 
+    const setThankYouPageTitle = (thankyouPageIndex: number, title?: string) => {
+        setFormState((prev) => patchThankYouPage(prev, thankyouPageIndex, { title }));
+    };
+
     const setThankYouPageDescription = (thankyouPageIndex: number, description?: string) => {
         setFormState((prev) => patchThankYouPage(prev, thankyouPageIndex, { message: description }));
     };
@@ -151,6 +156,7 @@ export function useFormState() {
         setFormState,
         setFormDescription,
         setWelcomePageButtonText,
+        setThankYouPageTitle,
         setThankYouPageDescription,
         setThankYouPageButtonText,
         setThankYouPageButtonLink,

--- a/webapp/src/views/molecules/form-builder/builder-trust-strip.tsx
+++ b/webapp/src/views/molecules/form-builder/builder-trust-strip.tsx
@@ -25,6 +25,7 @@ export function BuilderTrustStrip() {
             purpose={standardForm?.settings?.purpose}
             retention={standardForm?.settings?.retentionText}
             privacyUrl={standardForm?.settings?.privacyPolicyUrl}
+            poweredBy={!standardForm?.settings?.disableBranding}
         />
     );
 }

--- a/webapp/src/views/molecules/form-builder/preview-wrapper.tsx
+++ b/webapp/src/views/molecules/form-builder/preview-wrapper.tsx
@@ -105,6 +105,7 @@ const PreviewWrapper = ({ children, handleResetResponderState }: { children: Rea
                                 purpose={standardForm?.settings?.purpose}
                                 retention={standardForm?.settings?.retentionText}
                                 privacyUrl={standardForm?.settings?.privacyPolicyUrl}
+                                poweredBy={!standardForm?.settings?.disableBranding}
                             />
                         </div>
                     </div>

--- a/webapp/src/views/molecules/form/trust-layer.test.tsx
+++ b/webapp/src/views/molecules/form/trust-layer.test.tsx
@@ -29,4 +29,12 @@ describe('TrustLayer — the privacy story on every form (Design-Language §4)',
         expect(screen.getByText(/schedule your appointment/i)).toBeInTheDocument();
         expect(screen.getByText(/kept for 90 days/i)).toBeInTheDocument();
     });
+
+    it('carries the product attribution only when branding is on — the strip is the single footer', () => {
+        const { rerender } = render(<TrustLayer ownerName="Acme" poweredBy />);
+        expect(screen.getByRole('link', { name: /powered by/i })).toHaveAttribute('href', 'https://bettercollected.com/');
+
+        rerender(<TrustLayer ownerName="Acme" />);
+        expect(screen.queryByText(/powered by/i)).not.toBeInTheDocument();
+    });
 });

--- a/webapp/src/views/molecules/form/trust-layer.tsx
+++ b/webapp/src/views/molecules/form/trust-layer.tsx
@@ -15,6 +15,13 @@ export interface TrustLayerProps {
     retention?: string;
     /** Link to the responder portal where a submission can be viewed/deleted. */
     portalUrl?: string;
+    /**
+     * Show "Powered by bettercollected" as the strip's last item. The strip is
+     * the form's single footer — attribution lives here rather than floating
+     * over page content (the thank-you page used to stack its own footer
+     * underneath this one). Off when the form's disableBranding setting is on.
+     */
+    poweredBy?: boolean;
 }
 
 /**
@@ -25,7 +32,7 @@ export interface TrustLayerProps {
  *
  * Presentational only: pass in data (see the wired usage on the fill page).
  */
-export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl, retention, portalUrl }: TrustLayerProps) {
+export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl, retention, portalUrl, poweredBy }: TrustLayerProps) {
     const items: React.ReactNode[] = [];
 
     if (ownerName) {
@@ -61,6 +68,13 @@ export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl,
             </span>
         )
     );
+    if (poweredBy) {
+        items.push(
+            <a key="powered-by" href="https://bettercollected.com/" target="_blank" rel="noopener noreferrer" className="text-black-600 hover:text-black-900 pointer-events-auto">
+                Powered by <span className="font-semibold">bettercollected</span>
+            </a>
+        );
+    }
 
     return (
         // 13px legible ink-2 — the strip that carries the product's differentiator

--- a/webapp/src/views/molecules/form/trust-layer.tsx
+++ b/webapp/src/views/molecules/form/trust-layer.tsx
@@ -36,13 +36,26 @@ export default function TrustLayer({ ownerName, ownerImage, purpose, privacyUrl,
     const items: React.ReactNode[] = [];
 
     if (ownerName) {
-        items.push(
-            <span key="owner" className="text-black-700 inline-flex items-center gap-1.5">
+        const owner = (
+            <>
                 {ownerImage ? (
                     <img src={ownerImage} alt="" className="h-4 w-4 rounded-full object-cover" />
                 ) : null}
                 Collected by <span className="text-black-900 font-semibold">{ownerName}</span>
-            </span>
+            </>
+        );
+        items.push(
+            // Provenance doubles as the way home: the owner chip links to the
+            // workspace portal (new tab — never interrupt an in-progress fill).
+            portalUrl ? (
+                <a key="owner" href={portalUrl} target="_blank" rel="noopener noreferrer" className="text-black-700 hover:text-black-900 pointer-events-auto inline-flex items-center gap-1.5">
+                    {owner}
+                </a>
+            ) : (
+                <span key="owner" className="text-black-700 inline-flex items-center gap-1.5">
+                    {owner}
+                </span>
+            )
         );
     }
     if (purpose) {

--- a/webapp/src/views/organism/form-builder/flow-view.tsx
+++ b/webapp/src/views/organism/form-builder/flow-view.tsx
@@ -257,17 +257,29 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
     const overlayIndex = slides.findIndex((s) => s.id === overlayId);
     const overlaySlide = overlayIndex >= 0 ? slides[overlayIndex] : undefined;
 
-    // Same scale-to-fit trick as the main editor: the slide lays out at viewport
-    // size and is CSS-scaled into the available overlay area.
-    const overlayScaleStyle = useMemo(() => {
-        if (typeof window === 'undefined' || !overlaySlide) return undefined;
-        const availW = window.innerWidth - 280 - 120; // properties drawer + margins
-        const availH = window.innerHeight - 150;
-        if (availW / (16 / 9) > availH) {
-            return { height: '100vh', scale: availH / window.innerHeight, transformOrigin: 'top left' } as React.CSSProperties;
-        }
-        return { width: '100vw', scale: availW / window.innerWidth, transformOrigin: 'top left' } as React.CSSProperties;
-    }, [overlaySlide]);
+    // Same measured-scale approach as the main editor: the slide lays out at
+    // its true 1440×810 design size and is scaled to fit the overlay's mat,
+    // with the wrapper sized to the visual card so centring is exact. (The
+    // old window-arithmetic version left the sheet off-centre in dead space.)
+    const SLIDE_W = 1440;
+    const SLIDE_H = 810;
+    const overlayMatRef = useRef<HTMLDivElement>(null);
+    const [overlayScale, setOverlayScale] = useState(0.5);
+    useEffect(() => {
+        const mat = overlayMatRef.current;
+        if (!mat) return;
+        const compute = () => {
+            const cs = getComputedStyle(mat);
+            const availableWidth = mat.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
+            const availableHeight = mat.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
+            setOverlayScale(Math.min(availableWidth / SLIDE_W, availableHeight / SLIDE_H, 1));
+        };
+        compute();
+        const observer = new ResizeObserver(compute);
+        observer.observe(mat);
+        return () => observer.disconnect();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [overlayId]);
 
     /* ------------ derive nodes/edges from the form model ------------ */
 
@@ -380,7 +392,12 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
     );
     useEffect(() => {
         setNodes(buildNodes());
-        setEdges(buildEdges());
+        // Edges one frame later: React Flow silently DROPS edges whose source/
+        // target handles aren't mounted yet, and same-tick node+edge updates
+        // intermittently lose that race — leaving the whole graph unlinked
+        // until something else touches the edges array.
+        const frame = requestAnimationFrame(() => setEdges(buildEdges()));
+        return () => cancelAnimationFrame(frame);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [modelSignature, traffic, armed, flowAnalytics, showInsights]);
 
@@ -544,9 +561,19 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
                             {autosaveStatus.state === 'error' && "Couldn't save — edit to retry"}
                         </span>
                     )}
+                    {/* Two instruments, labelled apart: node/edge counts replay the
+                        SUBMITTED responses (all-time), while journey tracking counts
+                        anonymous page-to-page sessions — including people who never
+                        submitted, and only since flow analytics was enabled. Shown
+                        unlabelled they read as the same number disagreeing. */}
+                    {showInsights && (traffic?.total ?? 0) > 0 && (
+                        <span className="text-black-600 mr-1 text-xs" title="All-time submitted responses — the population behind the node and edge counts">
+                            <span className="font-semibold">{traffic!.total}</span> response{traffic!.total === 1 ? '' : 's'}
+                        </span>
+                    )}
                     {showInsights && flowAnalytics && flowAnalytics.totalSessions > 0 && (
-                        <span className="text-black-600 mr-1 text-xs">
-                            {flowAnalytics.totalSessions} started · {flowAnalytics.submittedSessions} finished
+                        <span className="text-black-600 mr-1 text-xs" title="Anonymous page-to-page journeys since flow analytics was enabled — includes visitors who never submitted, which is where the drop-off chips come from">
+                            · journeys: {flowAnalytics.totalSessions} started · {flowAnalytics.submittedSessions} finished
                         </span>
                     )}
                     {showInsights && !insightsLoading && traffic?.total === 0 && (!flowAnalytics || flowAnalytics.totalSessions === 0) && <span className="text-black-500 mr-1 text-xs">No responses yet</span>}
@@ -637,7 +664,9 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
                             <div className="border-b-black-200 flex flex-col gap-2 border-b px-4 py-4">
                                 <div>
                                     <div className="text-black-600 text-[10px] font-semibold uppercase tracking-wide">Page {selectedIndex + 1}</div>
-                                    <div className="text-black-900 truncate text-sm font-semibold">{pageLabel(selectedSlide, selectedIndex).replace(/^Page \d+ · /, '') || 'Untitled page'}</div>
+                                    {/* The canvas card may truncate the question; the panel is
+                                        where the full text belongs — wrap, don't clip. */}
+                                    <div className="text-black-900 break-words text-sm font-semibold leading-snug">{pageLabel(selectedSlide, selectedIndex).replace(/^Page \d+ · /, '') || 'Untitled page'}</div>
                                 </div>
                                 <div className="flex items-center gap-2">
                                     <button onClick={() => openPageEditor(selectedSlide.id)} className="bg-brand-500 hover:bg-brand-600 flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white">
@@ -679,22 +708,45 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
             {overlaySlide && (
                 <div role="dialog" aria-modal="true" aria-label={`Edit page ${overlayIndex + 1}`} className="absolute inset-0 z-30 flex flex-col bg-black/40 p-5" onClick={() => setOverlayId(null)}>
                     <div className="flex min-h-0 flex-1 overflow-hidden rounded-xl bg-white shadow-2xl" onClick={(e) => e.stopPropagation()}>
-                        <div className="bg-new-white-200 relative flex min-w-0 flex-1 flex-col overflow-hidden">
-                            <div className="border-b-black-200 flex items-center justify-between border-b bg-white px-4 py-2.5">
-                                <div className="text-black-800 text-sm font-semibold">
-                                    Page {overlayIndex + 1} · <span className="text-black-500 font-normal">changes save automatically</span>
+                        <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden">
+                            <div className="border-b-black-200 flex items-center justify-between gap-4 border-b bg-white px-4 py-2.5">
+                                <div className="min-w-0">
+                                    <div className="text-black-600 text-[10px] font-semibold uppercase tracking-wide">Page {overlayIndex + 1}</div>
+                                    <div className="text-black-900 truncate text-sm font-semibold">{pageLabel(overlaySlide, overlayIndex).replace(/^Page \d+ · /, '') || 'Untitled page'}</div>
                                 </div>
-                                <button onClick={() => setOverlayId(null)} className="border-black-300 text-black-700 hover:border-brand-500 hover:text-brand-600 flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium">
-                                    <X className="h-3.5 w-3.5" /> Back to flow
-                                </button>
+                                <div className="flex shrink-0 items-center gap-3">
+                                    {/* Live save state beats the static "changes save automatically" claim. */}
+                                    <span aria-live="polite" className={'whitespace-nowrap text-xs ' + (autosaveStatus.state === 'error' ? 'font-medium text-[#B26B00]' : 'text-black-600')}>
+                                        {autosaveStatus.state === 'saving' && 'Saving…'}
+                                        {autosaveStatus.state === 'saved' && 'Saved'}
+                                        {autosaveStatus.state === 'error' && "Couldn't save — edit to retry"}
+                                        {autosaveStatus.state === 'idle' && 'Changes save automatically'}
+                                    </span>
+                                    <button onClick={() => setOverlayId(null)} className="border-black-300 text-black-700 hover:border-brand-500 hover:text-brand-600 flex items-center gap-1 rounded-md border px-2.5 py-1.5 text-xs font-medium">
+                                        <X className="h-3.5 w-3.5" /> Back to flow
+                                    </button>
+                                </div>
                             </div>
-                            <div className="flex min-h-0 flex-1 items-start justify-center overflow-auto p-6">
-                                <div className="!shadow-slide aspect-video overflow-hidden" style={overlayScaleStyle}>
-                                    <SlideBuilder slide={overlaySlide} />
+                            {/* Same mat + floating-sheet treatment as the main canvas, so
+                                "edit a page" looks identical wherever it happens. */}
+                            <div ref={overlayMatRef} className="flex min-h-0 flex-1 overflow-auto bg-[#E9EEF5] px-8 py-8" onClick={() => setActiveFieldComponent(null)}>
+                                <div className="m-auto shrink-0" style={{ width: SLIDE_W * overlayScale, height: SLIDE_H * overlayScale }}>
+                                    <div
+                                        className="border-black-400 overflow-hidden rounded-lg border bg-white"
+                                        style={{
+                                            width: SLIDE_W,
+                                            height: SLIDE_H,
+                                            transform: `scale(${overlayScale})`,
+                                            transformOrigin: 'top left',
+                                            boxShadow: '0px 1px 3px rgba(16, 24, 38, 0.06), 0px 12px 32px rgba(16, 24, 38, 0.12)'
+                                        }}
+                                    >
+                                        <SlideBuilder slide={overlaySlide} />
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div className="border-l-black-200 w-[280px] shrink-0 overflow-y-auto border-l bg-white">
+                        <div className="border-l-black-200 w-[300px] shrink-0 overflow-y-auto border-l bg-white">
                             <PropertiesDrawer />
                         </div>
                     </div>

--- a/webapp/src/views/organism/form-builder/flow-view.tsx
+++ b/webapp/src/views/organism/form-builder/flow-view.tsx
@@ -272,7 +272,8 @@ export default function FlowView({ onClose }: { onClose?: () => void }) {
             const cs = getComputedStyle(mat);
             const availableWidth = mat.clientWidth - parseFloat(cs.paddingLeft) - parseFloat(cs.paddingRight);
             const availableHeight = mat.clientHeight - parseFloat(cs.paddingTop) - parseFloat(cs.paddingBottom);
-            setOverlayScale(Math.min(availableWidth / SLIDE_W, availableHeight / SLIDE_H, 1));
+            // Uncapped: on large screens the sheet fills the overlay mat.
+            setOverlayScale(Math.min(availableWidth / SLIDE_W, availableHeight / SLIDE_H));
         };
         compute();
         const observer = new ResizeObserver(compute);

--- a/webapp/src/views/organism/form-builder/left-drawer.tsx
+++ b/webapp/src/views/organism/form-builder/left-drawer.tsx
@@ -124,7 +124,7 @@ function LeftDrawer({ formFields, activeSlideComponent }: { formFields: Array<St
                             label="Thank you"
                             selected={activeSlideComponent?.id === 'thank-you-page'}
                             onSelect={() => setActiveSlideComponent({ id: 'thank-you-page', index: -20 })}
-                            primaryText={formState.thankyouPage?.[0]?.message || undefined}
+                            primaryText={formState.thankyouPage?.[0]?.title || formState.thankyouPage?.[0]?.message || undefined}
                             secondaryText="Ending"
                         />
                     </div>

--- a/webapp/src/views/organism/form-builder/thankyou-page.tsx
+++ b/webapp/src/views/organism/form-builder/thankyou-page.tsx
@@ -9,13 +9,19 @@ import { IsValidString } from '@app/utils/string-utils';
 import GreetingLayoutWrapper from '../layout/greeting-layout-wrapper';
 
 const ThankYouSlide = ({ disabled }: { disabled?: boolean }) => {
-    const { formState, theme, setThankYouPageDescription } = useFormState();
+    const { formState, theme, setThankYouPageTitle, setThankYouPageDescription } = useFormState();
     const { activeThankYouPageComponent } = useActiveThankYouPageComponent();
     return (
         <GreetingLayoutWrapper disabled={disabled} greetingIndex={-20} theme={theme}>
             <div className={cn('flex w-full  items-start', formState.thankyouPage![activeThankYouPageComponent?.index || 0]?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : ' justify-center')}>
                 <div className="flex w-full max-w-[800px] flex-col items-start">
-                    <h1 className="text-[40px] font-semibold">Thank You! 🎉</h1>
+                    <AutosizeTextarea
+                        style={{ resize: 'none' }}
+                        placeholder="Thank You! 🎉"
+                        className="w-full border-0 px-0 py-0 text-[40px] font-semibold leading-[48px]"
+                        value={formState.thankyouPage![activeThankYouPageComponent?.index || 0]?.title ?? ''}
+                        onChange={(event: any) => setThankYouPageTitle(activeThankYouPageComponent?.index || 0, event.target.value)}
+                    />
                     {formState.thankyouPage && IsValidString(formState.thankyouPage[activeThankYouPageComponent?.index || 0].message) ? (
                         <AutosizeTextarea
                             placeholder="Your response has been successfully submitted"

--- a/webapp/src/views/organism/form/form.tsx
+++ b/webapp/src/views/organism/form/form.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 
 import { Progress } from '@app/shadcn/components/ui/progress';
 import { cn } from '@app/shadcn/util/lib';
@@ -11,8 +11,34 @@ import FormSlide from './form-slide';
 import ThankyouPage from './thankyou-page';
 import WelcomePage from './welcome-page';
 
+/**
+ * One slide transition for every page type. Each page used to declare its own
+ * animation (different easings, no exit motion at all — the old page froze
+ * while the new one covered it), and the ±100% fly-in wasn't clipped, so a
+ * horizontal scrollbar flashed on every transition.
+ *
+ * The entering page slides the full width in the direction of travel; the
+ * exiting page drifts a quarter width the other way while fading (parallax),
+ * which reads as one continuous surface. Honors prefers-reduced-motion with a
+ * plain cross-fade.
+ */
+const slideVariants = {
+    enter: (direction: number) => ({ x: direction >= 0 ? '100%' : '-100%', opacity: 1 }),
+    center: { x: 0, opacity: 1 },
+    exit: (direction: number) => ({ x: direction >= 0 ? '-24%' : '24%', opacity: 0 })
+};
+
+const fadeVariants = {
+    enter: { x: 0, opacity: 0 },
+    center: { x: 0, opacity: 1 },
+    exit: { x: 0, opacity: 0 }
+};
+
+const slideTransition = { duration: 0.35, ease: [0.32, 0.72, 0, 1] as [number, number, number, number] };
+
 const Form = ({ isPreviewMode = false, showDesktopLayout }: { isPreviewMode?: boolean; showDesktopLayout?: boolean }) => {
     const { currentSlide, prevActiveSlide: previousSlide } = useResponderState();
+    const prefersReducedMotion = useReducedMotion();
 
     const standardForm = useAppSelector(selectForm);
 
@@ -26,66 +52,52 @@ const Form = ({ isPreviewMode = false, showDesktopLayout }: { isPreviewMode?: bo
         return (currentSlideIndex / totalSlides) * 100;
     };
 
+    // Position of a slide along the journey: welcome → pages → thank-you.
+    // The sentinels (-1 welcome, -2 thank-you) don't compare numerically.
+    const ordinalOf = (slide: number) => {
+        if (slide === -1) return 0;
+        if (slide === -2) return (standardForm?.fields?.length || 0) + 1;
+        return slide + 1;
+    };
+    const direction = ordinalOf(currentSlide) >= ordinalOf(previousSlide) ? 1 : -1;
+    const variants = prefersReducedMotion ? fadeVariants : slideVariants;
+
     return (
-        <div className={cn(isPreviewMode ? 'h-full w-full  ' : 'h-screen w-screen', 'relative h-full w-full')}>
+        // overflow-hidden clips the ±100% fly-in/out — without it the document
+        // grows sideways mid-transition and a horizontal scrollbar flashes.
+        <div className={cn(isPreviewMode ? 'h-full w-full  ' : 'h-screen w-screen', 'relative h-full w-full overflow-hidden')}>
             {currentSlide !== -1 && (
-                <div className="absolute left-0 right-0 top-0 !z-[80] bg-green-500">
+                <div className="absolute left-0 right-0 top-0 !z-[80]">
                     <Progress indicatorColor={standardForm.theme?.secondary} value={getProgressValue()} className="h-1 rounded-none" />
                 </div>
             )}
-            <AnimatePresence mode="sync">
-                {currentSlide === -1 && (
-                    <motion.div
-                        key="welcome-page"
-                        {...({
-                            className: cn('absolute z-10 flex h-full w-full flex-1 flex-col items-center justify-center'),
-                            initial: { opacity: 1, x: currentSlide === previousSlide ? 0 : '-100%' },
-                            animate: { opacity: 1, x: 0 },
-                            exit: { opacity: 1, x: 0 },
-                            transition: { duration: 0.3 }
-                        } as any)}
-                    >
-                        <div className="relative h-full w-full">
+            <AnimatePresence mode="sync" initial={false} custom={direction}>
+                <motion.div
+                    key={currentSlide}
+                    {...({
+                        custom: direction,
+                        variants,
+                        initial: 'enter',
+                        animate: 'center',
+                        exit: 'exit',
+                        transition: slideTransition,
+                        className: 'absolute inset-0 z-10 flex h-full w-full flex-1 flex-col items-center justify-center'
+                    } as any)}
+                >
+                    <div className="relative h-full w-full">
+                        {currentSlide === -1 && (
                             <LayoutWrapper removePaddingXForSmallScreen showDesktopLayout={showDesktopLayout} theme={standardForm.theme} disabled layout={standardForm.welcomePage?.layout} imageUrl={standardForm?.welcomePage?.imageUrl}>
                                 <WelcomePage isPreviewMode={isPreviewMode} />
                             </LayoutWrapper>
-                        </div>
-                    </motion.div>
-                )}
-
-                {currentSlide >= 0 && (
-                    <motion.div
-                        key={currentSlide}
-                        {...({
-                            className: cn('absolute z-10 flex h-full w-full flex-1 flex-col items-center justify-center'),
-                            initial: { opacity: 1, x: currentSlide > previousSlide ? '100%' : '-100%' },
-                            animate: { opacity: 1, x: 0 },
-                            exit: { opacity: 1, x: 0 },
-                            transition: { duration: 0.3, ease: 'linear' }
-                        } as any)}
-                    >
-                        <div className="relative h-full w-full">
-                            <FormSlide showDesktopLayout={showDesktopLayout} index={currentSlide} isPreviewMode={isPreviewMode} />
-                        </div>
-                    </motion.div>
-                )}
-                {currentSlide === -2 && (
-                    <motion.div
-                        key="thank-you-page"
-                        {...({
-                            className: cn('absolute z-20 flex h-full w-full flex-1 flex-col items-center justify-center'),
-                            initial: { opacity: 1, x: '100%' },
-                            animate: { opacity: 1, x: 0 },
-                            transition: { duration: 0.3, ease: 'linear' }
-                        } as any)}
-                    >
-                        <div className="relative h-full w-full">
+                        )}
+                        {currentSlide >= 0 && <FormSlide showDesktopLayout={showDesktopLayout} index={currentSlide} isPreviewMode={isPreviewMode} />}
+                        {currentSlide === -2 && (
                             <LayoutWrapper showDesktopLayout={showDesktopLayout} theme={standardForm.theme} disabled layout={standardForm?.thankyouPage?.[0]?.layout} imageUrl={standardForm?.thankyouPage?.[0]?.imageUrl}>
                                 <ThankyouPage isPreviewMode={isPreviewMode} />
                             </LayoutWrapper>
-                        </div>
-                    </motion.div>
-                )}
+                        )}
+                    </div>
+                </motion.div>
             </AnimatePresence>
         </div>
     );

--- a/webapp/src/views/organism/form/thankyou-page.tsx
+++ b/webapp/src/views/organism/form/thankyou-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 import Link from 'next/link';
 
-import Logo from '@app/components/ui/logo';
 import { FormSlideLayout } from '@app/models/enums/form';
 import { Button } from '@app/shadcn/components/ui/button';
 import { useToast } from '@app/shadcn/components/ui/use-toast';
@@ -35,6 +34,14 @@ export default function ThankyouPage({ isPreviewMode }: { isPreviewMode: boolean
         return resolvePipesInText(message, { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues });
     }
 
+    // The heading is customizable (and pipeable) like the message; the classic
+    // greeting stays as the default for forms that never set one.
+    function getThankYouTitle() {
+        const title = standardForm?.thankyouPage?.[0]?.title;
+        if (!title) return 'Thank You! 🎉';
+        return resolvePipesInText(title, { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues });
+    }
+
     const handleOnCopy = (copyValue: string) => {
         copyToClipboard(copyValue);
         toast({
@@ -46,7 +53,7 @@ export default function ThankyouPage({ isPreviewMode }: { isPreviewMode: boolean
             <UserAvatarDropDown disabled />
             <div className=" flex h-full w-full max-w-[800px] flex-col justify-between">
                 <div className="flex">
-                    <span className="text-[40px] font-bold leading-[48px]">Thank You! 🎉</span>
+                    <span className="text-[40px] font-bold leading-[48px]">{getThankYouTitle()}</span>
                 </div>
                 <div className="p2-new text-black-700 mt-4">{getThankYouMessage()}</div>
                 {standardForm?.thankyouPage && standardForm?.thankyouPage[0].buttonText && (
@@ -76,12 +83,9 @@ export default function ThankyouPage({ isPreviewMode }: { isPreviewMode: boolean
                         </div>
                     </div>
                 )}
-                <Link href={isPreviewMode ? '#' : 'https://bettercollected.com/'} target={isPreviewMode ? '' : 'blank'}>
-                    <div className="bottom-8 mt-4 flex cursor-pointer flex-row gap-2 lg:absolute lg:m-0">
-                        <span className="body3 text-black-700">Powered by:</span>
-                        <Logo showProTag={false} isLink={false} isCustomDomain className="h-[14px] w-fit" />
-                    </div>
-                </Link>
+                {/* Attribution moved into the trust strip — the form's single
+                    footer. A second floating "Powered by" here sat underneath
+                    the fixed strip and the two overlapped. */}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Fourteen commits of feedback-driven work, roughly three arcs: finishing touches on the builder/flow view, a responder-form rendering pass, and a deep overhaul of the responder portal — the surface where every form's "view or delete your response anytime" promise is kept. All grounded in browser-verified findings; several real bugs fixed along the way.

### Builder & Flow view (`ec9bf772`, `05a67267`)
- Flow Insights header no longer contradicts node chips — its two instruments are labelled apart ("N responses" vs "journeys: X started · Y finished", with tooltips); the side panel shows the full question; the Edit-content overlay was rebuilt on the measured-scale layout with a live save status; **fixed a race where React Flow silently dropped every edge** when node handles weren't mounted yet (the graph intermittently rendered unlinked).
- Large screens: the canvas mat collapsed to a floating band (no `self-stretch` under an `items-center` row) and its collapsed height fed back into the Fit scale; Fit also capped at 1× making Fit ≡ 100%. Mat stretches, Fit fills, 100% is true size.

### Responder form (`917b2213`, `96b54fdc`)
- One direction-aware slide transition for welcome/pages/thank-you (entering slides full-width, exiting parallax-drifts and fades) replacing three inconsistent animations with no exit motion; the container clips the fly-in that used to flash a horizontal scrollbar; `prefers-reduced-motion` gets a cross-fade.
- One footer: "Powered by bettercollected" merged into the trust strip (honouring the existing disableBranding setting the old thank-you footer ignored); the thank-you heading is now a customizable, pipeable `title` field end to end (common model → builder inline edit → responder).
- **Found & fixed a data-trust bug: the builder loaded the latest *published* version, not the draft it edits** (`?published=true&draft=true` returns published-if-exists) — every autosave persisted correctly but reloads re-hydrated from the stale published snapshot, so changes appeared lost.

### Responder portal (`ad02be0e` … `3dc3dd92`)
- **Redesigned as the trust surface**: responder-language form cards (purpose + question count instead of provider glyph + "Public"), identifiable submission receipts (mono receipt number, exact time, Anonymous chip, deletion status), trust anchor on the workspace card, right-of-access search card, tokens throughout (body wash, tabs, avatar fallback), plus a full copy pass for the signed-out view (no more "all the data associated with you" surveillance-speak; the empty state stops claiming "No submissions yet" when signed out).
- **Deletion flow actually works now** — it only *appeared* to work for admins: authorization rejected anonymous owners (403 on their own responses); anonymous requests stored no identity and vanished from listings; My submissions gave no feedback after requesting. All fixed with a regression test, plus receipt numbers on request cards and honest "Requested:" timestamps.
- **Anonymity holds at the account level**: verified-email listings no longer link anonymous submissions to the account (the listing matched the anonymous identity hash, contradicting the product promise and the portal's own copy); an anonymous response is reachable solely through its receipt number. Regression-tested.
- **One brand, one journey**: the submission detail dropped its bettercollected wordmark header for the workspace's own identity (the portal is the workspace's branded space, incl. custom domains), wears the portal design (receipt card, "My response · Privacy & deletion" tabs, calm deletion section instead of a red danger zone), resolves piped question titles against that submission's answers, and distinguishes question (muted label) from answer (full-size ink) by style.
- **Navigation & mechanics**: portal tabs and the search card stay affixed while only the content column scrolls (stable scrollbar gutter kills the enable-scroll flicker); receipts link straight to `/form` (no redirect hop) with a branded skeleton instead of a white flash; forms open in their own tab so the portal is never lost, and the trust strip's "Collected by" links direct-link arrivals back to the portal; confirm dialogs got a quiet Cancel + action-labelled buttons ("Request deletion", not "Yes"); the response view sizes to content instead of a forced 90vh.

## Test plan
- [x] webapp: `tsc --noEmit` clean, 149 vitest passing
- [x] backend: 152 pytest passing, incl. new regressions (anonymous owner can request deletion; anonymous submissions not listed under the account)
- [x] Browser-verified end to end: flow-view fixes, large-screen Fit/100%, slide transitions (zero horizontal overflow measured per frame), thank-you title + single footer on a live submission, deletion flow for identified + anonymous responses, portal scroll/affix behaviour, piped receipt detail ("Hello Maya — welcome Maya"), new-tab form opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)