### PR TITLE
Your site: portal mirror, in-frame settings, trust chrome, deletion-request actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,151 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Fixed
 
+- **Workspace settings: React error fixed and given a discoverable home.**
+  Opening the settings sheet errored (`value` prop on `input` should not be
+  null): the privacy-policy and terms URLs fed null into controlled inputs
+  (title/description already had fallbacks). The save diff also compared
+  snake_case keys against the camelCase DTO, so those two fields were sent on
+  every save whether changed or not — both fixed. Settings was reachable only
+  through an unlabelled translucent pencil on one page; it's now a
+  first-class "Workspace settings" item in the sidebar's administration
+  cluster (above Members), and the contextual pencil on the details card is a
+  bordered, titled button.
+- **Field spacing on form pages brought down to a readable rhythm.** Question
+  groups sat 120px apart for responders (desktop) and 80px in the builder —
+  10–15× the 8px gap inside a group, so question–input pairs stopped reading
+  as neighbours and a 6-question page showed ~3. Now 48px mobile / 64px
+  desktop everywhere (builder canvas, live form, preview thumbnails), so the
+  builder is honest WYSIWYG. Also removed the builder's per-row `h-full`
+  (each field stretched to an equal share of the slide, so spacing changed
+  with field count) and its doubled padding (`py-[10vh]` + `px-6` twice on
+  top of the layout's own 60px).
+- **Form preview modal rebuilt.** "Open preview" opened on a dark "please use
+  the desktop version to edit this form" banner (a mobile-editing message, in
+  a preview, on desktop) above an empty nav strip, and the `aspect-video
+  h-full` stage pushed the form card past the bottom of the screen. The
+  preview now has one quiet header — Back, the form title with a Preview
+  chip, the honest "Answers aren't saved" note, and Share/Publish — over a
+  centered 16:9 stage sized to fit both viewport dimensions (mobile fills the
+  screen, as a responder would see it).
+- Responder portal (and its dashboard mirror): the "Find a response by its
+  number" card moved from a third column on wide screens into the left
+  sidebar, below the identity section — one utility column, a consistent
+  two-column layout at every width, and no more modal fallback below xl.
+- **One vocabulary: workspace + site.** The product used three overlapping
+  terms — onboarding created an "Organization", the dashboard managed a
+  "workspace", and the responder-facing surface was a "Public Workspace" (or
+  internally, the "responder portal"). Now: the **workspace** is where you
+  work; your **site** is what the world sees ("Site" as the nav label, "your
+  site" in running copy). Onboarding says "Create your workspace /
+  Workspace name"; settings copy, custom-domain copy ("Serve your site from
+  a domain you own"), template visibility, and the sign-in feature line all
+  speak the same two words. "Organization" survives only where it means the
+  real-world entity. The settings surface follows the scheme too: "Workspace
+  Settings" is now **Site settings** (it configures exactly what the world
+  sees), with **Identity** and **Link & domain** tabs replacing "Workspace
+  Details" / "Manage URLs" — renamed in the sidebar entry and the frame's
+  gear as well.
+- Workspace settings: the Privacy Policy URL and Terms of Service URL inputs
+  are full-width, capitalized, and validated on save — values must be real
+  http(s) links (a missing scheme is forgiven by prepending https://;
+  whitespace, non-web schemes like javascript:, and scheme-less non-domains
+  are rejected with "Enter a full link, like https://yoursite.com/privacy").
+  These values render as links on the public workspace and in every form's
+  trust footer, so bad values were a broken-trust-link (or script-injection)
+  vector.
+- **Workspace settings audited against the trust language.** Copy rewritten
+  in plain speech: the Title-Case marketing header ("Tailor Title, Refine
+  Description… and Elevate with a Banner Image") now says what the page is
+  ("The identity responders see on your public workspace"); "Organizations
+  Title"/"Organization Descriptions" became "Workspace name"/"Description";
+  the policy-URL fields explain their trust role (linked from the public
+  workspace and every form's trust footer). One left edge for header, tabs
+  and panel content — the panels used to stack their own px-20+ on top of
+  the container's, indenting content past the tabs. Manage URLs was
+  reorganised into two honest sections: the workspace link (mono URL with
+  trust-blue handle, Copy, Change link, and the stated consequence — "the
+  old link stops working") and Custom Domain, which no longer shows free
+  users a domain form that only bounced them to the upgrade modal — the
+  upgrade note is the whole section. Validation copy tells you what to type
+  ("try something like forms.yoursite.com") in muted red, warnings in amber;
+  Save is the trust-blue primary instead of near-black.
+- Workspace settings now open **inside the Public Workspace frame** (behind
+  the address-bar gear, with a highlighted gear state and a "Back to page"
+  return) instead of a bottom sheet over the whole app — edit, save, and
+  you're looking at the page you just changed. The sidebar "Workspace
+  settings" entry routes to this view; the settings surface was extracted to
+  a shared component so the URL-update deep links that still use the bottom
+  sheet render the identical content. Inside the frame the settings' own
+  URL-actions row is hidden (the address bar already carries it).
+- **The dashboard's "Public Workspace" page is now a true mirror of the
+  responder portal.** It rendered admin-style form cards (provider icon,
+  "Public", response counts, edit/share affordances) — not what responders
+  see. It now renders the portal's own components: the same three tabs
+  (Forms · My submissions · Deletion requests), the same receipt-search card
+  (with the portal's below-xl modal fallback), forms with purpose line,
+  question count and pinned chip, with the page title matching the sidebar
+  entry. Clicking a form opens the real public form on the client domain in
+  a new tab, exactly as a responder experiences it. The mirror sits inside a
+  browser-style frame that says what this is — a page that lives at a URL:
+  the chrome carries the real public address with copy and open-live
+  actions, plus the workspace-settings gear, so creator controls live on the
+  frame and never inside the mirrored content (the old settings pencil
+  floated over the details card, which responders never see; the separate
+  Workspace Link card was absorbed by the address bar). Deliberately NOT
+  mirrored: the portal's identity furniture (verify-email card, responder
+  account card, powered-by caption) — redundant or misleading inside the
+  signed-in dashboard. Also fixed a React warning the fulfilled
+  deletion-request card tripped everywhere it renders (`href=""` spread onto
+  a plain div).
+- **Dashboard chrome brought onto the trust palette.** The sidebar's "Public
+  Workspace" link was blue→pink gradient text (the retired "playful" rainbow,
+  with no measurable contrast) and the "Pro" badge was an orange-gradient pill
+  with ~2.1:1 white-on-orange text in a one-off display face — both are now
+  quiet chips/links on the trust ramp. Sidebar selection had two bugs: exact
+  URL matching meant nested routes (Responders, Members subpages) highlighted
+  nothing, and the selected state was grey — now prefix-matched and trust-blue
+  tinted like every other selected state. Old bright-blue (`#0764EB`,
+  `blue-600`), slate/gray neutrals, Bootstrap greys in the account dropdown,
+  and the alarmist red Logout were retuned to the ink ramp and muted red; the
+  account dropdown avatar now falls back to the email initial instead of an
+  empty square. Page tabs (Members, Responders and Groups) use the trust-blue
+  underline; all admin data tables share hairline borders, surface headers and
+  ink text; duplicated page titles (sticky bar + in-page h1) collapsed to one.
+- **Upgrade-to-PRO modal made honest (no-dark-patterns law).** The headline
+  promised "PRO is Free" / "You won't be charged any money" while a footnote
+  said "Free for 90 days!" — and the upgrade has no expiry in code at all. It
+  now makes one claim ("currently free — no card needed and nothing is
+  charged"), the button says what it does ("Activate PRO for free"), the
+  pastel-rainbow feature cards became one calm treatment, and the feature
+  copy was corrected ("as many forms as you want", "separate workspaces for
+  different teams, organizations, and projects").
+- Copy: form cards pluralize response counts ("0 Responses"); the responders
+  page explains the list in plain language and states the responder's rights;
+  the groups empty state reads "Create a group to control who can access your
+  forms"; members rows no longer print the same email twice.
+- **Deletion requests were impossible to fulfil from the dashboard.** The only
+  delete affordance — a kebab menu inside the response drawer — was rendered
+  with a literal `hidden` class, and even unhidden it deleted permanently with
+  no confirmation. Pending rows in the Deletion requests table now carry a
+  first-class "Delete response" action (plus a quiet "View") that routes
+  through a consequence-stating confirmation dialog; the drawer kebab is
+  visible and uses the same confirm. Deleting now refreshes the table and the
+  pending counter (the mutation didn't invalidate the queries feeding them),
+  the status chip speaks the trust palette (amber Pending / green Deleted —
+  it was error-red, and a dead code path labelled fulfilled requests
+  "Expired"), fulfilled rows show the deletion date instead of "Not deleted
+  yet" beside a Pending chip, rows carry the submission receipt number so
+  anonymous requests can be matched to what a responder quotes, and the
+  header counter reads "N of M requests pending" instead of the quota-like
+  "5/5 deletion remaining".
+- The response drawer rendered blank question labels outside a form page:
+  the fetched form was never passed down, so titles and pipe resolution fell
+  back to the (empty) redux form. All VIEW_RESPONSE openers now pass the
+  form — question titles render, answer pipes resolve with that submission's
+  answers, legacy fields whose text lives in `value` (null rich-text title)
+  show their real question instead of the "Enter Question" placeholder, and
+  unanswered file-upload fields say "No answer" instead of an empty grey box.
 - Responders table rows drifted out of alignment: the "frozen" Responder ID
   area was faked with two independent tables whose row heights were never
   guaranteed equal (two-line identifier cells vs. one-line answers, against a

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -107,7 +107,6 @@
     "DESCRIPTION": "Any questions or remarks? Just write us a message",
     "DEFAULT": "Contact us"
   },
-  
   "CREATE_FORM": "Create Form",
   "CUSTOMIZE_DOMAIN": {
     "DEFAULT": "Customize domain",
@@ -119,7 +118,6 @@
     "POINT_2": "Avoid using spaces or special characters. Only “-” and “_” is accepted.",
     "POINT_3": "Keep it short and concise."
   },
-  
   "CUSTOMIZE_URL": "Customize URL",
   "CUSTOM_DOMAIN": "Custom Domain",
   "DASHBOARD": {
@@ -313,7 +311,7 @@
       },
       "LINKS": {
         "DESCRIPTION": "Create personalized form links that align with your branding or specific requirements. A link slug is a brief, descriptive part of a URL that identifies web page content.",
-        "CHANGE_SLUG": "Customize Link",
+        "CHANGE_SLUG": "Change link",
         "CUSTOM_DOMAIN_LINK": "Custom Domain Link",
         "DEFAULT_LINK": "Default Link",
         "COPY_LINK": "Copy Link",
@@ -405,7 +403,7 @@
     },
     "ADDED_MEMBERS": "Added Members",
     "DETAILS": "Group Details",
-    "TITLE": "Create a group to limit access to form from your workspace",
+    "TITLE": "Create a group to control who can access your forms",
     "CREATE_GROUP": "Create Group",
     "EDIT_GROUP": "Edit Group",
     "CREATE_NEW_GROUP": {
@@ -447,7 +445,6 @@
     },
     "TITLE": "Select a form to import"
   },
-
   "INVALID_DOMAIN": "Invalid domain",
   "INVALID_WORKSPACE_HANDLE": "Invalid Workspace Handle",
   "INVITATION": {
@@ -476,7 +473,7 @@
   "LINK_TO_TERMS_OF_SERVICES": "Link to Terms of Service",
   "LOGOUT_MESSAGE": "Are you sure you want to logout?",
   "MANAGE": "Manage",
-  "MANAGE_URLS": "Manage URLs",
+  "MANAGE_URLS": "Link & domain",
   "MANAGE_WORKSPACE": "Manage Workspace",
   "MEMBER": "Member",
   "MEMBERS": {
@@ -505,7 +502,7 @@
   "OF": "of",
   "ONBOARDING": {
     "PRIVACY_FRIENDLY": "Privacy-friendly form builder",
-    "ADD_YOUR_ORGANIZATION": "Add Your Organization",
+    "ADD_YOUR_ORGANIZATION": "Create your workspace",
     "ADD_WORKSPACE": "Add your workspace",
     "DESCRIPTION": "Please create your workspace so that your team know you are here.",
     "TIME_MESSAGE": "It will only take few minutes",
@@ -515,7 +512,7 @@
     "NOT_AVAILABLE": "Not Available",
     "USE_SMALLCASE": "Use smallcase for your handle name",
     "ERROR": {
-      "FILL_ORGANIZATION_NAME": "Please fill the organization name.",
+      "FILL_ORGANIZATION_NAME": "Please enter a workspace name.",
       "FILL_HANDLE_NAME": "Please fill the handle name",
       "SPACE_NOT_ALLOWED": "Spaces are not allowed in this field",
       "ALLOWED_CHARACTERS": "Allowed characters a-z, 0-9 and _",
@@ -608,7 +605,7 @@
     "SIGNIN_AGREEMENT_DESCRIPTION": "By signing in, you agree to our",
     "WELCOME_MESSAGE": "Welcome back!",
     "FEATURES": {
-      "TITLE": "Empower Your Organization with Custom Form Page",
+      "TITLE": "Your forms, on a site you own",
       "OTP_TITLE": "Custom URLs and Improved SEO",
       "DESCRIPTION": "Create your custom Form Page to centralize all your forms (bettercollected forms, Google Forms and Typeform). This personalized solution allows you to gather and manage all your forms within a single.",
       "OTP_DESCRIPTION": "Replace default links with your own URLs that better represent your business and enhance your online presence."
@@ -685,7 +682,7 @@
       "VISIBILITY": {
         "TEMPLATE_VISIBILITY": "Template Visibility",
         "PUBLIC": "Everyone with the link can use this template. You can share this template.",
-        "PRIVATE": "Only your organization can use this template. You cannot share this template."
+        "PRIVATE": "Only your workspace can use this template. You cannot share this template."
       }
     },
     "DELETE_MODAL": {
@@ -801,9 +798,9 @@
     "DEFAULT_SLOGAN": "Upgrade To PRO Plan For More Features",
     "FEATURES": {
       "WORKSPACE": {
-        "SLOGAN": "Organize Your Users With Multiple Workspace",
-        "TITLE": "Multiple Workspace",
-        "DESCRIPTION": "Create separate workspace for different teams, organization and projects."
+        "SLOGAN": "Organize Your Users With Multiple Workspaces",
+        "TITLE": "Multiple Workspaces",
+        "DESCRIPTION": "Create separate workspaces for different teams, organizations, and projects."
       },
       "COLLABORATOR": {
         "SLOGAN": "Start Collaborating With Your Team",
@@ -813,14 +810,14 @@
       "CUSTOM_DOMAIN": {
         "SLOGAN": "Personalize Your URLs With Custom Domain",
         "TITLE": "Custom Domain Name",
-        "DESCRIPTION": "Make your business look more professional and to improve your brand recognition.",
+        "DESCRIPTION": "Serve your site and forms from your own domain, so responders see your brand end to end.",
         "NOTE": "Notice !!! Ensure  DNS A Record of your custom-domain is Pointed to {{ domain }} ",
         "TEXT_FIELD_TITLE": "Enter the domain you want to connect"
       },
       "UNLIMITED_FORMS": {
         "SLOGAN": "Import Unlimited Forms with PRO Plan",
         "TITLE": "Unlimited Forms",
-        "DESCRIPTION": "Create and import as many forms you want, free account only allows 100 forms."
+        "DESCRIPTION": "Create and import as many forms as you want. The free plan allows up to 100 forms."
       }
     }
   },
@@ -837,21 +834,21 @@
     "PREVIEW.EMPTY_FORM_TITLE": "No forms to show",
     "PROFILE_IMAGE": "Workspace Profile Image",
     "SETTINGS": {
-      "DEFAULT": "Workspace Settings",
-      "DESCRIPTION": "Tailor Title, Refine Description, Upload Profile Image, and Elevate with a Banner Image",
+      "DEFAULT": "Site settings",
+      "DESCRIPTION": "The identity responders see on your site — name, description, images, and policy links.",
       "TABS": {
-        "DETAILS": "Workspace Details"
+        "DETAILS": "Identity"
       },
       "DETAILS": {
-        "TITLE": "Organizations Title",
-        "DESCRIPTION": "Organization Descriptions",
+        "TITLE": "Workspace name",
+        "DESCRIPTION": "Description",
         "ADD_COVER_IMAGE": "Add cover image",
         "ADD_LOGO": "Add logo"
       },
       "URLS": {
-        "TITLE": "Workspace URLs",
-        "DEFAULT": "Default URL",
-        "DESCRIPTION": "Customize your workspace handle name to make your workspace more personal. A link slug is a brief, descriptive part of a URL that identifies web page content."
+        "TITLE": "Your site's link",
+        "DEFAULT": "Your workspace link",
+        "DESCRIPTION": "This is where responders find your forms — and where they can view or delete their own submissions."
       }
     },
     "TITLE": "Workspace Title",
@@ -866,7 +863,7 @@
     "TEMPLATE": {
       "TITLE": "template",
       "DESCRIPTION_PUBLIC": "Everyone with the link can use this template. You can share this template.",
-      "DESCRIPTION_PRIVATE": "Only your organization can use this template. You cannot share this template."
+      "DESCRIPTION_PRIVATE": "Only your workspace can use this template. You cannot share this template."
     },
     "FORM": {
       "TITLE": "form",

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/creator-dashboard-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/creator-dashboard-client.tsx
@@ -1,88 +1,159 @@
 'use client';
 
-import { useToast } from '@app/shadcn/components/ui/use-toast';
+import { useState } from 'react';
+
+import cn from 'classnames';
 import { useTranslation } from 'react-i18next';
 
-import { ProLogo } from '@app/components/ui/logo';
-import WorkspaceDashboardForms from '@app/components/workspace-dashboard/workspace-dashboard-forms';
-import WorkspaceDashboardPinnedForms from '@app/components/workspace-dashboard/workspace-dashboard-pinned-forms';
-import { Button } from '@app/shadcn/components/ui/button';
+import { ChevronLeft, Copy, Settings } from 'lucide-react';
+
+import { useToast } from '@app/shadcn/components/ui/use-toast';
+
+import WorkspaceFormsTabContent from '@app/components/dashboard/workspace-forms-tab-content';
+import WorkspaceResponsesTabContent from '@app/components/dashboard/workspace-responses-tab-content';
+import Globe from '@app/components/icons/flags/globe';
+import { HistoryIcon } from '@app/components/icons/history';
+import { TrashIcon } from '@app/components/icons/trash';
+import { localesCommon } from '@app/constants/locales/common';
+import { formConstant } from '@app/constants/locales/form';
 import { useAppSelector } from '@app/store/hooks';
-import { useGetWorkspaceFormsQuery } from '@app/store/workspaces/api';
+import { useWorkspaceSettingsView } from '@app/store/jotai/workspace-settings-view';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import { getWorkspaceShareURL } from '@app/utils/workspace-utils';
-import EditIcon from '@Components/icons/edit';
+import { FormIcon } from '@Components/icons/form-icon';
 import OpenLinkIcon from '@Components/icons/open-link';
-import { useBottomSheetModal } from '@Components/modals/contexts/bottom-sheet-modal-context';
+import SearchBySubmissionNumber from '@Components/responder-portal/search-by-submission-number';
 import WorkspaceDetailsCard from '@Components/responder-portal/workspace-details-card';
+import WorkspaceSettingsContent from '@Components/workspace/workspace-settings-content';
 
+// The creator's mirror of the public workspace, presented as what it is: a
+// PAGE THAT LIVES AT A URL. A browser-style frame carries the real public
+// address (copy / open live in the chrome, where those actions belong), and
+// the workspace-settings gear sits on the chrome too — creator controls on
+// the frame, never inside the mirrored content responders actually see.
+// The content itself is the portal's own components (same tabs, same cards,
+// same receipt search), so the mirror can't drift from the portal. The
+// portal's identity furniture (verify-email card, responder account card,
+// powered-by) is deliberately not mirrored — redundant or misleading inside
+// the signed-in dashboard.
 export default function CreatorDashboardClient({ hasCustomDomain }: { hasCustomDomain: boolean }) {
     const { t } = useTranslation();
+    const { toast } = useToast();
     const workspace = useAppSelector(selectWorkspace);
-    const { openBottomSheetModal } = useBottomSheetModal();
+    // Set by the sidebar "Workspace settings" item before it navigates here;
+    // deliberately sticky across visits (an unmount reset would misfire under
+    // strict-mode double effects and close the view it just opened).
+    const { settingsViewOpen, setSettingsViewOpen } = useWorkspaceSettingsView();
+    const [activeTab, setActiveTab] = useState<'forms' | 'my-submissions' | 'deletion-requests'>('forms');
 
-    const pinnedFormsQuery = {
-        workspace_id: workspace?.id ?? '',
-        pinned_only: true
-    };
+    const publicUrl = getWorkspaceShareURL(workspace);
 
-    const pinnedFormsResponse = useGetWorkspaceFormsQuery(pinnedFormsQuery, { skip: !workspace?.id });
-    const pinnedForms = pinnedFormsResponse?.data?.items || [];
+    const tabs = [
+        { key: 'forms' as const, icon: <FormIcon />, title: t(localesCommon.forms) },
+        { key: 'my-submissions' as const, icon: <HistoryIcon className="h-5 w-5" />, title: t(formConstant.submittedForms) },
+        { key: 'deletion-requests' as const, icon: <TrashIcon className="h-5 w-5" />, title: t(formConstant.deletionRequests) }
+    ];
 
     return (
-        <div className="flex flex-col md:flex-row gap-4">
-            <div className="relative flex flex-col gap-4 md:w-[320px] md:max-w-[320px]">
-                <div className="absolute right-4 top-4 z-[50] bg-white/30">
-                    <EditIcon
-                        width={32}
-                        height={32}
-                        onClick={() => {
-                            openBottomSheetModal('WORKSPACE_SETTINGS');
-                        }}
-                        className="text-black-600 hover:text-black-700 hover:bg-black-100 cursor-pointer rounded p-2"
-                    />
+        <div className="border-black-300 shadow-formCardDefault flex flex-col overflow-hidden rounded-xl border bg-white">
+            {/* Browser chrome: dots · address pill (globe + URL + copy) · open · settings gear */}
+            <div className="border-black-300 flex items-center gap-3 border-b bg-white px-4 py-2.5">
+                <div className="hidden items-center gap-1.5 sm:flex" aria-hidden="true">
+                    <span className="bg-black-300 h-2.5 w-2.5 rounded-full" />
+                    <span className="bg-black-300 h-2.5 w-2.5 rounded-full" />
+                    <span className="bg-black-300 h-2.5 w-2.5 rounded-full" />
                 </div>
-                <WorkspaceDetailsCard workspace={workspace} />
-                <WorkspaceLinkCard />
-                {workspace?.customDomain && workspace?.customDomainVerified && <WorkspaceLinkCard customDomain />}
+                <div className="bg-black-100 flex min-w-0 flex-1 items-center gap-2 rounded-full px-3 py-1.5">
+                    <Globe width={14} height={14} className="text-black-600 shrink-0" />
+                    <span className="text-black-700 truncate font-mono text-xs" title={publicUrl}>
+                        {publicUrl}
+                    </span>
+                    <button
+                        type="button"
+                        title="Copy link"
+                        aria-label="Copy your site’s link"
+                        className="text-black-600 hover:text-black-900 ml-auto shrink-0"
+                        onClick={() => {
+                            navigator.clipboard.writeText(publicUrl);
+                            toast({ description: 'Copied' });
+                        }}
+                    >
+                        <Copy className="h-3.5 w-3.5" />
+                    </button>
+                </div>
+                <a
+                    href={publicUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Open the live page"
+                    aria-label="Open your live site"
+                    className="text-black-600 hover:text-black-900 hover:bg-black-100 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                >
+                    <OpenLinkIcon />
+                </a>
+                <button
+                    type="button"
+                    title="Site settings"
+                    aria-label="Site settings"
+                    aria-pressed={settingsViewOpen}
+                    onClick={() => setSettingsViewOpen(!settingsViewOpen)}
+                    className={cn(
+                        'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
+                        settingsViewOpen ? 'bg-[#E9EFFC] text-[#2456CC]' : 'text-black-600 hover:text-black-900 hover:bg-black-100'
+                    )}
+                >
+                    <Settings className="h-[18px] w-[18px]" />
+                </button>
             </div>
-            <div className="flex-1">
-                {pinnedForms?.length > 0 && <WorkspaceDashboardPinnedForms workspacePinnedForms={pinnedFormsResponse} title={t('PINNED_FORMS')} workspace={workspace} hasCustomDomain={hasCustomDomain} />}
-                <WorkspaceDashboardForms isWorkspace showButtons={pinnedForms?.length === 0} workspace={workspace} hasCustomDomain={hasCustomDomain} />
+
+            {/* Settings render INSIDE the frame — the gear opens the site's
+                settings page, you close it and you're back on the page you
+                were configuring. (Previously a bottom sheet over everything.) */}
+            {settingsViewOpen && (
+                <div className="bg-white py-6">
+                    <button type="button" onClick={() => setSettingsViewOpen(false)} className="text-black-600 hover:text-black-900 mb-4 flex items-center gap-1 px-5 text-sm font-medium md:px-10">
+                        <ChevronLeft className="h-4 w-4" />
+                        Back to page
+                    </button>
+                    <WorkspaceSettingsContent showUrlRow={false} />
+                </div>
+            )}
+
+            {/* The "page": the portal's surface colour and content. */}
+            <div className={cn('flex-col gap-4 bg-[#F6F8FC] p-5 md:flex-row md:p-8', settingsViewOpen ? 'hidden' : 'flex')}>
+                <div className="flex flex-col gap-4 md:w-[320px] md:max-w-[320px]">
+                    <WorkspaceDetailsCard workspace={workspace} />
+                    {/* Same sidebar placement as the portal: one utility
+                        column, two-column page. */}
+                    <SearchBySubmissionNumber className="w-full" />
+                </div>
+                <div className="flex min-w-0 flex-1 flex-col">
+                    <div className="border-black-300 flex space-x-1 overflow-x-auto border-b pb-0">
+                        {tabs.map((tab) => {
+                            const isActive = activeTab === tab.key;
+                            return (
+                                <button
+                                    key={tab.key}
+                                    type="button"
+                                    onClick={() => setActiveTab(tab.key)}
+                                    className={cn(
+                                        'mb-[-1px] flex cursor-pointer items-center gap-2 whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors focus:outline-none',
+                                        isActive ? 'border-[#2456CC] text-black-900' : 'text-black-600 hover:text-black-900 border-transparent'
+                                    )}
+                                >
+                                    {tab.icon}
+                                    {tab.title}
+                                </button>
+                            );
+                        })}
+                    </div>
+                    <div className="mt-4 min-w-0">
+                        {activeTab === 'forms' && <WorkspaceFormsTabContent workspace={workspace} publicBaseUrl={publicUrl} />}
+                        {activeTab === 'my-submissions' && <WorkspaceResponsesTabContent workspace={workspace} />}
+                        {activeTab === 'deletion-requests' && <WorkspaceResponsesTabContent workspace={workspace} deletionRequests />}
+                    </div>
+                </div>
             </div>
         </div>
     );
 }
-
-const WorkspaceLinkCard = ({ customDomain = false }: { customDomain?: boolean }) => {
-    const { toast } = useToast();
-    const workspace = useAppSelector(selectWorkspace);
-    return (
-        <div className=" flex flex-col gap-2 rounded-lg bg-white p-4">
-            <div className="p5 text-black-600 flex justify-between">
-                <span className=" ">Workspace Link</span>
-                <a className="hover:text-black-800 flex items-center gap-2" target="_blank" referrerPolicy="no-referrer" href={getWorkspaceShareURL(workspace, customDomain)}>
-                    <OpenLinkIcon className="inline" />
-                    <span>Go to link</span>
-                </a>
-            </div>
-            <div className="bg-black-100 text-black-800 break-all rounded-lg px-3 py-2 text-xs">{getWorkspaceShareURL(workspace, customDomain)}</div>
-            <div className="flex justify-between">
-                <Button
-                    variant={'v2Button'}
-                    onClick={() => {
-                        navigator.clipboard.writeText(getWorkspaceShareURL(workspace, customDomain));
-                        toast({ description: 'Copied' });
-                    }}
-                >
-                    Copy
-                </Button>
-                {(!workspace?.customDomain || !workspace.customDomainVerified) && !customDomain && (
-                    <a href={`/${workspace.workspaceName}/dashboard/custom-domain`} className="text-black-600 hover:text-black-800 flex cursor-pointer items-center gap-2 text-xs">
-                        Use Custom Domain <ProLogo />
-                    </a>
-                )}
-            </div>
-        </div>
-    );
-};

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
@@ -15,7 +15,8 @@ import MembersIcon from '@Components/icons/members';
 import ResponderIcon from '@Components/icons/responder';
 import HelpMenuComponent from '@Components/sidebar/help-menu-component';
 import HelpMenuItem from '@Components/sidebar/help-menu-item';
-import { Trash2 } from 'lucide-react';
+import { Settings, Trash2 } from 'lucide-react';
+import { useWorkspaceSettingsView } from '@app/store/jotai/workspace-settings-view';
 
 import AuthNavbar from '@app/components/auth/auth-navbar';
 import { localesCommon } from '@app/constants/locales/common';
@@ -34,6 +35,7 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
 
     const auth = useAppSelector(selectAuth);
     const { openModal } = useFullScreenModal();
+    const { setSettingsViewOpen } = useWorkspaceSettingsView();
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const handleDrawerToggle = () => {
@@ -79,6 +81,18 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
 
     const bottomNavList: Array<INavbarItem> = [
         {
+            key: 'workspace-settings',
+            // Settings live inside the Public Workspace frame (behind the
+            // address-bar gear) — this entry opens that view directly.
+            name: 'Site settings',
+            url: `/${workspace?.workspaceName}/dashboard/workspace-settings`,
+            icon: <Settings className="h-5 w-5 stroke-2" />,
+            onClick: () => {
+                setSettingsViewOpen(true);
+                router.push(commonWorkspaceUrl);
+            }
+        },
+        {
             key: 'members',
             name: t(members.default),
             url: `/${workspace?.workspaceName}/dashboard/members`,
@@ -115,6 +129,9 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
         // Routes not represented in the sidebar nav still need a correct title.
         if (pathname.includes('/dashboard/templates')) return 'Templates';
         if (pathname.includes('/dashboard/account-settings')) return 'Account Settings';
+        // The dashboard root is the public-workspace mirror — title it the same
+        // as the sidebar entry that leads here.
+        if (pathname.endsWith('/dashboard')) return 'Your site';
         return 'My Workspace';
     };
 

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/deletion-requests/page.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/deletion-requests/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTranslation } from 'next-i18next';
 import { useEffect, useState } from 'react';
 
 import SearchInput from '@Components/common/search-input';
@@ -8,15 +7,12 @@ import SearchInput from '@Components/common/search-input';
 import ResponsesTable from '@Components/datatable/responses-table';
 import Loader from '@app/components/ui/loader';
 import globalConstants from '@app/constants/global';
-import { localesCommon } from '@app/constants/locales/common';
-import { formConstant } from '@app/constants/locales/form';
 import { useAppSelector } from '@app/store/hooks';
 import { useGetWorkspaceAllSubmissionsQuery, useGetWorkspaceStatsQuery } from '@app/store/workspaces/api';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import { IGetAllSubmissionsQuery } from '@app/store/workspaces/types';
 
 export default function DeletionRequests() {
-    const { t } = useTranslation();
     const workspace = useAppSelector(selectWorkspace);
     const [page, setPage] = useState(1);
 
@@ -73,12 +69,18 @@ export default function DeletionRequests() {
             )}
             {data && (
                 <>
-                    <div className="heading4">{t(formConstant.deletionRequests)}</div>
-                    <p className="body1 text-black-900 my-10">
-                        {workspaceStats?.data?.deletionRequests.pending || 0}/{workspaceStats?.data?.deletionRequests.total || 0} {t(localesCommon.deletionRemaining)}
+                    {/* No h1 here — the sticky top bar already titles the page.
+                        "5/5 deletion remaining" read like a quota; say what the
+                        number is — how many requests still need handling. */}
+                    <p className="body1 text-black-900 mb-10 mt-2">
+                        {(workspaceStats?.data?.deletionRequests.pending || 0) === 0
+                            ? (workspaceStats?.data?.deletionRequests.total || 0) === 0
+                                ? 'No deletion requests yet.'
+                                : 'All deletion requests handled.'
+                            : `${workspaceStats?.data?.deletionRequests.pending} of ${workspaceStats?.data?.deletionRequests.total} requests pending — deleting the response completes a request.`}
                     </p>
                     <div className="w-full md:w-[282px] mb-8">
-                        <SearchInput handleSearch={handleSearch} />
+                        <SearchInput placeholder="Search by responder email" handleSearch={handleSearch} />
                     </div>
                     <ResponsesTable requestForDeletion={true} page={page} setPage={setPage} submissions={data} />
                 </>

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/members/_components/members-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/members/_components/members-layout-client.tsx
@@ -32,13 +32,13 @@ export default function MembersLayout({
         }
     ];
 
+    // No page h1 here — the sticky top bar already titles the page, and the
+    // section below ("Collaborators (N)") carries the specifics. Selection is
+    // the trust-blue underline used across the app.
     return (
         <div className="flex flex-col">
-            <div className="flex justify-between">
-                <div className="h4">{t(members.default)}</div>
-            </div>
-            <div className="mb-[38px] mt-[24px]">
-                <div className="flex space-x-1 border-b border-gray-200 overflow-x-auto pb-0">
+            <div className="mb-[38px]">
+                <div className="border-black-300 flex space-x-1 overflow-x-auto border-b pb-0">
                     {tabs.map((tab) => {
                         const isActive = pathname?.includes(`/${tab.path}`);
                         return (
@@ -46,10 +46,10 @@ export default function MembersLayout({
                                 key={tab.path}
                                 href={`/${params?.workspace_name}/dashboard/members/${tab.path}`}
                                 className={cn(
-                                    'flex items-center gap-2 px-4 py-2 text-sm font-medium mb-[-1px] cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap',
+                                    'mb-[-1px] flex cursor-pointer items-center gap-2 whitespace-nowrap border-b-2 px-4 py-2 text-sm font-medium transition-colors',
                                     isActive
-                                        ? 'border-b-2 border-black-900 text-black-900'
-                                        : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                        ? 'border-[#2456CC] text-[#2456CC]'
+                                        : 'text-black-600 hover:text-black-800 border-transparent'
                                 )}
                             >
                                 {tab.icon}

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/responders-groups/_components/responders-groups-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/responders-groups/_components/responders-groups-layout-client.tsx
@@ -35,7 +35,7 @@ export default function RespondersGroupsLayoutClient({ children, workspaceName }
 
     return (
         <div className="flex flex-col">
-            <div className="flex items-center space-x-8 border-b border-gray-200 mb-8">
+            <div className="border-black-300 mb-8 flex items-center space-x-8 border-b">
                 {tabs.map((tab) => {
                     const isActive = pathname.endsWith(tab.path);
                     return (
@@ -45,8 +45,8 @@ export default function RespondersGroupsLayoutClient({ children, workspaceName }
                             className={cn(
                                 'flex items-center px-1 py-4 text-sm font-medium border-b-2 transition-colors duration-200 mb-[-1px]',
                                 isActive
-                                    ? 'border-gray-900 text-gray-900'
-                                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                                    ? 'border-[#2456CC] text-[#2456CC]'
+                                    : 'border-transparent text-black-600 hover:text-black-800'
                             )}
                         >
                             <span className="mr-2">{tab.icon}</span>

--- a/webapp/src/components/auth/account-menu-dropdown.tsx
+++ b/webapp/src/components/auth/account-menu-dropdown.tsx
@@ -105,11 +105,13 @@ export default function AuthAccountMenuDropdown({ isClientDomain, fullWidth, hid
                 <ul className="list-none m-0 p-0">
                     <li className="flex items-center px-5 py-3 hover:bg-brand-100 gap-4">
                         <div className="m-0">
-                            <AuthAccountProfileImage size={40} image={user?.profileImage} name={profileName ?? ''} />
+                            {/* Fall back to the email for the avatar initial — a
+                                name-less account rendered an empty square. */}
+                            <AuthAccountProfileImage size={40} image={user?.profileImage} name={profileName ?? user?.email ?? ''} />
                         </div>
                         <div className="flex flex-col m-0">
-                            <span className="text-[16px] leading-[24px] text-[#212529] font-normal">{profileName ?? 'Signed in as'}</span>
-                            <span className="text-[12px] leading-[20px] text-[#6C757D] font-normal">{user?.email}</span>
+                            <span className="text-black-900 text-[16px] font-normal leading-[24px]">{profileName ?? 'Signed in as'}</span>
+                            <span className="text-black-600 text-[12px] font-normal leading-[20px]">{user?.email}</span>
                         </div>
                     </li>
                     <WorkspaceAdminSelector>
@@ -163,7 +165,7 @@ export default function AuthAccountMenuDropdown({ isClientDomain, fullWidth, hid
                     </li>
                     <li
                         onClick={handleLogout}
-                        className="flex items-center gap-4 px-[20px] py-[10px] h-[36px] body4 !text-red-500 hover:bg-red-100 cursor-pointer"
+                        className="flex items-center gap-4 px-[20px] py-[10px] h-[36px] body4 !text-[#C43D3D] hover:bg-[#FBEFEF] cursor-pointer"
                     >
                         <div className="flex items-center justify-center">
                             <LogOut width={20} height={20} />

--- a/webapp/src/components/badge/status-badge.tsx
+++ b/webapp/src/components/badge/status-badge.tsx
@@ -11,8 +11,8 @@ export default function StatusBadge({ status, className = '' }: { status: string
     const { currentStatus, cName, dotCName } = statusProps(status, t);
 
     return (
-        <span className={`text-[9px] flex items-center gap-1 !h-[22px] body4  p-4 rounded-[50px] ${cName} ${className}`}>
-            <div className={`rounded-full bg-black-800 !h-3 w-3 ${dotCName}`} />
+        <span className={`inline-flex h-[22px] w-fit items-center gap-1.5 rounded-full px-2.5 text-xs font-medium ${cName} ${className}`}>
+            <div className={`h-1.5 w-1.5 rounded-full ${dotCName}`} />
             {_.startCase(currentStatus || '')}
         </span>
     );

--- a/webapp/src/components/common/user-details.tsx
+++ b/webapp/src/components/common/user-details.tsx
@@ -8,12 +8,15 @@ interface IUserDetailsProps {
 }
 
 export default function UserDetails({ user }: IUserDetailsProps) {
+    // A name-less account falls back to the email as its display name —
+    // don't print the same email twice, stacked.
+    const displayName = getFullNameFromUser(user);
     return (
         <div className="flex items-center space-x-3">
-            <AuthAccountProfileImage image={user.profileImage} name={getFullNameFromUser(user)} size={40} />
+            <AuthAccountProfileImage image={user.profileImage} name={displayName} size={40} />
             <div className="flex flex-col">
-                <div className="body3">{getFullNameFromUser(user)}</div>
-                <div className="body5 !text-black-600">{user.email}</div>
+                <div className="body3">{displayName}</div>
+                {displayName !== user.email && <div className="body5 !text-black-600">{user.email}</div>}
             </div>
         </div>
     );

--- a/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
+++ b/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
@@ -40,7 +40,7 @@ const AddWorkspaceDomainForm = () => {
             return;
         }
         if (!domain.match(/^(?!:\/\/)([a-zA-Z0-9-_]+\.)+[a-zA-Z]{2,63}$/)) {
-            setMessage({ error: true, message: 'Invalid Domain' });
+            setMessage({ error: true, message: "That doesn't look like a domain — try something like forms.yoursite.com." });
         } else {
             const formData = new FormData();
             formData.append('custom_domain', domain);
@@ -60,53 +60,56 @@ const AddWorkspaceDomainForm = () => {
         }
     };
     return (
-        <div className="mt-4 flex flex-col  gap-2">
-            <span className="text-black-700 text-xs">You can use your own domain name to have a custom URL for your published forms. Consider using a subdomain, such as : forms.yourdomain.com</span>
-            {!workspace.isPro && (
-                <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-[#FFD79A] bg-[#FFF7EA] px-3 py-2 text-xs text-[#8A5A00]">
-                    <span className="rounded bg-[#FFB020] px-1.5 py-0.5 text-[10px] font-semibold text-white">PRO</span>
+        <div className="mt-3 flex flex-col gap-2">
+            <span className="p2-new text-black-700">Serve your site from a domain you own — a subdomain like forms.yourdomain.com works best.</span>
+            {!workspace.isPro ? (
+                // Free plan: the upgrade note IS the whole section. Showing the
+                // domain form too was misleading — filling it in only bounced
+                // you to the upgrade modal.
+                <div className="mt-2 flex flex-wrap items-center gap-2 rounded-lg bg-[#FBF3E4] px-3 py-2.5 text-sm text-[#B26B00]">
                     <span>Custom domains are a Pro feature.</span>
-                    <button type="button" onClick={() => openModal('UPGRADE_TO_PRO')} className="font-semibold text-[#8A5A00] underline underline-offset-2">
+                    <button type="button" onClick={() => openModal('UPGRADE_TO_PRO')} className="font-semibold underline underline-offset-2">
                         Upgrade to connect your domain
                     </button>
                 </div>
-            )}
-            <div className="text-black-800 mt-4 text-xs font-medium">Enter a domain you own</div>
-            <form
-                onSubmit={(event) => {
-                    event.preventDefault();
-                    addDomain();
-                }}
-                className="flex justify-start items-start gap-4"
-            >
-                <div>
-
-                    <AppInput
-                        className={cn('max-w-[600px]', message.message && (message.error ? 'border-red-500' : ''))}
-                        value={domain}
-                        onChange={(event) => {
-                            setDomain(event.target.value);
-                            setWarned(false);
-                            if (message.message) {
-                                setMessage({ error: false, message: '' });
-                            }
+            ) : (
+                <>
+                    <div className="text-black-800 mt-4 text-sm font-medium">Enter a domain you own</div>
+                    <form
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            addDomain();
                         }}
-                        placeholder="eg. forms.yoursite.com"
-                    />
-                </div>
-                <Button variant={'v2Button'} type="submit" disabled={warned} isLoading={isLoading}>
-                    {' '}
-                    Add Domain
-                </Button>
-            </form>
-            <div className="max-w-[400px]">
-                {message.message && <div className={cn(message.error ? 'text-red-500' : 'text-[#FFA716]', 'whitespace-pre-wrap text-wrap text-xs	')}>{message.message}</div>}
-                {warned && (
-                    <Button variant="ghost" isLoading={isLoading} className="mt-2 cursor-pointer text-xs text-blue-500" onClick={addDomain}>
-                        Add Anyway
-                    </Button>
-                )}
-            </div>
+                        className="flex items-start justify-start gap-4"
+                    >
+                        <div>
+                            <AppInput
+                                className={cn('max-w-[600px]', message.message && (message.error ? 'border-[#C43D3D]' : ''))}
+                                value={domain}
+                                onChange={(event) => {
+                                    setDomain(event.target.value);
+                                    setWarned(false);
+                                    if (message.message) {
+                                        setMessage({ error: false, message: '' });
+                                    }
+                                }}
+                                placeholder="eg. forms.yoursite.com"
+                            />
+                        </div>
+                        <Button variant={'v2Button'} type="submit" disabled={warned} isLoading={isLoading}>
+                            Add domain
+                        </Button>
+                    </form>
+                    <div className="max-w-[440px]">
+                        {message.message && <div className={cn(message.error ? 'text-[#C43D3D]' : 'text-[#B26B00]', 'whitespace-pre-wrap text-wrap text-xs')}>{message.message}</div>}
+                        {warned && (
+                            <Button variant="ghost" isLoading={isLoading} className="mt-2 cursor-pointer text-xs" onClick={addDomain}>
+                                Add anyway
+                            </Button>
+                        )}
+                    </div>
+                </>
+            )}
         </div>
     );
 };

--- a/webapp/src/components/dashboard/form-cards.tsx
+++ b/webapp/src/components/dashboard/form-cards.tsx
@@ -12,19 +12,23 @@ interface FormCardsProps {
     isFormCreator: boolean;
     showPinned?: boolean;
     showVisibility?: boolean;
+    /** Absolute base of the public workspace (e.g. https://forms.example/acme).
+     *  The relative-path fallback assumes the card renders on the client/custom
+     *  domain — the admin dashboard's Public Workspace preview must link out. */
+    publicBaseUrl?: string;
 }
 
-const FormCards = ({ title, formsArray, workspace, showPinned = true, showVisibility }: FormCardsProps) => {
+const FormCards = ({ title, formsArray, workspace, showPinned = true, showVisibility, publicBaseUrl }: FormCardsProps) => {
     const isCustomDomain = window?.location.host !== window.PUBLIC_CONFIG?.FORM_DOMAIN;
 
     if (formsArray.length === 0) return <></>;
     return (
         <div data-testid="form-cards-container">
-            {!!title && <h1 className="text-gray-700 font-semibold text-md md:text-lg mb-6">{title + ' (' + formsArray.length + ')'}</h1>}
+            {!!title && <h1 className="text-black-800 font-semibold text-md md:text-lg mb-6">{title + ' (' + formsArray.length + ')'}</h1>}
             <div className="flex flex-col gap-4">
                 {formsArray.map((form: StandardFormDto, idx: number) => {
                     const slug = form.settings?.customUrl;
-                    const pathname = isCustomDomain ? `/forms/${slug}` : `/${workspace.workspaceName}/forms/${slug}`;
+                    const pathname = publicBaseUrl ? `${publicBaseUrl}/forms/${slug}` : isCustomDomain ? `/forms/${slug}` : `/${workspace.workspaceName}/forms/${slug}`;
                     return (
                         <Link
                             key={form.formId + idx}

--- a/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
@@ -19,9 +19,12 @@ import { useGetWorkspaceFormsQuery, useLazySearchWorkspaceFormsQuery } from '@ap
 interface IWorkspaceFormsTabContentProps {
     workspace: WorkspaceDto;
     isFormCreator?: boolean;
+    /** Set when rendered outside the public portal (the admin dashboard's
+     *  Public Workspace preview) so form links point at the real portal. */
+    publicBaseUrl?: string;
 }
 
-export default function WorkspaceFormsTabContent({ workspace, isFormCreator = false }: IWorkspaceFormsTabContentProps) {
+export default function WorkspaceFormsTabContent({ workspace, isFormCreator = false, publicBaseUrl }: IWorkspaceFormsTabContentProps) {
     const workspaceId = workspace.id;
     const query = {
         workspace_id: workspaceId,
@@ -82,12 +85,12 @@ export default function WorkspaceFormsTabContent({ workspace, isFormCreator = fa
     return (
         // <SearchByUUIDWrapper>
         <div className="flex w-full flex-col gap-6">
-            {pinnedForms?.items?.length !== 0 && <FormCards title={t(formConstant.pinnedforms)} showPinned={false} isFormCreator={isFormCreator} showVisibility={false} workspace={workspace} formsArray={pinnedForms?.items || []} />}
+            {pinnedForms?.items?.length !== 0 && <FormCards title={t(formConstant.pinnedforms)} showPinned={false} isFormCreator={isFormCreator} showVisibility={false} workspace={workspace} formsArray={pinnedForms?.items || []} publicBaseUrl={publicBaseUrl} />}
             {pinnedForms?.items?.length !== 0 && <Divider />}
             <div className={`w-full md:w-[282px]`}>
                 <SearchInput placeholder="Search forms" handleSearch={handleSearch} />
             </div>
-            {allForms.length !== 0 && <FormCards title={pinnedForms?.items?.length !== 0 ? t(formConstant.all) : ''} isFormCreator={isFormCreator} formsArray={allForms} workspace={workspace} />}
+            {allForms.length !== 0 && <FormCards title={pinnedForms?.items?.length !== 0 ? t(formConstant.all) : ''} isFormCreator={isFormCreator} formsArray={allForms} workspace={workspace} publicBaseUrl={publicBaseUrl} />}
         </div>
         // </SearchByUUIDWrapper>
     );

--- a/webapp/src/components/datatable/datatable-styles.ts
+++ b/webapp/src/components/datatable/datatable-styles.ts
@@ -1,24 +1,26 @@
+// Shared admin-table treatment on the trust ramp: hairline borders (#E2E8F2),
+// surface header (#F6F8FC), ink text — the old pure greys (#DBDBDB/#2E2E2E)
+// sat outside the blue-biased neutral system every other surface uses.
 export const dataTableCustomStyles = {
     table: {
         style: {
-            borderTop: '1px solid #DBDBDB',
-            borderBottom: '1px solid #DBDBDB'
-            // borderRight: '1px solid #DBDBDB',
+            borderTop: '1px solid #E2E8F2',
+            borderBottom: '1px solid #E2E8F2'
         }
     },
     headRow: {
         style: {
             border: 'none',
-            backgroundColor: '#E9EEF5',
+            backgroundColor: '#F6F8FC',
             fontSize: '14px',
-            color: '#2E2E2E !important',
+            color: '#3A465A !important',
             height: '50px !important'
         }
     },
     headCells: {
         style: {
-            borderRight: '1px solid #DBDBDB',
-            color: '#2E2E2E !important',
+            borderRight: '1px solid #E2E8F2',
+            color: '#3A465A !important',
             fontSize: '14px',
             paddingTop: '5px',
             paddingBottom: '5px',
@@ -30,15 +32,15 @@ export const dataTableCustomStyles = {
         style: {
             padding: '0',
             fontSize: '18px',
-            color: '#2E2E2E !important',
-            borderRight: '1px solid #DBDBDB',
+            color: '#101826 !important',
+            borderRight: '1px solid #E2E8F2',
             paddingTop: '8px',
             paddingBottom: '8px'
         }
     },
     rows: {
         style: {
-            color: '#6E6E6E',
+            color: '#657085',
             outlineWidth: '0',
             borderRadius: '4px',
             paddingLeft: '0',

--- a/webapp/src/components/datatable/responses-table.tsx
+++ b/webapp/src/components/datatable/responses-table.tsx
@@ -27,12 +27,10 @@ const responseTableStyles = {
     rows: {
         style: {
             ...dataTableCustomStyles.rows.style,
-            borderColor: '#EEEEEE !important',
-            // border: '1px solid transparent',
+            borderColor: '#E2E8F2 !important',
             '&:hover': {
                 cursor: 'pointer',
-                background: '#EEEEEE'
-                // border: '1px solid #0764EB'
+                background: '#F6F8FC'
             }
         }
     }
@@ -46,12 +44,14 @@ interface IResponsetableProps {
     setPage: (page: number) => void;
 }
 
+import { useModal } from '@app/components/modal-views/context';
 import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
 import { useLazyGetWorkspaceSubmissionQuery } from '@app/store/workspaces/api';
 import { getFormFields } from '@app/utils/form-builder-block-utils';
 
 const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage }: IResponsetableProps) => {
     const { openModal } = useFullScreenModal();
+    const { openModal: openConfirmModal } = useModal();
     const [triggerSingleResponse] = useLazyGetWorkspaceSubmissionQuery();
 
     const user = useAppSelector(selectAuth);
@@ -68,7 +68,7 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
                 workspace_id: workspace?.id ?? '',
                 submission_id: response.responseId
             }).then((result: any) => {
-                openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), formId: result.data.form.formId, workspaceId: workspace.id });
+                openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), form: result.data.form, formId: result.data.form.formId, workspaceId: workspace.id });
             });
         }
     };
@@ -78,6 +78,15 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
                 {!requestForDeletion && <span onClick={() => onRowClicked(response)}>{response?.dataOwnerIdentifier ?? 'Anonymous'}</span>}
                 {requestForDeletion && (response?.dataOwnerIdentifier ?? 'Anonymous')}
             </div>
+            {/* The receipt number is the only handle a responder (especially an
+                anonymous one) has on their submission — showing it lets the
+                owner match a request against what the responder quotes. The
+                cell is too narrow for all 36 chars; the title carries the rest. */}
+            {requestForDeletion && response?.submissionUuid && (
+                <div title={response.submissionUuid} className="text-black-600 mt-0.5 font-mono text-[11px]">
+                    #{response.submissionUuid.split('-')[0]}…
+                </div>
+            )}
         </div>
     );
     const responseFormTitle = (response: StandardFormResponseDto) => (
@@ -102,37 +111,44 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
     const Status = ({ status }: { status: string }) => <StatusBadge status={status} />;
 
     const DeletedOn = ({ status, response }: { status: string; response: StandardFormResponseDto }) => {
+        // "Not deleted yet" restated the Pending chip one column over; a quiet
+        // dash keeps the column for the fact it actually holds — the date.
         return (
             <div className="flex items-center gap-10 md:gap-20 xl:gap-40">
-                <span className="text-black-700 text-sm font-medium">{status.toLowerCase() === 'pending' ? t('NOT_DELETED_YET') : utcToLocalDateTIme(response.updatedAt)}</span>
+                {status.toLowerCase() === 'pending' ? <span className="text-black-500 text-sm">—</span> : <span className="text-black-700 text-sm font-medium">{utcToLocalDateTIme(response.updatedAt)}</span>}
             </div>
         );
     };
 
-    const GoToResponse = ({ status, response }: { status: string; response: StandardFormResponseDto }) => {
+    // A deletion request is a task for the workspace owner, so a pending row
+    // carries the action that completes it — deleting the response — next to
+    // a quiet way to review what would be deleted first. The delete goes
+    // through the DELETE_RESPONSE confirmation; it is permanent.
+    const RequestActions = ({ status, response }: { status: string; response: StandardFormResponseDto }) => {
         const isSelf = response.provider === 'self' || response.formImportedBy === user.id;
 
         if (status.toLowerCase() !== 'pending' || !isSelf) return <></>;
 
         if (requestForDeletion && response.provider === 'self') {
             return (
-                <div className="truncate">
-                    <div
-                        className="cursor-pointer inline-flex"
+                <div className="flex items-center gap-1">
+                    <Button
+                        variant="ghost"
+                        className="!px-2"
                         onClick={() => {
                             triggerSingleResponse({
                                 workspace_id: workspace?.id ?? '',
                                 submission_id: response.responseId
                             }).then((result: any) => {
-                                openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), formId: result.data.form.formId, workspaceId: workspace.id });
+                                openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), form: result.data.form, formId: result.data.form.formId, workspaceId: workspace.id });
                             });
                         }}
                     >
-                        <Button variant="ghost" className="!p-0">
-                            {t(localesCommon.goToResponse)}
-                            <ChevronForward className={'text-brand-500 h-6 w-6 ml-2'} />
-                        </Button>
-                    </div>
+                        View
+                    </Button>
+                    <Button variant="dangerGhost" className="!px-2" onClick={() => openConfirmModal('DELETE_RESPONSE', { workspace, formId: response.formId, responseId: response.responseId })}>
+                        Delete response
+                    </Button>
                 </div>
             );
         }
@@ -185,7 +201,7 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
                         status: row?.status || t(formConstant.status.pending)
                     }),
                 style: {
-                    color: 'rgba(0,0,0,.54)',
+                    color: '#3A465A',
                     paddingLeft: '8px',
                     paddingRight: '8px'
                 }
@@ -198,20 +214,21 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
                         response: row
                     }),
                 style: {
-                    color: 'rgba(0,0,0,.54)',
+                    color: '#3A465A',
                     paddingLeft: '8px',
                     paddingRight: '8px'
                 }
             },
             {
                 name: '',
+                minWidth: '250px',
                 selector: (row: StandardFormResponseDto) =>
-                    GoToResponse({
+                    RequestActions({
                         status: row?.status || t(formConstant.status.pending),
                         response: row
                     }),
                 style: {
-                    color: 'rgba(0,0,0,.54)',
+                    color: '#3A465A',
                     paddingLeft: '8px',
                     paddingRight: '8px'
                 }
@@ -225,7 +242,7 @@ const ResponsesTable = ({ requestForDeletion, submissions, formId, page, setPage
                 name: t(formConstant.default),
                 selector: (response: StandardFormResponseDto) => responseFormTitle(response),
                 style: {
-                    color: '#202124',
+                    color: '#101826',
                     fontSize: '14px',
                     fontWeight: 500,
                     paddingLeft: '8px',

--- a/webapp/src/components/form/tabular-responses.tsx
+++ b/webapp/src/components/form/tabular-responses.tsx
@@ -130,7 +130,7 @@ export default function TabularResponses({ form }: TabularResponsesProps) {
             workspace_id: workspace?.id ?? '',
             submission_id: response.responseId
         }).then((result: any) => {
-            openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), formId: result.data.form.formId, workspaceId: workspace.id });
+            openModal('VIEW_RESPONSE', { response: result.data.response, formFields: getFormFields(result.data.form), form: result.data.form, formId: result.data.form.formId, workspaceId: workspace.id });
         });
     };
 

--- a/webapp/src/components/modal-views/full-screen-modals/v2-preview-modal.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/v2-preview-modal.tsx
@@ -1,7 +1,6 @@
 import { formConstant } from '@app/constants/locales/form';
 import { useIsMobile } from '@app/lib/hooks/use-breakpoint';
 import { Button } from '@app/shadcn/components/ui/button';
-import { Separator } from '@app/shadcn/components/ui/separator';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
@@ -16,6 +15,15 @@ import { useTranslation } from 'next-i18next';
 import { useModal } from '../context';
 import { useFullScreenModal } from '../full-screen-modal-context';
 
+/**
+ * Full-screen form preview. One quiet header names what this is (Preview),
+ * states the honest fact (answers aren't saved), and offers the next step
+ * (Share / Publish). The stage letterboxes the form to a 16:9 card that fits
+ * BOTH viewport dimensions on desktop — the old modal opened with a "use the
+ * desktop version to edit" banner (this is a preview, on any device) above an
+ * empty nav strip, and its `aspect-video h-full` stage clipped off the bottom
+ * of the screen.
+ */
 export const PreviewFullModalView = () => {
     const { t } = useTranslation();
     const standardForm = useAppSelector(selectForm);
@@ -23,50 +31,51 @@ export const PreviewFullModalView = () => {
     const { openModal } = useModal();
     const { resetResponderState } = useResponderState();
     const { resetFormResponseAnswer } = useFormResponse();
+    const { closeModal } = useFullScreenModal();
+    const isMobile = useIsMobile();
+
     const handleClickClose = () => {
         resetResponderState();
         resetFormResponseAnswer();
         closeModal();
     };
-    const { closeModal } = useFullScreenModal();
-    const isMobile = useIsMobile();
 
     return (
-        <div className="relative h-screen w-full">
-            <div className="absolute left-4 top-16 z-50 lg:top-4 " onClick={handleClickClose}>
-                <BackButton hideForSmallScreen />
-            </div>
-            <div className=" h-full w-full bg-white">
-                <div className="bg-black-900 xs:px-16 flex h-[52px] w-full items-center justify-center px-1 py-2">
-                    <span className="text-center text-xs text-white sm:text-sm">Please use the desktop version to edit this form. Mobile editing will be available soon!</span>
+        <div className="flex h-screen w-full flex-col bg-[#F6F8FC]">
+            <header className="border-black-300 z-10 flex h-14 w-full shrink-0 items-center justify-between gap-2 border-b bg-white px-4">
+                <BackButton handleClick={handleClickClose} />
+                <div className="flex min-w-0 items-center gap-2 text-sm">
+                    <span className="text-black-800 max-w-[200px] truncate font-medium sm:max-w-[320px]">{standardForm?.title || 'Untitled'}</span>
+                    <span className="rounded-full bg-[#E9EFFC] px-2 py-0.5 text-xs font-semibold text-[#2456CC]">Preview</span>
+                    <span className="text-black-600 hidden text-xs md:inline">Answers aren&apos;t saved</span>
                 </div>
-                <nav className="flex h-14 flex-row justify-between px-4 py-2" style={{ background: isMobile ? standardForm.theme?.accent : 'inherit' }}>
-                    <div></div>
-                    <div className="flex gap-2 lg:hidden">
-                        {standardForm?.isPublished ? (
-                            <Button
-                                variant={'primary'}
-                                icon={<ShareIcon className="h-4 w-4" />}
-                                disabled={standardForm?.settings?.hidden}
-                                onClick={() =>
-                                    openModal('SHARE_VIEW', {
-                                        url: getFormShareURL(standardForm, workspace),
-                                        title: t(formConstant.shareThisForm)
-                                    })
-                                }
-                            >
-                                <span className="text-xs font-medium">Share</span>
-                            </Button>
-                        ) : (
-                            <PublishButton refresh />
-                        )}
-                    </div>
-                </nav>
-                <Separator />
-                <div className="h-full  drop-shadow-xl lg:mx-10 lg:py-10 lg:pb-24 ">
-                    <div className={`aspect-video h-full max-w-full`}>
-                        <Form isPreviewMode />
-                    </div>
+                <div className="flex items-center gap-2">
+                    {standardForm?.isPublished ? (
+                        <Button
+                            variant="v2Button"
+                            icon={<ShareIcon className="h-4 w-4" />}
+                            disabled={standardForm?.settings?.hidden}
+                            onClick={() =>
+                                openModal('SHARE_VIEW', {
+                                    url: getFormShareURL(standardForm, workspace),
+                                    title: t(formConstant.shareThisForm)
+                                })
+                            }
+                        >
+                            <span className="hidden text-xs font-medium sm:inline">Share</span>
+                        </Button>
+                    ) : (
+                        <PublishButton refresh />
+                    )}
+                </div>
+            </header>
+            {/* Mobile fills the screen (that IS the responder experience);
+                desktop letterboxes a 16:9 card whose width is capped so the
+                derived height also fits: min(full width, available-height ×
+                16/9). 104px = 56px header + 48px stage padding. */}
+            <div className="flex min-h-0 w-full flex-1 items-center justify-center lg:p-6">
+                <div className="border-black-300 relative h-full w-full overflow-hidden bg-white lg:aspect-video lg:h-auto lg:w-[min(100%,calc((100vh-104px)*16/9))] lg:rounded-lg lg:border lg:shadow-lg">
+                    <Form isPreviewMode showDesktopLayout={!isMobile} />
                 </div>
             </div>
         </div>

--- a/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/view-response-full-modal-view.tsx
@@ -4,9 +4,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@app/shadcn/components/
 import { Separator } from '@app/shadcn/components/ui/separator';
 import { useToast } from '@app/shadcn/components/ui/use-toast';
 import { cn } from '@app/shadcn/util/lib';
+import { useModal } from '@app/components/modal-views/context';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
-import { useDeleteResponseMutation } from '@app/store/workspaces/api';
+import { selectWorkspace } from '@app/store/workspaces/slice';
 import { utcToLocalDateTIme } from '@app/utils/date-utils';
 import { downloadFile } from '@app/utils/file-utils';
 import { resolvePipesInTitle, titleHasPipes } from '@app/utils/answer-piping';
@@ -20,11 +21,15 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 interface IViewResponseFullModalView {
     response: StandardFormResponseDto;
     formFields: StandardFormFieldDto[];
+    // The form the response belongs to. Without it the body falls back to the
+    // redux form — empty or stale outside a form page (e.g. the workspace
+    // deletion-requests table), which blanked question titles and pipes.
+    form?: StandardFormDto;
     formId: string;
     workspaceId: string;
 }
 
-const ViewResponseFullModalView = ({ response, formFields, formId, workspaceId }: IViewResponseFullModalView) => {
+const ViewResponseFullModalView = ({ response, formFields, form, formId, workspaceId }: IViewResponseFullModalView) => {
     const { toast } = useToast();
     const { closeModal } = useFullScreenModal();
 
@@ -48,7 +53,7 @@ const ViewResponseFullModalView = ({ response, formFields, formId, workspaceId }
                 </div>
             </div>
             <Separator />
-            <IndividualFormResponse className="h-[90vh] overflow-y-auto" formFields={formFields} response={response} />
+            <IndividualFormResponse className="h-[90vh] overflow-y-auto" formFields={formFields} response={response} form={form} />
         </motion.div>
     );
 };
@@ -130,9 +135,13 @@ export const IndividualFormResponse = ({ formFields, response, form, className }
                     return (
                         <div className="flex flex-col gap-1.5" key={field.id}>
                             {getTitleForHeaderForTable(field)}
-                            <div onClick={() => downloadFormFile(ans)} className={cn('!text-black-600 p2-new   w-[140px] cursor-default truncate rounded px-2 py-1', ans?.file_metadata?.url ? 'bg-black-300 active:bg-black-400 !cursor-pointer' : '')}>
-                                {getAnswerForField(response, field)}
-                            </div>
+                            {ans?.file_metadata ? (
+                                <div onClick={() => downloadFormFile(ans)} className={cn('!text-black-600 p2-new w-[140px] truncate rounded px-2 py-1', ans?.file_metadata?.url ? 'bg-black-300 active:bg-black-400 cursor-pointer' : 'cursor-default')}>
+                                    {getAnswerForField(response, field)}
+                                </div>
+                            ) : (
+                                <span className="text-black-500 text-sm italic">No answer</span>
+                            )}
                         </div>
                     );
                 }
@@ -160,30 +169,28 @@ export const IndividualFormResponse = ({ formFields, response, form, className }
 };
 
 const EllipsisSection = ({ formId, workspaceId, responseId }: { formId: string; workspaceId: string; responseId: string }) => {
-    const { toast } = useToast();
-    const [deleteResponse] = useDeleteResponseMutation();
     const { closeModal } = useFullScreenModal();
+    const { openModal: openConfirmModal } = useModal();
+    const workspace = useAppSelector(selectWorkspace);
 
-    const handleDelete = async () => {
-        const response: any = await deleteResponse({ workspaceId, formId, responseId });
-        if (response?.data) {
-            toast({ description: 'Response Deleted' });
-            closeModal();
-        } else {
-            toast({ description: 'Error Deleting Response', variant: 'destructive' });
-        }
+    // Deleting is permanent, so it goes through the DELETE_RESPONSE confirm.
+    // Only one modal layer renders at a time (full-screen wins), so the drawer
+    // closes before the confirmation opens.
+    const handleDelete = () => {
+        closeModal();
+        openConfirmModal('DELETE_RESPONSE', { workspace, formId, responseId });
     };
     return (
         <Popover>
             <PopoverTrigger>
                 <div className="hover:bg-black-200 flex h-fit w-fit items-center justify-center rounded-md p-2">
-                    <MoreVertical className={cn('hidden cursor-pointer')} width={16} height={16} />
+                    <MoreVertical className={cn('cursor-pointer')} width={16} height={16} />
                 </div>
             </PopoverTrigger>
-            <PopoverContent side="left" align="start" className=" !z-[10000]  w-[150px] bg-white p-0 shadow-lg">
-                <div className=" p2 !my-2  flex cursor-pointer items-center gap-2 px-4 py-2 !text-red-500 hover:bg-red-50" onClick={handleDelete}>
-                    <DeleteIcon className="text-red-500" />
-                    Delete
+            <PopoverContent side="left" align="start" className=" !z-[10000]  w-[180px] bg-white p-0 shadow-lg">
+                <div className=" p2 !my-2  flex cursor-pointer items-center gap-2 px-4 py-2 !text-[#C43D3D] hover:bg-[#FBEFEF]" onClick={handleDelete}>
+                    <DeleteIcon className="text-[#C43D3D]" />
+                    Delete response
                 </div>
             </PopoverContent>
         </Popover>

--- a/webapp/src/components/modal-views/modals/delete-response-modal.tsx
+++ b/webapp/src/components/modal-views/modals/delete-response-modal.tsx
@@ -1,4 +1,5 @@
-import { useTranslation } from 'next-i18next';
+import { useState } from 'react';
+
 import { useRouter } from 'next/navigation';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
@@ -7,25 +8,36 @@ import { useToast } from '@app/shadcn/components/ui/use-toast';
 import { useModal } from '@app/components/modal-views/context';
 import { useDeleteResponseMutation } from '@app/store/workspaces/api';
 
-
 export default function DeleteResponseModal({ workspace, formId, responseId, navigateToForm = false }: any) {
     const { toast } = useToast();
     const { closeModal } = useModal();
-    const { t } = useTranslation();
     const router = useRouter();
+    const [isDeleting, setIsDeleting] = useState(false);
 
     const [deleteResponse] = useDeleteResponseMutation();
 
     const handleDelete = async () => {
+        setIsDeleting(true);
         const response: any = await deleteResponse({ workspaceId: workspace.id, formId, responseId });
+        setIsDeleting(false);
         if (response?.data) {
-            toast({ description: 'Response Deleted' });
+            toast({ description: 'Response deleted' });
             if (navigateToForm) router.push(`/${workspace.workspaceName}/dashboard/forms/${formId}`);
             closeModal();
         } else {
-            toast({ description: 'Error Deleting Response', variant: 'destructive' });
+            toast({ description: 'Could not delete the response. Try again.', variant: 'destructive' });
         }
     };
 
-    return <GenericHalfModal headerTitle="Delete response" title="Are you sure to delete this response?" type={'danger'} positiveAction={handleDelete} />;
+    return (
+        <GenericHalfModal
+            headerTitle="Delete response"
+            title="Delete this response permanently?"
+            subTitle="The response and any uploaded files are removed and can't be recovered. If the responder asked for this deletion, their request is marked as completed."
+            type="danger"
+            positiveText="Delete response"
+            loading={isDeleting}
+            positiveAction={handleDelete}
+        />
+    );
 }

--- a/webapp/src/components/modals/bottom-sheet-modals/create-group-modal.tsx
+++ b/webapp/src/components/modals/bottom-sheet-modals/create-group-modal.tsx
@@ -118,7 +118,7 @@ export default function CreateGroupModal() {
             <BottomSheetModalWrapper>
                 <div>
                     <div className="h2-new mb-2">{t(groupConstant.createGroup)}</div>
-                    <div className="p2-new text-black-700">Create a group to limit access to form from your workspace</div>
+                    <div className="p2-new text-black-700">Create a group to control who can access your forms</div>
                 </div>
                 <div className="mb-4 flex flex-col md:max-w-[700px] xl:max-w-[1000px]">
                     <div className="md:max-w-[618px]">

--- a/webapp/src/components/modals/bottom-sheet-modals/workspace-settings-modal.tsx
+++ b/webapp/src/components/modals/bottom-sheet-modals/workspace-settings-modal.tsx
@@ -1,65 +1,13 @@
-import cn from 'classnames';
-import { useTranslation } from 'next-i18next';
-import { useState } from 'react';
-
 import BottomSheetModalWrapper from '@Components/modals/modal-wrapper/bottom-sheet-modal-wrapper';
-import ManageURLs from '@Components/workspace/manage-urls';
-import WorkspaceDetails from '@Components/workspace/workspace-details';
+import WorkspaceSettingsContent from '@Components/workspace/workspace-settings-content';
 
+// Kept for the deep-link flows (URL updates) that open settings from other
+// dashboard pages; the primary settings surface is inside the Public
+// Workspace frame, rendering the same WorkspaceSettingsContent.
 export default function WorkspaceSettingsModal({ initialIndex = 0 }: { initialIndex?: number }) {
-    const { t } = useTranslation();
-    const [activeTab, setActiveTab] = useState(initialIndex === 1 ? 'manage-url' : 'workspace-details');
-
-    const tabMenu = [
-        {
-            title: t('WORKSPACE.SETTINGS.TABS.DETAILS'),
-            path: 'workspace-details'
-        },
-        {
-            title: t('MANAGE_URLS'),
-            path: 'manage-url'
-        }
-    ];
-
     return (
         <BottomSheetModalWrapper className="!px-0 pb-10">
-            <div className="lg:px-30 px-5 md:px-20">
-                <div className="h2-new text-black-800 mb-2">{t('WORKSPACE.SETTINGS.DEFAULT')}</div>
-                <div className="p2-new text-black-700 mb-10 max-w-[440px]">{t('WORKSPACE.SETTINGS.DESCRIPTION')}</div>
-            </div>
-
-            <div className="lg:px-30 !py-0 px-5 md:px-20">
-                <div className="flex space-x-1 border-b border-gray-200 overflow-x-auto pb-0">
-                    {tabMenu.map((tab) => {
-                        const isActive = activeTab === tab.path;
-                        return (
-                            <button
-                                key={tab.path}
-                                onClick={() => setActiveTab(tab.path)}
-                                className={cn(
-                                    'flex items-center gap-2 px-4 py-2 text-sm font-medium mb-[-1px] cursor-pointer hover:bg-black-200 hover:rounded whitespace-nowrap focus:outline-none',
-                                    isActive
-                                        ? 'border-b-2 border-black-900 text-black-900'
-                                        : 'text-gray-500 hover:text-gray-700 hover:border-gray-300'
-                                )}
-                            >
-                                {tab.title}
-                            </button>
-                        );
-                    })}
-                </div>
-
-                <div className="mt-4">
-                    {activeTab === 'workspace-details' && (
-                        <WorkspaceDetails />
-                    )}
-                    {activeTab === 'manage-url' && (
-                        <div className="lg:px-30 px-5 md:px-20">
-                            <ManageURLs />
-                        </div>
-                    )}
-                </div>
-            </div>
+            <WorkspaceSettingsContent initialIndex={initialIndex} />
         </BottomSheetModalWrapper>
     );
 }

--- a/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
+++ b/webapp/src/components/responder-portal/responder-portal-layout-client.tsx
@@ -141,14 +141,9 @@ export default function ResponderPortalLayoutClient({
                     </div>
                 )}
 
-                <div
-                    className="p2-new my-6 w-full cursor-pointer rounded-xl bg-white p-4 xl:hidden"
-                    onClick={() => {
-                        openModal('SEARCH_BY_SUBMISSION_NUMBER');
-                    }}
-                >
-                    Search your form response by submission number
-                </div>
+                {/* The receipt search lives with the other identity/recovery
+                    tools in the sidebar — one utility column, two-column page. */}
+                <SearchBySubmissionNumber className="mt-6 w-full" />
 
                 {/* Attribution, not advertisement: a quiet caption, not a card
                     competing with the workspace's own identity. */}
@@ -179,11 +174,10 @@ export default function ResponderPortalLayoutClient({
                         );
                     })}
                 </div>
-                <div className="mt-4 flex flex-col gap-6 md:min-h-0 md:flex-1 xl:flex-row">
-                    {/* Only the receipts/forms column scrolls — the search-by-number
-                        card is a persistent utility and stays in view. */}
+                <div className="mt-4 flex flex-col gap-6 md:min-h-0 md:flex-1">
+                    {/* Only the content column scrolls; the sidebar column
+                        (identity + receipt search) stays put. */}
                     <div className="min-w-0 flex-1 md:min-h-0 md:overflow-y-auto md:[scrollbar-gutter:stable]">{children}</div>
-                    <SearchBySubmissionNumber className='hidden shrink-0 xl:block' />
                 </div>
             </div>
             <div className="lg:hidden">

--- a/webapp/src/components/responder-portal/search-by-submission-number.tsx
+++ b/webapp/src/components/responder-portal/search-by-submission-number.tsx
@@ -39,7 +39,8 @@ const SearchBySubmissionNumber = ({ className }: { className?: string }) => {
 
     return (
         <form onSubmit={handleSubmit} className={className}>
-            <div className="flex w-full max-w-[367px] flex-col items-center justify-center rounded-xl bg-white px-6 py-8 xl:w-[367px]">
+            {/* Fluid width — the parent column (sidebar) decides how wide. */}
+            <div className="flex w-full flex-col items-center justify-center rounded-xl bg-white px-6 py-8">
                 <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#E9EFFC]" aria-hidden="true">
                     <SearchIcon className="text-[#2456CC]" width={22} height={22} strokeWidth={2} />
                 </div>

--- a/webapp/src/components/settings/invitations-table.tsx
+++ b/webapp/src/components/settings/invitations-table.tsx
@@ -74,7 +74,7 @@ export default function InvitationsTable({ data }: IInvitationTableProps) {
             selector: (invitation: WorkspaceInvitationDto) => invitation.email,
             minWidth: '300px',
             style: {
-                color: '#202124',
+                color: '#101826',
                 fontSize: '16px',
                 fontWeight: 500,
                 paddingLeft: '16px',
@@ -86,7 +86,7 @@ export default function InvitationsTable({ data }: IInvitationTableProps) {
             name: t(members.invitationDate),
             selector: (invitation: WorkspaceInvitationDto) => (!!invitation?.createdAt ? `${utcToLocalDate(invitation?.createdAt)} ${utcToLocalTime(invitation?.createdAt)}` : ''),
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px',
                 fontSize: '16px'
@@ -101,7 +101,7 @@ export default function InvitationsTable({ data }: IInvitationTableProps) {
                     email: invitation.email
                 }),
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px',
                 fontSize: '16px'

--- a/webapp/src/components/settings/members-table.tsx
+++ b/webapp/src/components/settings/members-table.tsx
@@ -24,7 +24,7 @@ export default function MembersTable({ data }: any) {
             name: t(members.member),
             minWidth: '300px',
             style: {
-                color: '#202124',
+                color: '#101826',
                 fontSize: '14px',
                 fontWeight: 500,
                 paddingLeft: '16px',
@@ -37,7 +37,7 @@ export default function MembersTable({ data }: any) {
             name: t(members.join),
             selector: (member: any) => (!!member?.joined ? `${utcToLocalDate(member?.joined)} - ${utcToLocalTime(member?.joined)}` : ''),
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px',
                 fontSize: '16px'
@@ -47,7 +47,7 @@ export default function MembersTable({ data }: any) {
             name: t(members.role),
             selector: (member: any) => _.capitalize(member.roles[0]),
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px',
                 fontSize: '16px'

--- a/webapp/src/components/settings/workspace-info.tsx
+++ b/webapp/src/components/settings/workspace-info.tsx
@@ -13,6 +13,7 @@ import { AppInput } from '@app/shadcn/components/ui/input';
 import { Textarea } from '@app/shadcn/components/ui/textarea';
 import { selectAuth } from '@app/store/auth/slice';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
+import { useWorkspaceSettingsView } from '@app/store/jotai/workspace-settings-view';
 import { usePatchExistingWorkspaceMutation } from '@app/store/workspaces/api';
 import { setWorkspace } from '@app/store/workspaces/slice';
 import { useBottomSheetModal } from '@Components/modals/contexts/bottom-sheet-modal-context';
@@ -23,12 +24,24 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
     const { toast } = useToast();
     const [patchExistingWorkspace, { isLoading }] = usePatchExistingWorkspaceMutation();
     const { closeBottomSheetModal } = useBottomSheetModal();
-    const [workspaceInfo, setWorkspaceInfo] = useState({
+    const { setSettingsViewOpen } = useWorkspaceSettingsView();
+
+    // Settings render in two containers (the Public Workspace frame and the
+    // deep-link bottom sheet); saving closes whichever is open.
+    const closeSettings = () => {
+        closeBottomSheetModal();
+        setSettingsViewOpen(false);
+    };
+    // Controlled inputs need strings — privacyPolicy/termsOfService are null
+    // until set, and React errors on value={null}.
+    const currentInfo = {
         title: workspace.title || '',
         description: workspace.description || '',
-        privacy_policy: workspace.privacyPolicy,
-        terms_of_service: workspace.termsOfService
-    });
+        privacy_policy: workspace.privacyPolicy || '',
+        terms_of_service: workspace.termsOfService || ''
+    };
+    const [workspaceInfo, setWorkspaceInfo] = useState(currentInfo);
+    const [urlErrors, setUrlErrors] = useState<{ privacy_policy?: string; terms_of_service?: string }>({});
     const auth = useAppSelector(selectAuth);
 
     const onChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -36,21 +49,64 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
             if (e.target.value.length >= 280) return;
             setWorkspaceInfo({ ...workspaceInfo, description: e.target.value });
         } else {
+            if (e.target.name in urlErrors) setUrlErrors({ ...urlErrors, [e.target.name]: undefined });
             setWorkspaceInfo({ ...workspaceInfo, [e.target.name]: e.target.value });
+        }
+    };
+
+    // These values render as links on the public workspace and in every form's
+    // trust footer, so they must be real http(s) URLs — anything else (typos,
+    // javascript: schemes) is rejected. A missing scheme is forgiven by
+    // prepending https:// rather than bouncing the save.
+    const normalizeUrl = (value: string): string | null => {
+        const trimmed = value.trim();
+        if (!trimmed) return '';
+        // The URL constructor happily percent-encodes inner whitespace, which
+        // would wave through paste accidents like "https://x.com/terms oops".
+        if (/\s/.test(trimmed)) return null;
+        const candidate = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(trimmed) ? trimmed : `https://${trimmed}`;
+        try {
+            const url = new URL(candidate);
+            if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+            if (!url.hostname.includes('.')) return null;
+            return candidate;
+        } catch {
+            return null;
         }
     };
 
     const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        const formData = new FormData();
-        if (workspaceInfo.title === workspace?.title && workspaceInfo.description === workspace?.description && workspaceInfo.privacy_policy === workspace?.privacyPolicy && workspaceInfo.terms_of_service === workspace?.termsOfService) {
-            closeBottomSheetModal();
+
+        const urlFields = ['privacy_policy', 'terms_of_service'] as const;
+        const normalized = { ...workspaceInfo };
+        const errors: typeof urlErrors = {};
+        urlFields.forEach((field) => {
+            const result = normalizeUrl(workspaceInfo[field]);
+            if (result === null) {
+                errors[field] = 'Enter a full link, like https://yoursite.com/privacy';
+            } else {
+                normalized[field] = result;
+            }
+        });
+        if (Object.values(errors).some(Boolean)) {
+            setUrlErrors(errors);
             return;
         }
-        Object.keys(workspaceInfo).forEach((key: any) => {
-            //@ts-ignore
-            if (workspace[key] !== workspaceInfo[key]) formData.append(key, workspaceInfo[key]);
-        });
+        if (normalized.privacy_policy !== workspaceInfo.privacy_policy || normalized.terms_of_service !== workspaceInfo.terms_of_service) {
+            setWorkspaceInfo(normalized);
+        }
+
+        const formData = new FormData();
+        // Diff against the normalised current values — the old check read
+        // workspace['privacy_policy'] (snake_case) off a camelCase DTO, so
+        // those fields were sent on every save whether changed or not.
+        const changedKeys = (Object.keys(normalized) as Array<keyof typeof normalized>).filter((key) => normalized[key] !== currentInfo[key]);
+        if (changedKeys.length === 0) {
+            closeSettings();
+            return;
+        }
+        changedKeys.forEach((key) => formData.append(key, normalized[key]));
         const response: any = await patchExistingWorkspace({ workspace_id: workspace.id, body: formData });
 
         if (response.error) {
@@ -58,7 +114,7 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
         }
         if (response.data) {
             dispatch(setWorkspace(response.data));
-            closeBottomSheetModal();
+            closeSettings();
             toast({ description: t(toastMessage.workspaceUpdate).toString() });
         }
     };
@@ -91,7 +147,7 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
             </div>
             <div className="flex w-full flex-col gap-2">
                 <div className="body1">{t('WORKSPACE.SETTINGS.DETAILS.TITLE')}</div>
-                <AppInput onChange={onChange} value={workspaceInfo.title} name="title" placeholder={t(placeHolder.workspaceTitle)} />
+                <AppInput className="w-full" onChange={onChange} value={workspaceInfo.title} name="title" placeholder={t(placeHolder.workspaceTitle)} />
             </div>
             <div className="flex w-full flex-col gap-2">
                 <div className="body1">{t('WORKSPACE.SETTINGS.DETAILS.DESCRIPTION')}</div>
@@ -105,12 +161,16 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
                 />
             </div>
             <div className="flex w-full flex-col gap-2">
-                <div className="body1">Organization&apos;s Privacy Policy URL</div>
-                <AppInput onChange={onChange} value={workspaceInfo.privacy_policy} name="privacy_policy" placeholder={'Privacy Policy URL'} />
+                <div className="body1">Privacy Policy URL</div>
+                <AppInput className={`w-full ${urlErrors.privacy_policy ? '!border-[#C43D3D]' : ''}`} onChange={onChange} value={workspaceInfo.privacy_policy} name="privacy_policy" placeholder={'https://yoursite.com/privacy'} />
+                {urlErrors.privacy_policy && <div className="text-xs text-[#C43D3D]">{urlErrors.privacy_policy}</div>}
+                <div className="p4-new text-black-600">Linked from your site and from the trust footer on every form — it tells responders how their data is used.</div>
             </div>
             <div className="flex w-full flex-col gap-2">
-                <div className="body1">Organization&apos;s Terms of Service URL</div>
-                <AppInput onChange={onChange} value={workspaceInfo.terms_of_service} name="terms_of_service" placeholder={'Terms of Service URL'} />
+                <div className="body1">Terms of Service URL</div>
+                <AppInput className={`w-full ${urlErrors.terms_of_service ? '!border-[#C43D3D]' : ''}`} onChange={onChange} value={workspaceInfo.terms_of_service} name="terms_of_service" placeholder={'https://yoursite.com/terms'} />
+                {urlErrors.terms_of_service && <div className="text-xs text-[#C43D3D]">{urlErrors.terms_of_service}</div>}
+                <div className="p4-new text-black-600">Shown alongside the privacy policy on your site.</div>
             </div>
 
             <Button
@@ -119,7 +179,7 @@ export default function WorkspaceInfo({ workspace }: { workspace: WorkspaceDto }
                 className="mt-4 w-full"
                 type="submit"
                 size="medium"
-                variant="secondary"
+                variant="primary"
                 disabled={!workspaceInfo.title}
                 isLoading={isLoading}
             >

--- a/webapp/src/components/sidebar/dashboard-drawer.tsx
+++ b/webapp/src/components/sidebar/dashboard-drawer.tsx
@@ -27,20 +27,6 @@ import { selectWorkspace } from '@app/store/workspaces/slice';
 import Globe from '@Components/icons/globe';
 import WorkspaceMenuDropdown from '@Components/workspace/workspace-menu-dropdown';
 
-const GradientBgDiv = ({ className, children }: { className?: string, children: React.ReactNode }) => (
-    <div
-        className={className}
-        style={{
-            background: 'linear-gradient(90.01deg, #0764eb 0.01%, #fe3678 101.52%)',
-            backgroundClip: 'text',
-            WebkitBackgroundClip: 'text',
-            color: 'transparent'
-        }}
-    >
-        {children}
-    </div>
-);
-
 const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
     const { t } = useTranslation();
     const workspace: WorkspaceDto = useAppSelector(selectWorkspace);
@@ -64,12 +50,16 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
                             <WorkspaceMenuDropdown fullWidth />
                         </div>
 
-                        <Link href={commonWorkspaceUrl} className={cn('hover:bg-slate-100 mb-3 mt-2 flex cursor-pointer items-center gap-2 rounded-xl px-4 py-3 text-xs  font-medium group', pathname === commonWorkspaceUrl && 'bg-slate-100')}>
-                            <Globe width={20} height={20} className="text-blue-600" />
-                            <GradientBgDiv className="p3-new">Public Workspace</GradientBgDiv>
+                        {/* This is a link, so it speaks the one action colour —
+                            the old blue→pink gradient text was the loudest thing
+                            in the chrome and the exact "playful" note the trust
+                            language retires (Design-Language §1). */}
+                        <Link href={commonWorkspaceUrl} className={cn('hover:bg-black-100 mb-3 mt-2 flex cursor-pointer items-center gap-2 rounded-lg px-4 py-3 text-xs font-medium', pathname === commonWorkspaceUrl && 'bg-[#E9EFFC]')}>
+                            <Globe width={20} height={20} className="text-[#2456CC]" />
+                            <span className="p3-new text-[#2456CC]">Site</span>
                         </Link>
 
-                        <div className="my-3 border-t border-gray-200" />
+                        <div className="border-black-300 my-3 border-t" />
 
                         <div className="py-2">
                             <NavigationList navigationList={topNavList} />
@@ -88,15 +78,14 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
                     {/* Bottom section for free plan / ads */}
                     {isAdmin && !isProPlan && (
                         <div className="mt-4 pb-4">
-                            <div className="bg-slate-50 mx-4 mb-4 rounded-md p-4">
+                            <div className="bg-black-100 mx-4 mb-4 rounded-md p-4">
                                 <div className="h5-new mb-2">{t(pricingPlan.title)}</div>
                                 <div className="text-black-600 text-sm">For unlimited forms and many more features</div>
 
-                                {/* Shadcn Progress */}
                                 <Progress
-                                    className="mb-2 mt-4 h-2.5 bg-white border border-gray-100"
+                                    className="border-black-200 mb-2 mt-4 h-2.5 border bg-white"
                                     value={data?.forms || 0}
-                                    indicatorColor="#0764EB"
+                                    indicatorColor="#2456CC"
                                 />
 
                                 <div className="flex items-center justify-between text-xs font-semibold mt-2">
@@ -104,7 +93,7 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
                                         {data?.forms || 0}/100 {' ' + t(toolTipConstant.formImported)}
                                     </span>
                                     <span
-                                        className="cursor-pointer hover:underline text-blue-600"
+                                        className="cursor-pointer hover:underline text-[#2456CC]"
                                         onClick={() => {
                                             openFullScreenModal('UPGRADE_TO_PRO', { featureText: t(upgradeConst.features.unlimitedForms.slogan) });
                                         }}
@@ -115,7 +104,7 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
                             </div>
 
                             {environments.ENABLE_COUPON_CODES && (
-                                <div className="bg-slate-50 mx-4 mb-6 rounded-md p-4">
+                                <div className="bg-black-100 mx-4 mb-6 rounded-md p-4">
                                     <div className="h5-new mb-2">Pro Lifetime Deal</div>
                                     <div className="text-black-600 text-sm">
                                         Redeem{' '}
@@ -127,7 +116,7 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
 
                                     <div className="flex items-center justify-end text-xs font-semibold mt-2">
                                         <span
-                                            className="cursor-pointer hover:underline text-blue-600"
+                                            className="cursor-pointer hover:underline text-[#2456CC]"
                                             onClick={() => {
                                                 openModal('REDEEM_CODE_MODAL');
                                             }}

--- a/webapp/src/components/sidebar/navigation-list.tsx
+++ b/webapp/src/components/sidebar/navigation-list.tsx
@@ -25,12 +25,15 @@ export default function NavigationList({ navigationList, className = '', sx = {}
     return (
         <ul className={cn("flex flex-col gap-1 p-0 m-0 list-none", className)}>
             {navigationList?.map((element) => {
-                const active = element.url == pathname;
+                // Prefix match, not equality — nested routes (e.g.
+                // /responders-groups/all-responders, /members/collaborators)
+                // left the whole sidebar with nothing selected.
+                const active = pathname === element.url || pathname?.startsWith(element.url + '/');
                 return (
                     <li key={element.key}
                         className={cn(
                             "cursor-pointer rounded-lg text-sm transition-colors",
-                            active ? "bg-slate-100 text-slate-900 font-medium" : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                            active ? "bg-[#E9EFFC] text-[#2456CC] font-medium" : "text-black-700 hover:bg-black-100 hover:text-black-900"
                         )}
                         onClick={() => {
                             if (element.onClick) {
@@ -42,7 +45,7 @@ export default function NavigationList({ navigationList, className = '', sx = {}
                     >
                         <div className="flex items-center px-4 py-2 w-full">
                             {element.icon && (
-                                <span className={cn("mr-3 flex h-5 w-5 items-center justify-center", active ? "text-slate-900" : "text-slate-500")}>
+                                <span className={cn("mr-3 flex h-5 w-5 items-center justify-center", active ? "text-[#2456CC]" : "text-black-600")}>
                                     {element?.icon}
                                 </span>
                             )}

--- a/webapp/src/components/sidebar/sidebar-layout.tsx
+++ b/webapp/src/components/sidebar/sidebar-layout.tsx
@@ -8,7 +8,7 @@ import { FormIcon } from '@Components/icons/form-icon';
 import MembersIcon from '@Components/icons/members';
 import ResponderIcon from '@Components/icons/responder';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Trash2 } from 'lucide-react';
+import { Settings, Trash2 } from 'lucide-react';
 
 import { cn } from '@app/shadcn/util/lib';
 
@@ -27,6 +27,7 @@ import { selectAuth } from '@app/store/auth/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import { PopoverTrigger } from '@radix-ui/react-popover';
+import { useWorkspaceSettingsView } from '@app/store/jotai/workspace-settings-view';
 import { useFullScreenModal } from '../modal-views/full-screen-modal-context';
 import { ProLogo } from '../ui/logo';
 import HelpMenuComponent from './help-menu-component';
@@ -44,6 +45,7 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
     const auth = useAppSelector(selectAuth);
 
     const { openModal } = useFullScreenModal();
+    const { setSettingsViewOpen } = useWorkspaceSettingsView();
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const handleDrawerToggle = () => {
@@ -86,6 +88,18 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
         });
     const bottomNavList: Array<INavbarItem> = [
         {
+            key: 'workspace-settings',
+            // Settings live inside the Public Workspace frame (behind the
+            // address-bar gear) — this entry opens that view directly.
+            name: 'Site settings',
+            url: `/${workspace?.workspaceName}/dashboard/workspace-settings`,
+            icon: <Settings className="h-5 w-5 stroke-2" />,
+            onClick: () => {
+                setSettingsViewOpen(true);
+                router.push(commonWorkspaceUrl);
+            }
+        },
+        {
             key: 'members',
             name: t(members.default),
             url: `/${workspace?.workspaceName}/dashboard/members`,
@@ -122,6 +136,9 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
         // title instead of the generic "My Workspace" fallback.
         if (pathname?.includes('/dashboard/templates')) return 'Templates';
         if (pathname?.includes('/dashboard/account-settings')) return 'Account Settings';
+        // The dashboard root is the public-workspace mirror — title it the same
+        // as the sidebar entry that leads here.
+        if (pathname?.endsWith('/dashboard')) return 'Your site';
         return 'My Workspace';
     };
 

--- a/webapp/src/components/ui/logo.tsx
+++ b/webapp/src/components/ui/logo.tsx
@@ -49,9 +49,11 @@ Logo.defaultProps = {
 };
 export default Logo;
 
+// A quiet plan chip on the trust ramp. The old orange-gradient pill put white
+// text on #FFA004 (~2.1:1 contrast) in a display face used nowhere else.
 export const ProLogo = () => {
     return (
-        <div className="font-comfortaa flex h-fit flex-row  items-center rounded-[18px] bg-green-200 px-[5px] pb-[3px] pt-[5px] text-[13px] font-bold leading-[13px] text-white" style={{ background: 'linear-gradient(to right, #FFB843, #FFA004)' }}>
+        <div className="flex h-fit flex-row items-center rounded-full bg-[#FBF3E4] px-2 py-[2px] text-[11px] font-semibold leading-[14px] text-[#B26B00]">
             <span>Pro</span>
         </div>
     );

--- a/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
+++ b/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
@@ -17,7 +17,9 @@ interface IWorkspaceFormResponseDeletionCardProps {
     workspaceName: string;
 }
 
-const DefaultDiv = (props: any) => <div {...props} />;
+// Drop the href a Link would take — spreading href="" onto the div trips
+// React's empty-href warning.
+const DefaultDiv = ({ href, ...props }: any) => <div {...props} />;
 
 /**
  * A submission receipt. Its whole job is to let a responder pick THEIR

--- a/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
@@ -142,7 +142,7 @@ export default function WorkspaceFormCard({ form, hasCustomDomain, group, worksp
                             <>
                                 <DotIcon />
                                 <span className="text-black-600 text-sm">
-                                    {form?.responses} {t(`FORM.RESPONSE${(form?.responses || 0) > 1 ? 'S' : ''}`)}
+                                    {form?.responses} {t(`FORM.RESPONSE${(form?.responses || 0) === 1 ? '' : 'S'}`)}
                                 </span>
                             </>
                         )}

--- a/webapp/src/components/workspace-responders/workspace-responders.tsx
+++ b/webapp/src/components/workspace-responders/workspace-responders.tsx
@@ -145,7 +145,7 @@ export default function WorkspaceResponses({ workspace }: { workspace: Workspace
             selector: (responder: WorkspaceResponderDto) => responder.email,
             minWidth: '300px',
             style: {
-                color: '#202124',
+                color: '#101826',
                 fontSize: '14px',
                 fontWeight: 500,
                 paddingLeft: '16px',
@@ -157,7 +157,7 @@ export default function WorkspaceResponses({ workspace }: { workspace: Workspace
             name: t(formConstant.responses),
             selector: (responder: WorkspaceResponderDto) => responder.responses,
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px'
             }
@@ -166,7 +166,7 @@ export default function WorkspaceResponses({ workspace }: { workspace: Workspace
             name: t(formConstant.deletionRequests),
             selector: (responder: WorkspaceResponderDto) => responder.deletionRequests,
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px'
             }
@@ -175,7 +175,7 @@ export default function WorkspaceResponses({ workspace }: { workspace: Workspace
             name: t(groupConstant.default),
             selector: (responder: WorkspaceResponderDto) => ShowResponderGroups(responder.email),
             style: {
-                color: 'rgba(0,0,0,.54)',
+                color: '#3A465A',
                 paddingLeft: '16px',
                 paddingRight: '16px'
             }
@@ -219,7 +219,7 @@ export default function WorkspaceResponses({ workspace }: { workspace: Workspace
                     <p className="h3-new font-semibold">
                         {t(workspaceConstant.allResponders)} {data && ' (' + data.total + ')'}{' '}
                     </p>
-                    <div className="p2-new text-black-700 mt-2 max-w-[400px]">Below, you will find a list of responders who have filled forms of your workspace.</div>
+                    <div className="p2-new text-black-700 mt-2 max-w-[420px]">People who have filled in your forms. They can view or ask you to delete their responses at any time.</div>
                 </div>
                 <div className="w-full md:w-[282px]">
                     <SearchInput handleSearch={handleSearch} />

--- a/webapp/src/components/workspace/manage-urls.tsx
+++ b/webapp/src/components/workspace/manage-urls.tsx
@@ -1,7 +1,5 @@
 import { useTranslation } from 'next-i18next';
 
-
-
 import { CustomDomainCard } from '@app/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/custom-domain/_components/custom-domain-client';
 import { useModal } from '@app/components/modal-views/context';
 import { useCopyToClipboard } from '@app/lib/hooks/use-copy-to-clipboard';
@@ -12,6 +10,13 @@ import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import { Copy, Pencil } from 'lucide-react';
 
+/**
+ * Two clearly separated sections: the workspace link responders use today
+ * (with the one honest consequence of changing it), and the custom-domain
+ * option. The old layout floated a "Customize Link" button mid-paragraph
+ * next to a dictionary definition of "slug", 72px of dead space, and a
+ * domain form free users couldn't actually use.
+ */
 export default function ManageURLs() {
     const { t } = useTranslation();
     const workspace = useAppSelector(selectWorkspace);
@@ -19,53 +24,51 @@ export default function ManageURLs() {
     const { openModal } = useModal();
     const auth = useAppSelector(selectAuth);
 
+    const workspaceUrl = `${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.FORM_DOMAIN}/${workspace.workspaceName}`;
+
     const [_, copyToClipboard] = useCopyToClipboard();
     return (
-        <div className="mt-10 max-w-[788px]">
-            <div>
-                <div className="h3-new mb-2">{t('WORKSPACE.SETTINGS.URLS.TITLE')}</div>
-                <div className="flex flex-col gap-6 md:flex-row">
-                    <span className="p2-new text-black-700">{t('WORKSPACE.SETTINGS.URLS.DESCRIPTION')}</span>
+        <div className="flex max-w-[720px] flex-col gap-10 pb-10">
+            <section>
+                <div className="h4-new mb-1">{t('WORKSPACE.SETTINGS.URLS.TITLE')}</div>
+                <p className="p2-new text-black-700">{t('WORKSPACE.SETTINGS.URLS.DESCRIPTION')}</p>
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                    <span className="bg-black-100 text-black-800 rounded-lg px-3 py-2 font-mono text-sm">
+                        {window.PUBLIC_CONFIG?.HTTP_SCHEME}
+                        {window.PUBLIC_CONFIG?.FORM_DOMAIN}/<span className="font-semibold text-[#2456CC]">{workspace.workspaceName}</span>
+                    </span>
+                    <Button
+                        data-umami-event="Copy Default Workspace Link From Workspace Setting"
+                        data-umami-event-email={auth.email}
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => {
+                            copyToClipboard(workspaceUrl);
+                            toast({ description: 'Copied' });
+                        }}
+                    >
+                        <Copy className="mr-2 h-4 w-4" />
+                        {t('BUTTON.COPY')}
+                    </Button>
                     <Button
                         data-umami-event="Customize Workspace Link"
                         data-umami-event-email={auth.email}
-                        variant="ghost"
+                        size="sm"
+                        variant="v2Button"
                         onClick={() => {
                             openModal('UPDATE_WORKSPACE_HANDLE');
                         }}
                     >
-                        <Pencil className="mr-2 w-4 h-4" />
+                        <Pencil className="mr-2 h-4 w-4" />
                         {t('FORM_PAGE.SETTINGS.LINKS.CHANGE_SLUG')}
                     </Button>
                 </div>
-            </div>
-            <div className="mt-[72px]">
-                <div className="h4-new mb-2">{t('WORKSPACE.SETTINGS.URLS.DEFAULT')}</div>
-                <div className="p2-new flex items-center gap-4">
-                    <span>
-                        {window.PUBLIC_CONFIG?.HTTP_SCHEME}
-                        {window.PUBLIC_CONFIG?.FORM_DOMAIN}/<span className="text-pink">{workspace.workspaceName}</span>
-                    </span>
-                    <div>
-                        <Button
-                            data-umami-event="Copy Default Workspace Link From Workspace Setting"
-                            data-umami-event-email={auth.email}
-                            size="icon"
-                            variant="ghost"
-                            onClick={() => {
-                                copyToClipboard(`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.FORM_DOMAIN}/${workspace.workspaceName}`);
-                                toast({ description: 'Copied' });
-                            }}
-                        >
-                            <Copy width={16} height={16} />{/* check if I need children here, original was Copy */}
-                            {t('BUTTON.COPY')}
-                        </Button>
-                    </div>
-                </div>
-            </div>
-            <div className="mt-12">
+                {/* The consequence, stated up front — not discovered after. */}
+                <p className="p4-new text-black-600 mt-2">Changing the handle changes this link; the old link stops working.</p>
+            </section>
+            <section>
                 <CustomDomainCard />
-            </div>
+            </section>
         </div>
     );
 }

--- a/webapp/src/components/workspace/workspace-details.tsx
+++ b/webapp/src/components/workspace/workspace-details.tsx
@@ -13,7 +13,7 @@ import WorkspaceInfo from '@Components/settings/workspace-info';
 import { Copy } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
-export default function WorkspaceDetails() {
+export default function WorkspaceDetails({ showUrlRow = true }: { showUrlRow?: boolean }) {
     const workspace: WorkspaceState = useAppSelector(selectWorkspace);
     const router = useRouter();
     const { toast } = useToast();
@@ -23,7 +23,9 @@ export default function WorkspaceDetails() {
 
     return (
         <div className="w-full">
-            <div className="shadow-settings mb-10 flex flex-col items-start gap-2 px-5 py-4 md:px-20 lg:flex-row lg:items-center">
+            {/* Hidden inside the Public Workspace frame — the frame's address
+                bar already carries the URL, copy and open-live actions. */}
+            <div className={showUrlRow ? 'shadow-settings mb-10 flex flex-col items-start gap-2 px-5 py-4 lg:flex-row lg:items-center' : 'hidden'}>
                 <div
                     className="mr-4 flex cursor-pointer items-center gap-4"
                     onClick={() => {
@@ -58,12 +60,12 @@ export default function WorkspaceDetails() {
                     </ActiveLink>
                 </div>
             </div>
-            <div className="w-full max-w-full px-5 md:px-20">
+            {/* No extra horizontal padding — the settings container owns the
+                left edge, so the banner and form line up with the tabs. */}
+            <div className="w-full max-w-[720px]">
                 <BannerImageComponent workspace={workspace} isFormCreator={true} />
             </div>
-            <div className="lg:px-30 px-5 md:px-20">
-                <WorkspaceInfo workspace={workspace} />
-            </div>
+            <WorkspaceInfo workspace={workspace} />
         </div>
     );
 }

--- a/webapp/src/components/workspace/workspace-settings-content.tsx
+++ b/webapp/src/components/workspace/workspace-settings-content.tsx
@@ -1,0 +1,63 @@
+import cn from 'classnames';
+import { useTranslation } from 'next-i18next';
+import { useState } from 'react';
+
+import ManageURLs from '@Components/workspace/manage-urls';
+import WorkspaceDetails from '@Components/workspace/workspace-details';
+
+/**
+ * The workspace-settings surface (header, Details / Manage URLs tabs and
+ * panels), independent of its container. The Public Workspace mirror renders
+ * it inside its browser frame; the bottom-sheet modal (used by the
+ * URL-update deep links) wraps the same component — one settings surface,
+ * two containers, no drift.
+ *
+ * One horizontal padding, applied ONCE here: header, tabs and panel content
+ * all start on the same left edge (the panels used to add their own px-20+
+ * on top, indenting content past the tabs above it).
+ */
+export default function WorkspaceSettingsContent({ initialIndex = 0, showUrlRow = true }: { initialIndex?: number; showUrlRow?: boolean }) {
+    const { t } = useTranslation();
+    const [activeTab, setActiveTab] = useState(initialIndex === 1 ? 'manage-url' : 'workspace-details');
+
+    const tabMenu = [
+        {
+            title: t('WORKSPACE.SETTINGS.TABS.DETAILS'),
+            path: 'workspace-details'
+        },
+        {
+            title: t('MANAGE_URLS'),
+            path: 'manage-url'
+        }
+    ];
+
+    return (
+        <div className="px-5 md:px-10">
+            <div className="h2-new text-black-800 mb-2">{t('WORKSPACE.SETTINGS.DEFAULT')}</div>
+            <div className="p2-new text-black-700 mb-8 max-w-[520px]">{t('WORKSPACE.SETTINGS.DESCRIPTION')}</div>
+
+            <div className="border-black-300 flex space-x-1 overflow-x-auto border-b pb-0">
+                {tabMenu.map((tab) => {
+                    const isActive = activeTab === tab.path;
+                    return (
+                        <button
+                            key={tab.path}
+                            onClick={() => setActiveTab(tab.path)}
+                            className={cn(
+                                'flex items-center gap-2 px-4 py-2 text-sm font-medium mb-[-1px] cursor-pointer whitespace-nowrap border-b-2 transition-colors focus:outline-none',
+                                isActive ? 'border-[#2456CC] text-black-900' : 'text-black-600 hover:text-black-800 border-transparent'
+                            )}
+                        >
+                            {tab.title}
+                        </button>
+                    );
+                })}
+            </div>
+
+            <div className="mt-6">
+                {activeTab === 'workspace-details' && <WorkspaceDetails showUrlRow={showUrlRow} />}
+                {activeTab === 'manage-url' && <ManageURLs />}
+            </div>
+        </div>
+    );
+}

--- a/webapp/src/containers/onboarding.tsx
+++ b/webapp/src/containers/onboarding.tsx
@@ -142,13 +142,13 @@ const OnboardingContainer = ({ workspace, createWorkspace }: onBoardingProps) =>
         if (formData.title && formData.workspaceName) {
             await onClickDone();
         } else {
-            if (!formData.title) setErrors({ ...errors, title: 'Please enter organization name' });
+            if (!formData.title) setErrors({ ...errors, title: 'Please enter a workspace name' });
         }
     };
 
     const onWorkspaceTitleBlur = async (event: any) => {
         if (!event.target.value) {
-            setErrors({ ...errors, title: 'Please enter organization name' });
+            setErrors({ ...errors, title: 'Please enter a workspace name' });
             return;
         }
         if (createWorkspace && !formData.workspaceName) {
@@ -182,10 +182,10 @@ const OnboardingContainer = ({ workspace, createWorkspace }: onBoardingProps) =>
                 <div className="h3-new">{t(onBoarding.addYourOrganization)}</div>
                 <UploadLogo logoImageUrl={workspace?.profileImage ?? ''} className="mt-12" onUpload={handleUploadLogo} onRemove={handleRemoveLogo} />
                 <form className="mt-12 w-full space-y-8 md:w-[541px] " onSubmit={onSubmitForm}>
-                    {/* Organization Name Input Section */}
+                    {/* Workspace name input section */}
                     <div className="flex flex-col gap-1.5 w-full relative">
                         <Label htmlFor="title" className="text-sm font-medium ml-1 mb-1 text-gray-700">
-                            Organization Name
+                            Workspace name
                         </Label>
                         <AppInput
                             onBlur={onWorkspaceTitleBlur}
@@ -196,7 +196,7 @@ const OnboardingContainer = ({ workspace, createWorkspace }: onBoardingProps) =>
                             onChange={handleOnchange}
                             className={!!errors?.title ? 'border-red-500 focus-visible:ring-red-500 w-full' : 'w-full'}
                         />
-                        {/* Error Message for Organization Name */}
+                        {/* Error message for workspace name */}
                         {!!errors?.title && (
                             <span className="flex items-center gap-1 text-xs text-red-600 absolute -bottom-6 left-1">
                                 <InfoIcon className="h-3 w-3" /> {errors.title}
@@ -210,7 +210,7 @@ const OnboardingContainer = ({ workspace, createWorkspace }: onBoardingProps) =>
                     {/* Description Textarea Section */}
                     <div className="flex flex-col gap-1.5 w-full">
                         <Label htmlFor="description" className="text-sm font-medium ml-1 mb-1 text-gray-700">
-                            Add Your Organization Description
+                            Add a workspace description
                         </Label>
                         <Textarea
                             id="description"

--- a/webapp/src/containers/upgrade-to-pro.tsx
+++ b/webapp/src/containers/upgrade-to-pro.tsx
@@ -35,26 +35,24 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
 
     const { closeModal } = useFullScreenModal();
 
+    // One calm treatment for every card — the pastel-rainbow tints were the
+    // "playful" palette the trust language retires (Design-Language §1).
     const features = [
         {
             title: t(upgradeConst.features.unlimitedForms.title),
-            description: t(upgradeConst.features.unlimitedForms.description),
-            color: '#E5EFFF'
+            description: t(upgradeConst.features.unlimitedForms.description)
         },
         {
             title: t(upgradeConst.features.customDomain.title),
-            description: t(upgradeConst.features.customDomain.description),
-            color: '#FFE8F0'
+            description: t(upgradeConst.features.customDomain.description)
         },
         {
             title: t(upgradeConst.features.collaborator.title),
-            description: t(upgradeConst.features.collaborator.description),
-            color: '#E4FFF4'
+            description: t(upgradeConst.features.collaborator.description)
         },
         {
             title: t(upgradeConst.features.workspace.title),
-            description: t(upgradeConst.features.workspace.description),
-            color: '#FFF7E9'
+            description: t(upgradeConst.features.workspace.description)
         }
     ];
     const router = useRouter();
@@ -76,10 +74,14 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                 </div>
             </div>
             <>
+                {/* One honest claim, stated once. The old copy said "is Free"
+                    up top and "Free for 90 days!" at the bottom — but the
+                    upgrade has no expiry in code, so the 90-day line was a
+                    surprise waiting to be discovered (Design-Language §5). */}
                 <div className="h2-new mb-2 text-center">
-                    bettercollected PRO is <span className="text-new-pink">Free</span>
+                    bettercollected PRO is <span className="text-[#2456CC]">currently free</span>
                 </div>
-                <div className="p2-new text-black-700 max-w-[426px] text-center">You won&apos;t be charged any money. Share your thoughts on what the best price would be. Future pricing will be based on your suggestions.</div>
+                <div className="p2-new text-black-700 max-w-[426px] text-center">No card needed and nothing is charged. Tell us what PRO would be worth to you — future pricing will be based on these suggestions.</div>
                 <div className="mt-10 flex flex-wrap justify-center gap-2">
                     {prices.map((price, index) => {
                         return (
@@ -91,7 +93,7 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                                     setCustomPrice('');
                                 }}
                                 className={cn(
-                                    'bg-black-100 hover:text-black-800 flex h-10 w-[70px] cursor-pointer items-center justify-center font-medium ' + 'text-black-500 rounded-lg hover:border hover:border-blue-200' + ' hover:bg-white',
+                                    'bg-black-100 hover:text-black-800 flex h-10 w-[70px] cursor-pointer items-center justify-center font-medium ' + 'text-black-500 rounded-lg hover:border hover:border-[#A8C0EA]' + ' hover:bg-white',
                                     price === activeSuggestion && 'shadow-suggestion-price !text-black-800 bg-white'
                                 )}
                             >
@@ -99,7 +101,7 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                             </div>
                         );
                     })}
-                    <div className={cn('focus-within:shadow-suggestion-price hidden h-10 rounded-lg border border-blue-100 lg:flex', customPrice && 'shadow-suggestion-price')}>
+                    <div className={cn('focus-within:shadow-suggestion-price hidden h-10 rounded-lg border border-black-300 lg:flex', customPrice && 'shadow-suggestion-price')}>
                         <div className="bg-black-100 text-black-500 flex h-full w-full items-center justify-center rounded-l-lg px-2">$</div>
                         <input
                             type="number"
@@ -152,9 +154,8 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                             });
                         }}
                     >
-                        Start Pro account
+                        Activate PRO for free
                     </Button>
-                    <div className="p2-new text-black-600 text-center italic">Free for 90 days!</div>
                 </div>
             </>
             {/* )} */}
@@ -163,7 +164,7 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                 <div className="grid w-full grid-cols-1 gap-4 md:grid-cols-2">
                     {features.map((feature: any, idx: number) => {
                         return (
-                            <div key={feature.title + idx} style={{ background: feature.color }} className={`flex flex-col rounded-lg p-4`}>
+                            <div key={feature.title + idx} className="border-black-300 bg-black-100 flex flex-col rounded-lg border p-4">
                                 <div className="h4-new font-medium ">{feature.title}</div>
 
                                 <div className="p2-new text-black-700 mt-2">{feature.description}</div>

--- a/webapp/src/shadcn/components/ui/button.tsx
+++ b/webapp/src/shadcn/components/ui/button.tsx
@@ -14,7 +14,7 @@ const buttonVariants = cva('rounded-lg gap-2 min-w-fit flex justify-center items
             tertiary: 'text-blue-500 border border-brand-500 hover:bg-brand-100 focus:ring focus:ring-blue-500 ' + 'active:bg-brand-600 disabled:bg-transparent disabled:border disabled:text-black-500 ' + 'disabled:border-black-300',
             secondary: 'bg-black-800 text-white hover:bg-black-900 focus:ring-blue-500 focus-ring active:bg-black-900' + 'disabled:bg-black-300 disabled:text-black-500',
             ghost: 'text-brand-500 border border-transparent hover:bg-black-200 outline-none ' + 'active:border-brand-500 active:bg-black-300 disabled:bg-black-300 disabled:text-black-500',
-            dangerGhost: 'bg-red-100 text-red hover:bg-red-200 focus:ring-red-500 focus-ring active:bg-red-300' + 'disabled:bg-black-300 disabled:text-black-500',
+            dangerGhost: 'text-[#C43D3D] border border-transparent hover:bg-[#FBEFEF] active:bg-[#F5DFDF] outline-none focus:ring ' + 'disabled:bg-black-300 disabled:text-black-500',
             v2Button: 'border border-black-300 bg-white text-black-600 hover:bg-black-200 active:text-black-800 hover:text-black-800 active:bg-black-300  active:bg-black-400' + 'disabled:bg-black-300 disabled:text-black-500',
             v2GhostButton:
                 'text-black-600 text-xs border border-transparent hover:bg-black-200 hover:text-black-800 outline-none rounded-lg ring' +

--- a/webapp/src/store/jotai/workspace-settings-view.ts
+++ b/webapp/src/store/jotai/workspace-settings-view.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { atom, useAtom } from 'jotai';
+
+// The Public Workspace mirror shows workspace settings inside its browser
+// frame. This flag lets the sidebar "Workspace settings" item request that
+// view before (or after) navigating to the dashboard root.
+const workspaceSettingsViewAtom = atom(false);
+
+export function useWorkspaceSettingsView() {
+    const [settingsViewOpen, setSettingsViewOpen] = useAtom(workspaceSettingsViewAtom);
+    return { settingsViewOpen, setSettingsViewOpen };
+}

--- a/webapp/src/store/workspaces/api.ts
+++ b/webapp/src/store/workspaces/api.ts
@@ -160,7 +160,10 @@ export const workspacesApi = createApi({
                 url: `/workspaces/${request.workspaceId}/forms/${request.formId}/response/${request.responseId}`,
                 method: 'DELETE'
             }),
-            invalidatesTags: [SUBMISSION_TAG]
+            // The deletion-requests table (getWorkspaceAllSubmissions) and the
+            // pending counter (getWorkspaceStats) only carry WORKSPACE_TAGS —
+            // without it they kept showing the row as Pending after the delete.
+            invalidatesTags: [SUBMISSION_TAG, WORKSPACE_TAGS]
         }),
         importForm: builder.mutation<any, ImportFormQueryInterface>({
             query: (request) => ({

--- a/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.ts
+++ b/webapp/src/utils/richTextEditorExtenstion/get-html-from-json.ts
@@ -22,7 +22,10 @@ export function getHtmlFromJson(value: JSONContent | string | undefined) {
  */
 export function extractTextfromJSON(field: StandardFormFieldDto): string {
     const title = field.title;
-    if (!title) return getPlaceholderValueForTitle(field.type || FieldTypes.TEXT);
+    // Fields created before the rich-text title carry their question in the
+    // legacy `value` string with a null title — prefer it over the generic
+    // per-type placeholder.
+    if (!title) return (typeof field.value === 'string' && field.value) || getPlaceholderValueForTitle(field.type || FieldTypes.TEXT);
     if (typeof title === 'string') return title;
 
     const walk = (node: any): string => {

--- a/webapp/src/utils/vvalidation-utils.ts
+++ b/webapp/src/utils/vvalidation-utils.ts
@@ -50,18 +50,27 @@ export function isNetherUndefinedNorNull(data: unknown): boolean {
     return !isUndefined(data) && !isNull(data);
 }
 
+// Status chips speak the trust palette: pending is amber (needs attention, not
+// an error — the old red chip read like something had gone wrong), done is
+// consent green, and anything else passes through as a neutral chip with its
+// own name instead of being mislabelled "Deleted".
 export const statusProps = (status: string, t: any) => {
-    let currentStatus = t('FORM.STATUS_DELETED');
-    let cName = 'bg-black-200 !text-black-800 dark:bg-yellow-900 dark:text-yellow-300';
-    let dotCName = 'bg-black-800';
-    if (status.toLowerCase() === 'pending') {
+    const normalized = status.toLowerCase();
+    let currentStatus = status;
+    let cName = 'bg-black-200 !text-black-800';
+    let dotCName = 'bg-black-600';
+    if (normalized === 'pending') {
         currentStatus = t(formConstant.status.pending);
-        cName = 'bg-red-200 !text-red-400 dark:bg-red-900 dark:text-red-300';
-        dotCName = 'bg-red-400';
-    } else if (status.toLowerCase() === 'deleted') {
+        cName = 'bg-[#FBF3E4] !text-[#B26B00]';
+        dotCName = 'bg-[#B26B00]';
+    } else if (normalized === 'success' || normalized === 'deleted') {
+        // The backend marks a fulfilled deletion request "success"; to the
+        // person reading the table the fact is that the response is deleted.
+        currentStatus = t('FORM.STATUS_DELETED');
+        cName = 'bg-[#E7F4EE] !text-[#0E8A5F]';
+        dotCName = 'bg-[#0E8A5F]';
+    } else if (normalized === 'expired') {
         currentStatus = t(formConstant.status.expired);
-        cName = 'bg-yellow-100 !text-yellow-500';
-        dotCName = 'bg-yellow-400';
     }
     return {
         currentStatus,

--- a/webapp/src/views/organism/form-builder/slide-builder.tsx
+++ b/webapp/src/views/organism/form-builder/slide-builder.tsx
@@ -37,8 +37,11 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
 
     return (
         <SlideLayoutWrapper showDesktopLayout slide={slide} disabled={disabled} theme={theme} scrollDivId={!disabled ? 'scroll-div' : undefined}>
-            <div className="flex h-full w-full flex-col justify-center gap-20 px-6 py-[10vh] ">
-                <div className="flex h-full w-full flex-col gap-20 px-6">
+            {/* 64px between question groups — the same rhythm the responder
+                sees (WYSIWYG). The old stack doubled up: gap-20 twice, py-[10vh]
+                on top of LayoutWrapper's own py-[60px], and px-6 twice. */}
+            <div className="flex h-full w-full flex-col justify-center px-6 py-4">
+                <div className="flex w-full flex-col gap-16">
                     <AnimatePresence>
                         {Array.isArray(slideFields) && slideFields.length ? (
                             slideFields.map((field, index) => {
@@ -51,7 +54,9 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                                             animate: { x: 0 },
                                             transition: { duration: 0.5 },
                                             id: disabled ? field.id : `scroll-field-${field.id}`,
-                                            className: cn('relative flex h-full w-full flex-row  items-center first:!pt-[0%]', slide.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')
+                                            // Rows size to content — h-full made every row stretch to an
+                                            // equal share of the slide, so spacing changed with field count.
+                                            className: cn('relative flex w-full flex-row items-center', slide.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')
                                         } as any)
                                         }
                                     >

--- a/webapp/src/views/organism/form-preview/form-slide-preview.tsx
+++ b/webapp/src/views/organism/form-preview/form-slide-preview.tsx
@@ -22,7 +22,8 @@ export default function FormSlidePreview({ slide, theme }: { slide: StandardForm
     return (
         <SlideLayoutWrapper showDesktopLayout slide={slide} theme={slideTheme} disabled>
             <div className={cn('flex w-full ', slide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')}>
-                <div className="relative my-10 grid h-full w-full max-w-[800px] flex-1 grid-cols-1 content-center gap-20 px-5 lg:my-20 lg:px-20">
+                {/* Same 64px group rhythm as the builder canvas and the live form. */}
+                <div className="relative my-10 grid h-full w-full max-w-[800px] flex-1 grid-cols-1 content-center gap-16 px-5 lg:my-20 lg:px-20">
                     {slide?.properties?.fields?.map((field) => {
                         return <FormFieldComponent key={field.id} field={field} slideIndex={slide!.index} />;
                     })}

--- a/webapp/src/views/organism/form/form-slide.tsx
+++ b/webapp/src/views/organism/form/form-slide.tsx
@@ -246,7 +246,11 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                     </div>
                 </div>
                 <div className={cn('flex h-full flex-1 flex-col justify-center ', formSlide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'items-start ' : 'items-center')}>
-                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 lg:gap-[120px] py-[60px]', isPreviewMode ? '' : 'lg:px-10')}>
+                    {/* 48px/64px between question groups (~6-8× the 8px gap inside a
+                        group) — 120px broke proximity grouping: pairs read as
+                        separate screens, and long pages scrolled far more than
+                        their content needed. */}
+                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 lg:gap-[64px] py-[60px]', isPreviewMode ? '' : 'lg:px-10')}>
                         {formSlide?.properties?.fields
                             ?.filter((field: StandardFormFieldDto) => !hiddenFieldIds.has(field.id))
                             .map((field: StandardFormFieldDto) => <FormFieldComponent key={field.id} field={field} slideIndex={formSlide!.index} />)}


### PR DESCRIPTION
## Summary

Continues the trust-first pass onto the dashboard chrome and ships the "your site" concept: the workspace is where you work; your site is what the world sees.

### Deletion requests become actionable
- Pending rows carry a first-class **Delete response** action through a consequence-stating confirmation (the only delete affordance was a kebab rendered with a literal `hidden` class — fulfilling a request was impossible from the UI — and even unhidden it deleted with no confirm).
- Deleting refreshes the table and pending counter (cache-tag fix); chips are amber **Pending** / green **Deleted** (the backend's `success` value was previously mislabelled); rows show receipt numbers so anonymous requests can be matched to what a responder quotes.
- The response drawer now receives the fetched form: question titles render (including legacy `value`-titled fields), answer pipes resolve with that submission's answers, unanswered fields say "No answer".

### Dashboard chrome on the trust palette
- De-rainbowed: gradient "Public Workspace" text and the 2.1:1 orange Pro pill are quiet trust-ramp chips/links; nav active state prefix-matches (nested routes highlighted nothing) with trust-blue selection; data tables, account dropdown, page tabs and copy retuned to ink/hairline tokens.
- **Upgrade modal made honest**: it promised "won't be charged" above "Free for 90 days!" while the upgrade has no expiry in code — it now makes one true claim ("currently free"), with calm feature cards.

### Your site
- The dashboard root mirrors the responder portal **inside a browser frame** — real public URL in an address pill (copy / open live) and a **Site settings** gear on the chrome, never inside the mirrored content. Same tabs and content components as the portal, so the mirror can't drift; cards open the live form in a new tab. Receipt-search card moved into the sidebar on both surfaces (two-column everywhere).
- **Site settings render in-frame** behind the gear (deep-links keep the bottom sheet, wrapping the same shared component). Fixed the `value={null}` React error and the snake/camel save-diff bug; one left edge for header/tabs/panels; Link & domain reorganised (free users no longer see a domain form that only bounced to the upgrade modal); full-width, validated policy-URL inputs (these render as links in every form's trust footer — http/https only, whitespace rejected, missing scheme forgiven).
- **One vocabulary**: "Site" nav label, "your site" in copy, "Site settings" with Identity / Link & domain tabs; onboarding creates a workspace, not an "Organization".

### Form pages
- Field rhythm 48/64px on builder, live form and previews (was 80/120px plus a per-row `h-full` stretch that changed spacing with field count) — honest WYSIWYG.
- Preview modal rebuilt: quiet header (Preview chip, "Answers aren't saved", Share/Publish) over a 16:9 stage that fits the viewport — it used to open on a mobile-editing banner with the form clipped off-screen.

## Test plan
- [x] All 149 webapp vitest tests pass
- [x] Browser-verified end-to-end: deletion request fulfilled (pending → Deleted, counter updates live), drawer pipes resolve, mirror tabs + live-form opens, in-frame settings open/save/close from gear and sidebar, URL validation blocks bad links and normalizes scheme-less ones, spacing on a 6-question page, preview modal walkthrough
- [ ] Re-verify on a Pro workspace (custom-domain form path in Link & domain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)