### PR TITLE
Sign-in page redesigned as the first trust decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,17 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Fixed
 
+- **Sign-in page redesigned as the first trust decision.** The pitch panel
+  was a gradient marketing collage with outdated UI screenshots and a
+  sentence that ended mid-thought; it's now a calm ink panel stating what
+  bettercollected is ("Your forms, on a site you own") with three honest
+  bullets (trust footer, your own site, responders' view/delete rights), a
+  responder-aware variant for portal "Verify email" arrivals, and a
+  passwordless pitch on the code step ("One code, no passwords — nothing to
+  create, remember, or leak"). The code step now says where the code went
+  and offers "Change email" (a typo used to be a dead end); copy fixes
+  throughout ("Sign in with Google or your email — no password needed",
+  "or continue with email", sentence-case buttons, grammar).
 - **Workspace settings: React error fixed and given a discoverable home.**
   Opening the settings sheet errored (`value` prop on `input` should not be
   null): the privacy-policy and terms URLs fed null into controlled inputs

--- a/webapp/public/locales/en/common.json
+++ b/webapp/public/locales/en/common.json
@@ -594,8 +594,8 @@
   "SIGNIN_SCREEN": {
     "EMAIL_INPUT_LABEL": "Email",
     "COLLECT_FORMS": "Collect your forms",
-    "WELCOME_BACK": "Welcome Back!",
-    "SIGNIN_TO_CONTINUE": "Please sign in to continue",
+    "WELCOME_BACK": "Welcome back",
+    "SIGNIN_TO_CONTINUE": "Sign in with Google or your email — no password needed.",
     "CONTINUE_WITH": "Don't have an account?",
     "DELETE_RESPONSES": "Delete responses",
     "EASY_TO_MANAGE_FORMS": "Easy to manage forms",
@@ -606,18 +606,18 @@
     "WELCOME_MESSAGE": "Welcome back!",
     "FEATURES": {
       "TITLE": "Your forms, on a site you own",
-      "OTP_TITLE": "Custom URLs and Improved SEO",
-      "DESCRIPTION": "Create your custom Form Page to centralize all your forms (bettercollected forms, Google Forms and Typeform). This personalized solution allows you to gather and manage all your forms within a single.",
-      "OTP_DESCRIPTION": "Replace default links with your own URLs that better represent your business and enhance your online presence."
+      "OTP_TITLE": "One code, no passwords",
+      "DESCRIPTION": "bettercollected is the privacy-first form builder — quiet, honest forms people feel safe filling in.",
+      "OTP_DESCRIPTION": "We emailed you a 6-digit sign-in code — nothing to create, remember, or leak."
     },
-    "SEND_CODE_BUTTON": "Send Code",
+    "SEND_CODE_BUTTON": "Send code",
     "SIGN_IN_BUTTON": "Sign In",
-    "OR_SIGN_IN_USING": "Or sign in using",
+    "OR_SIGN_IN_USING": "or continue with email",
     "VERIFICATION": {
       "TITLE": "Verification",
-      "DESCRIPTION": "6-digit has been sent in your email"
+      "DESCRIPTION": "We emailed you a 6-digit code."
     },
-    "ENTER_OTP_CODE": "Enter OTP Code",
+    "ENTER_OTP_CODE": "Enter the 6-digit code",
     "ENTER_CODE_PLACEHOLDER": "eg: 000000",
     "BACK_BUTTON_TITLE": "Back",
     "DIDNOT_RECEIVE_CODE": "Did not receive code?",
@@ -630,9 +630,9 @@
     "SIGN_UP": "Sign Up",
     "VERIFICATION": {
       "TITLE": "Verification",
-      "DESCRIPTION": "6-digit has been sent in your email"
+      "DESCRIPTION": "We emailed you a 6-digit code."
     },
-    "ENTER_OTP_CODE": "Enter OTP Code",
+    "ENTER_OTP_CODE": "Enter the 6-digit code",
     "ENTER_CODE_PLACEHOLDER": "eg: 000000",
     "SIGNUP_AGREEMENT_DESCRIPTION": "By signing up, you agree to our",
     "SIGNUP_TO_CONTINUE": "You can sign up by simply signing in with Google or Typeform, or using your email.",
@@ -640,7 +640,7 @@
       "TITLE": "We’re a privacy-focused form builder platform",
       "OTP_TITLE": "Become a better data collector.",
       "OTP_SUBTITLE": "Becoming a customer of bettercollected is a promise to",
-      "DESCRIPTION": "Unlike other form builders, we put form responders’ privacy rights at the fore front.",
+      "DESCRIPTION": "Unlike other form builders, we put form responders' privacy rights at the forefront.",
       "OTP_DESCRIPTION": "We make sure that the responders can access their form responses and can request deletion of their responses whenever they choose to do so."
     }
   },

--- a/webapp/src/app/(auth)/_components/login-view.tsx
+++ b/webapp/src/app/(auth)/_components/login-view.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import Image from "next/legacy/image";
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { Globe, ShieldCheck, Trash2 } from 'lucide-react';
 
 import Logo from '@app/components/ui/logo';
 import { localesCommon } from '@app/constants/locales/common';
@@ -11,93 +12,86 @@ import { signInScreen } from '@app/constants/locales/signin-screen';
 import { signUpScreen } from '@app/constants/locales/signup-screen';
 import TopNavLayout from '@app/layouts/top-navbar-layout';
 
-import ImageSignInPreview from '@app/assets/images/sign-in-image.png';
-import ImageSignInVerification from '@app/assets/images/sign-in-verification.png';
-import ImageSignUpPreview from '@app/assets/images/sign-up-image.png';
-import ImageSignUpValidation from '@app/assets/images/sign-up-verification.png';
-
 import OtpCodeForm from './otp-code-form';
 import OtpEmailForm from './otp-email-form';
 
+/**
+ * The sign-in screen is the first trust decision anyone makes about the
+ * product, so the pitch panel practices what the product preaches: a calm
+ * ink surface stating what bettercollected is and the rights it gives
+ * responders — instead of the old marketing collage (gradient background,
+ * outdated UI screenshots, and a sentence that ended mid-thought).
+ */
 export default function LoginView() {
     const { t } = useTranslation();
-    const isSignup = useSearchParams()?.get('isSignup') === 'true';
+    const searchParams = useSearchParams();
+    const isSignup = searchParams?.get('isSignup') === 'true';
+    // Responders land here from a portal's "Verify email" — pitching the form
+    // builder at them would be talking to the wrong person.
+    const isResponder = searchParams?.get('type') === 'responder';
     const [email, setEmail] = useState('');
 
-    const constants = {
-        signInEmailTitle: t(signInScreen.features.title),
-        signInEmailDescription: t(signInScreen.features.description),
-        signInCodeTitle: t(signInScreen.features.otp_title),
-        signInCodeDescription: t(signInScreen.features.otp_description),
-        signUpLogoSubTitle: t(signUpScreen.logoDescription),
-        signUpAgreementDescription: t(signUpScreen.signUpAgreementDescription),
-        signUpEmailTitle: t(signUpScreen.features.title),
-        signUpEmailDescription: t(signUpScreen.features.description),
-        signUpCodeTitle: t(signUpScreen.features.otp_title),
-        signUpCodeSubTitle: t(signUpScreen.features.otp_subtitle),
-        signUpCodeDescription: t(signUpScreen.features.otp_description),
-    };
+    const creatorBullets = [
+        { icon: ShieldCheck, text: 'A trust footer on every form — who is collecting, why, and the rights responders keep' },
+        { icon: Globe, text: 'Every workspace gets its own branded site, with custom domains on Pro' },
+        { icon: Trash2, text: 'Responders can view or delete their responses at any time' }
+    ];
+
+    const panel = isResponder
+        ? {
+              title: 'See your submissions',
+              description: "Verify your email to see every response you've submitted to this workspace — and request deletion of any of them.",
+              bullets: undefined
+          }
+        : email
+          ? {
+                title: t(isSignup ? signUpScreen.features.otp_title : signInScreen.features.otp_title),
+                description: t(isSignup ? signUpScreen.features.otp_description : signInScreen.features.otp_description),
+                bullets: undefined
+            }
+          : {
+                title: t(isSignup ? signUpScreen.features.title : signInScreen.features.title),
+                description: t(isSignup ? signUpScreen.features.description : signInScreen.features.description),
+                bullets: creatorBullets
+            };
 
     return (
         <TopNavLayout className="min-h-screen !mt-0 !p-0">
-            <div className="h-full w-full flex flex-col lg:flex-row">
-                <div className="bg-sign-in bg-no-repeat bg-cover relative min-h-fit sm:min-h-screen order-2 lg:order-1 overflow-hidden w-full lg:w-[50%] flex flex-col justify-start">
-                    {email ? (
-                        <PreviewContent
-                            title={isSignup ? constants.signUpCodeTitle : constants.signInCodeTitle}
-                            description={isSignup ? constants.signUpCodeDescription : constants.signInCodeDescription}
-                            subtitle={isSignup ? constants.signUpCodeSubTitle : undefined}
-                            image={isSignup ? ImageSignUpValidation : ImageSignInVerification}
-                        />
-                    ) : (
-                        <PreviewContent
-                            title={isSignup ? constants.signUpEmailTitle : constants.signInEmailTitle}
-                            description={isSignup ? constants.signUpEmailDescription : constants.signInEmailDescription}
-                            image={isSignup ? ImageSignUpPreview : ImageSignInPreview}
-                        />
+            <div className="flex h-full w-full flex-col lg:flex-row">
+                <div className="order-2 flex w-full flex-col justify-center gap-8 bg-[#101826] px-8 py-14 lg:order-1 lg:min-h-screen lg:w-1/2 lg:px-16">
+                    <h1 className="max-w-[480px] text-[26px] font-semibold leading-snug text-white lg:text-[32px]">{panel.title}</h1>
+                    <p className="max-w-[440px] text-[15px] leading-relaxed text-[#A8B3C4]">{panel.description}</p>
+                    {panel.bullets && (
+                        <ul className="flex max-w-[460px] flex-col gap-5">
+                            {panel.bullets.map(({ icon: Icon, text }) => (
+                                <li key={text} className="flex items-start gap-3 text-[15px] leading-relaxed text-[#DFE5EE]">
+                                    <Icon className="mt-0.5 h-5 w-5 shrink-0 text-[#A8C0EA]" strokeWidth={1.8} aria-hidden="true" />
+                                    {text}
+                                </li>
+                            ))}
+                        </ul>
                     )}
                 </div>
-                <div className="relative flex flex-col order-1 lg:order-2 items-start justify-between px-8 py-7 lg:py-8 xl:pl-[90px] xl:pr-28 min-h-fit sm:min-h-screen w-full lg:max-w-[50%]">
+                <div className="relative order-1 flex min-h-fit w-full flex-col items-start justify-between px-8 py-7 sm:min-h-screen lg:order-2 lg:max-w-[50%] lg:py-8 xl:pl-[90px] xl:pr-28">
                     <div className="mb-20 lg:mb-0">
                         <Logo isLink={false} />
-                        <h1 className="body4 !text-black-800 mt-2">{constants.signUpLogoSubTitle}</h1>
+                        <h1 className="body4 !text-black-800 mt-2">{t(signUpScreen.logoDescription)}</h1>
                     </div>
 
-                    <div className="w-full">
-                        {!email ? (
-                            <OtpEmailForm setEmail={setEmail} isSignup={isSignup} />
-                        ) : (
-                            <OtpCodeForm email={email} setEmail={setEmail} />
-                        )}
-                    </div>
+                    <div className="w-full">{!email ? <OtpEmailForm setEmail={setEmail} isSignup={isSignup} /> : <OtpCodeForm email={email} setEmail={setEmail} />}</div>
 
-                    <TermsAndCondition isSignup={isSignup} constants={constants} />
+                    <TermsAndCondition isSignup={isSignup} />
                 </div>
             </div>
         </TopNavLayout>
     );
 }
 
-const PreviewContent = ({ title, description, subtitle, image }: { title: string, description: string, subtitle?: string, image: any }) => (
-    <>
-        <div className="flex flex-col gap-4 items-center justify-center px-8 mt-28 mb-8 lg:max-h-[300px] text-center">
-            {subtitle && <h1 className="text-base font-semibold text-white mb-1">{subtitle}</h1>}
-            <h1 className="text-base md:text-[32px] leading-normal text-white font-semibold sm:w-[500px]">{title}</h1>
-            <span className="font-normal text-black-200 text-xs md:text-base sm:w-[400px]">{description}</span>
-        </div>
-        <div className="flex w-full justify-center lg:px-[60px] px-8 ">
-            <div className="lg:h-[400px] h-[300px] w-fit">
-                <Image src={image} alt="BetterCollected" objectFit="contain" />
-            </div>
-        </div>
-    </>
-);
-
-const TermsAndCondition = ({ isSignup, constants }: { isSignup: boolean, constants: any }) => {
+const TermsAndCondition = ({ isSignup }: { isSignup: boolean }) => {
     const { t } = useTranslation();
     return (
         <div className="body4 mt-24 lg:mt-0">
-            {t(isSignup ? constants.signUpAgreementDescription : signInScreen.signinAgreementDescription)}
+            {t(isSignup ? signUpScreen.signUpAgreementDescription : signInScreen.signinAgreementDescription)}
             <a href="https://bettercollected.com/terms-of-service" target="_blank" rel="noreferrer" className="mx-1 cursor-pointer underline text-brand-500 hover:text-brand-600">
                 {t(localesCommon.termsOfServices.title)}
             </a>

--- a/webapp/src/app/(auth)/_components/otp-code-form.tsx
+++ b/webapp/src/app/(auth)/_components/otp-code-form.tsx
@@ -81,7 +81,15 @@ export default function OtpCodeForm({ email, isModal, setEmail: setParentEmail }
 
     return (
         <form onSubmit={handleOtpPost} className="w-full">
-            <p className="text-black-900 mb-3 text-base font-semibold">{constants.enterOtpCode}</p>
+            <p className="text-black-900 mb-1 text-base font-semibold">{constants.enterOtpCode}</p>
+            {/* Say where the code went and offer a way back — a mistyped email
+                was a dead end (the only recovery was reloading the page). */}
+            <p className="text-black-700 mb-3 text-sm">
+                We emailed a 6-digit code to <span className="font-medium">{email}</span>.{' '}
+                <button type="button" className="text-brand-500 hover:text-brand-600 underline underline-offset-2" onClick={() => setParentEmail('')}>
+                    Change email
+                </button>
+            </p>
             <Input
                 autoFocus
                 placeholder={constants.enterOtpCodePlaceholder}
@@ -90,7 +98,7 @@ export default function OtpCodeForm({ email, isModal, setEmail: setParentEmail }
                     setOtp(e.target.value);
                     setIsError(false);
                 }}
-                className={isError ? 'border-red-500' : ''}
+                className={isError ? 'border-[#C43D3D]' : ''}
             />
 
             <div className="mt-8 flex items-center justify-between text-base">


### PR DESCRIPTION
## Summary

The sign-in screen is the first trust decision anyone makes about the product, so it now practices what the product preaches.

**Before:** a gradient marketing background with outdated product screenshots, a value-prop sentence that ended mid-thought ("…manage all your forms within a single."), and OTP-step filler about "Custom URLs and Improved SEO."

**Now:**
- **Calm ink panel** carrying the naming scheme's own headline — *"Your forms, on a site you own"* — with three honest bullets: the trust footer on every form; every workspace gets its own branded site (custom domains on Pro); responders can view or delete their responses at any time. No screenshots to age out.
- **Responder-aware**: arrivals from a portal's "Verify email" (`?type=responder`) see *"See your submissions"* and the portal's own promise instead of a form-builder pitch.
- **Code step is honest about itself**: panel says *"One code, no passwords — nothing to create, remember, or leak"*; the form states where the code went and offers **Change email** (a typo used to be a dead end recoverable only by reloading). Error border in muted red.
- **Copy pass**: "Welcome back", *"Sign in with Google or your email — no password needed"*, "or continue with email", "Send code", "Enter the 6-digit code", grammar/typo fixes ("6-digit has been sent in your email", "fore front").

## Test plan
- [x] All 149 webapp vitest tests pass
- [x] Verified end to end in the browser: logged out → email step → code step (context line + change-email + resend countdown) → signed in with the OTP
- [ ] Eyeball the responder variant (`/login?type=responder&workspace_id=…`) from a logged-out portal arrival

🤖 Generated with [Claude Code](https://claude.com/claude-code)