### PR TITLE
Site nav groups, active-state fix, and browser-frame scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,33 @@ See [RELEASING.md](RELEASING.md) for how releases are cut.
 
 ### Fixed
 
+- The "Your site" browser frame now behaves like a real browser on desktop:
+  bounded to the viewport with fixed chrome, the site content scrolls INSIDE
+  the frame instead of the dashboard page scrolling around it. Matching the
+  responder portal, the left column (identity + receipt search) and the tabs
+  stay affixed — only the tab content scrolls (an earlier pass scrolled the
+  whole content block, carrying the tabs and left column out of view). The
+  in-frame settings view scrolls internally the same way. Mobile keeps
+  natural page flow.
+- The site's identity card no longer carries the "you can view or delete
+  your responses… anytime" line. The site already makes that promise
+  actionable — the My submissions / Deletion requests tabs, the receipt
+  search, and (logged out) the "See your submissions" card — so the
+  declarative sentence was a redundant restatement bundled into a card whose
+  job is identity (name, logo, policy links), not rights.
+- **Sidebar navigation grouped by meaning, not permission.** The old split
+  was "everyone" vs "admins", which stranded Site at the top away from Site
+  settings. Now three labelled groups: **Collection** (Forms, Responders and
+  Groups, Deletion requests, Templates) — the daily work, first; **Your
+  site** (Site, Site settings, Custom domain) — view it, configure it, point
+  a domain at it, together; **Workspace** (Members) — administration.
+  Quiet uppercase group labels replace anonymous dividers; per-item admin
+  gating replaces the all-or-nothing bottom cluster; the Site item matches
+  its route exactly so it no longer depends on being outside the nav list.
+  Site and Site settings share the dashboard-root route, so their active
+  state (and the top-bar title) is driven by whether the settings view is
+  open rather than by URL — clicking Site hands the highlight back and
+  closes the view, clicking Site settings takes it.
 - **Sign-in page redesigned as the first trust decision.** The pitch panel
   was a gradient marketing collage with outdated UI screenshots and a
   sentence that ended mid-thought; it's now a calm ink panel stating what

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/creator-dashboard-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/creator-dashboard-client.tsx
@@ -55,9 +55,13 @@ export default function CreatorDashboardClient({ hasCustomDomain }: { hasCustomD
     ];
 
     return (
-        <div className="border-black-300 shadow-formCardDefault flex flex-col overflow-hidden rounded-xl border bg-white">
+        // Desktop: the frame is a real browser — bounded to the viewport
+        // (77px top bar + 40px top/bottom gaps) with fixed chrome and the site
+        // content scrolling INSIDE it, so the page itself never scrolls. Mobile
+        // keeps natural flow (mobile viewport height is unreliable).
+        <div className="border-black-300 shadow-formCardDefault flex flex-col overflow-hidden rounded-xl border bg-white lg:h-[calc(100vh-157px)]">
             {/* Browser chrome: dots · address pill (globe + URL + copy) · open · settings gear */}
-            <div className="border-black-300 flex items-center gap-3 border-b bg-white px-4 py-2.5">
+            <div className="border-black-300 flex shrink-0 items-center gap-3 border-b bg-white px-4 py-2.5">
                 <div className="hidden items-center gap-1.5 sm:flex" aria-hidden="true">
                     <span className="bg-black-300 h-2.5 w-2.5 rounded-full" />
                     <span className="bg-black-300 h-2.5 w-2.5 rounded-full" />
@@ -110,25 +114,27 @@ export default function CreatorDashboardClient({ hasCustomDomain }: { hasCustomD
                 settings page, you close it and you're back on the page you
                 were configuring. (Previously a bottom sheet over everything.) */}
             {settingsViewOpen && (
-                <div className="bg-white py-6">
+                <div className="bg-white py-6 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
                     <button type="button" onClick={() => setSettingsViewOpen(false)} className="text-black-600 hover:text-black-900 mb-4 flex items-center gap-1 px-5 text-sm font-medium md:px-10">
                         <ChevronLeft className="h-4 w-4" />
-                        Back to page
+                        Back to site
                     </button>
                     <WorkspaceSettingsContent showUrlRow={false} />
                 </div>
             )}
 
-            {/* The "page": the portal's surface colour and content. */}
-            <div className={cn('flex-col gap-4 bg-[#F6F8FC] p-5 md:flex-row md:p-8', settingsViewOpen ? 'hidden' : 'flex')}>
-                <div className="flex flex-col gap-4 md:w-[320px] md:max-w-[320px]">
+            {/* The "page": the portal's surface colour and content. Like the
+                portal, the left column and the tabs stay affixed — only the
+                tab content scrolls inside the frame (desktop); mobile flows. */}
+            <div className={cn('flex-col gap-4 bg-[#F6F8FC] p-5 md:flex-row md:p-8 lg:min-h-0 lg:flex-1 lg:overflow-hidden', settingsViewOpen ? 'hidden' : 'flex')}>
+                <div className="flex flex-col gap-4 md:w-[320px] md:max-w-[320px] lg:min-h-0 lg:overflow-y-auto">
                     <WorkspaceDetailsCard workspace={workspace} />
                     {/* Same sidebar placement as the portal: one utility
                         column, two-column page. */}
                     <SearchBySubmissionNumber className="w-full" />
                 </div>
-                <div className="flex min-w-0 flex-1 flex-col">
-                    <div className="border-black-300 flex space-x-1 overflow-x-auto border-b pb-0">
+                <div className="flex min-w-0 flex-1 flex-col lg:min-h-0">
+                    <div className="border-black-300 flex shrink-0 space-x-1 overflow-x-auto border-b pb-0">
                         {tabs.map((tab) => {
                             const isActive = activeTab === tab.key;
                             return (
@@ -147,7 +153,7 @@ export default function CreatorDashboardClient({ hasCustomDomain }: { hasCustomD
                             );
                         })}
                     </div>
-                    <div className="mt-4 min-w-0">
+                    <div className="mt-4 min-w-0 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:[scrollbar-gutter:stable]">
                         {activeTab === 'forms' && <WorkspaceFormsTabContent workspace={workspace} publicBaseUrl={publicUrl} />}
                         {activeTab === 'my-submissions' && <WorkspaceResponsesTabContent workspace={workspace} />}
                         {activeTab === 'deletion-requests' && <WorkspaceResponsesTabContent workspace={workspace} deletionRequests />}

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/_components/workspace-dashboard-layout.tsx
@@ -23,7 +23,7 @@ import { localesCommon } from '@app/constants/locales/common';
 import { formConstant } from '@app/constants/locales/form';
 import { members } from '@app/constants/locales/members';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
-import { INavbarItem } from '@app/models/props/navbar';
+import { INavGroup, INavbarItem } from '@app/models/props/navbar';
 import { cn } from '@app/shadcn/util/lib';
 import { selectAuth } from '@app/store/auth/slice';
 import { useAppSelector } from '@app/store/hooks';
@@ -35,7 +35,7 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
 
     const auth = useAppSelector(selectAuth);
     const { openModal } = useFullScreenModal();
-    const { setSettingsViewOpen } = useWorkspaceSettingsView();
+    const { settingsViewOpen, setSettingsViewOpen } = useWorkspaceSettingsView();
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const handleDrawerToggle = () => {
@@ -49,7 +49,9 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
     const { t } = useTranslation();
     const commonWorkspaceUrl = `/${workspace?.workspaceName}/dashboard`;
 
-    const topNavList: Array<INavbarItem> = [
+    // Nav grouped by meaning: the daily work first (Linear-style), then the
+    // public face, then administration.
+    const collectionItems: Array<INavbarItem> = [
         {
             key: 'forms',
             name: t(localesCommon.forms),
@@ -71,7 +73,7 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
     ];
 
     if (auth?.roles?.includes('ADMIN')) {
-        topNavList.push({
+        collectionItems.push({
             key: 'templates',
             name: t('TEMPLATE.TEMPLATES'),
             url: `${commonWorkspaceUrl}/templates`,
@@ -79,59 +81,93 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
         });
     }
 
-    const bottomNavList: Array<INavbarItem> = [
+    const navGroups: Array<INavGroup> = [
         {
-            key: 'workspace-settings',
-            // Settings live inside the Public Workspace frame (behind the
-            // address-bar gear) — this entry opens that view directly.
-            name: 'Site settings',
-            url: `/${workspace?.workspaceName}/dashboard/workspace-settings`,
-            icon: <Settings className="h-5 w-5 stroke-2" />,
-            onClick: () => {
-                setSettingsViewOpen(true);
-                router.push(commonWorkspaceUrl);
-            }
+            label: 'Collection',
+            items: collectionItems
         },
         {
-            key: 'members',
-            name: t(members.default),
-            url: `/${workspace?.workspaceName}/dashboard/members`,
-            icon: <MembersIcon />
-        },
-
-        {
-            key: 'custom-domain',
-            name: (
-                <div className="flex items-center gap-2">
-                    Custom Domain <ProLogo />
-                </div>
-            ),
-            icon: <Globe />,
-            url: `/${workspace?.workspaceName}/dashboard/custom-domain`,
-            onClick: () => {
-                if (workspace?.isPro) {
-                    router.push(`/${workspace?.workspaceName}/dashboard/custom-domain`);
-                } else {
-                    openModal('UPGRADE_TO_PRO');
+            label: 'Your site',
+            items: [
+                {
+                    key: 'site',
+                    name: 'Site',
+                    url: commonWorkspaceUrl,
+                    // The dashboard root prefixes every other route (exact
+                    // match only) — and when the settings view covers the
+                    // mirror, the highlight belongs to Site settings.
+                    exactMatch: true,
+                    isActive: pathname === commonWorkspaceUrl && !settingsViewOpen,
+                    icon: <Globe />,
+                    // Clicking Site returns to the page even when the settings
+                    // view (which lives on the same route) is open.
+                    onClick: () => {
+                        setSettingsViewOpen(false);
+                        router.push(commonWorkspaceUrl);
+                    }
+                },
+                {
+                    key: 'site-settings',
+                    // Settings live inside the site frame (behind the
+                    // address-bar gear) — this entry opens that view directly.
+                    name: 'Site settings',
+                    url: `${commonWorkspaceUrl}/site-settings`,
+                    adminOnly: true,
+                    // Not a route — active while its view is open on the root.
+                    isActive: pathname === commonWorkspaceUrl && settingsViewOpen,
+                    icon: <Settings className="h-5 w-5 stroke-2" />,
+                    onClick: () => {
+                        setSettingsViewOpen(true);
+                        router.push(commonWorkspaceUrl);
+                    }
+                },
+                {
+                    key: 'custom-domain',
+                    name: (
+                        <div className="flex items-center gap-2">
+                            Custom domain <ProLogo />
+                        </div>
+                    ),
+                    icon: <Globe />,
+                    url: `${commonWorkspaceUrl}/custom-domain`,
+                    adminOnly: true,
+                    onClick: () => {
+                        if (workspace?.isPro) {
+                            router.push(`${commonWorkspaceUrl}/custom-domain`);
+                        } else {
+                            openModal('UPGRADE_TO_PRO');
+                        }
+                    }
                 }
-            }
+            ]
+        },
+        {
+            label: 'Workspace',
+            items: [
+                {
+                    key: 'members',
+                    name: t(members.default),
+                    url: `${commonWorkspaceUrl}/members`,
+                    adminOnly: true,
+                    icon: <MembersIcon />
+                }
+            ]
         }
     ];
 
-    const allNavList = [...topNavList, ...bottomNavList];
+    const allNavList = navGroups.flatMap((group) => group.items);
 
     const getHeader = () => {
         if (!pathname) return 'My Workspace';
-        const matchingNavList = allNavList.filter((item) => pathname?.includes(item.url));
+        // Longest matching URL wins — the Site item's URL (the dashboard root)
+        // is a prefix of every other route.
+        const matchingNavList = allNavList.filter((item) => pathname?.includes(item.url)).sort((a, b) => b.url.length - a.url.length);
         if (matchingNavList.length > 0) {
-            return matchingNavList[matchingNavList.length - 1]?.name;
+            return matchingNavList[0]?.key === 'site' ? (settingsViewOpen ? 'Site settings' : 'Your site') : matchingNavList[0]?.name;
         }
         // Routes not represented in the sidebar nav still need a correct title.
         if (pathname.includes('/dashboard/templates')) return 'Templates';
         if (pathname.includes('/dashboard/account-settings')) return 'Account Settings';
-        // The dashboard root is the public-workspace mirror — title it the same
-        // as the sidebar entry that leads here.
-        if (pathname.endsWith('/dashboard')) return 'Your site';
         return 'My Workspace';
     };
 
@@ -140,13 +176,7 @@ const WorkspaceDashboardLayout: React.FC<{ children: React.ReactNode }> = ({ chi
             <div className="lg:hidden">
                 <AuthNavbar showHamburgerIcon handleDrawerToggle={handleDrawerToggle} mobileOpen={mobileOpen} showAuthAccount />
             </div>
-            <DashboardDrawer
-                drawerWidth={drawerWidth}
-                mobileOpen={mobileOpen}
-                handleDrawerToggle={handleDrawerToggle}
-                topNavList={topNavList}
-                bottomNavList={bottomNavList}
-            />
+            <DashboardDrawer drawerWidth={drawerWidth} mobileOpen={mobileOpen} handleDrawerToggle={handleDrawerToggle} navGroups={navGroups} />
             <main
                 className={cn(
                     "bg-black-100 float-none mt-[68px] flex min-h-[calc(100vh-68px)]",

--- a/webapp/src/components/responder-portal/workspace-details-card.tsx
+++ b/webapp/src/components/responder-portal/workspace-details-card.tsx
@@ -2,7 +2,6 @@ import AuthAccountProfileImage from '@app/components/auth/account-profile-image'
 import ActiveLink from '@app/components/ui/links/active-link';
 import { localesCommon } from '@app/constants/locales/common';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
-import { Shield } from 'lucide-react';
 import { useTranslation } from 'next-i18next';
 import Image from 'next/image';
 
@@ -25,12 +24,10 @@ export default function WorkspaceDetailsCard({ workspace }: IWorkspaceDetailsCar
             <div className={`${workspace.bannerImage ? '-mt-8' : 'mt-4'}  p-6`}>
                 <div className="h4-new">{workspace?.title || 'Untitled Workspace'}</div>
                 {workspace?.description && <div className="p2-new text-black-600 mt-1">{workspace.description}</div>}
-                {/* The trust anchor: this portal is where every form's "view or
-                    delete your response anytime" promise is kept. Say so here. */}
-                <div className="mt-4 flex items-start gap-2 rounded-lg bg-[#F4F7FD] px-3 py-2.5">
-                    <Shield className="mt-0.5 h-4 w-4 shrink-0 text-[#2456CC]" strokeWidth={1.8} aria-hidden="true" />
-                    <span className="text-black-700 text-sm leading-snug">You can view or delete your responses to this workspace&apos;s forms anytime.</span>
-                </div>
+                {/* Identity card does one job — who + policies. The
+                    "view or delete anytime" promise is made actionable by the
+                    tabs and the "See your submissions" card, so it no longer
+                    floats here as standalone prose. */}
                 <div className="text-new-black-600 p4-new mt-6 flex justify-between gap-6">
                     <ActiveLink target="_blank" className="p4-new !text-black-600 !not-italic !leading-none" href={workspace.termsOfService ?? `https://bettercollected.com/terms-of-service/`}>
                         {t(localesCommon.termsOfServices.title)}

--- a/webapp/src/components/sidebar/dashboard-drawer.tsx
+++ b/webapp/src/components/sidebar/dashboard-drawer.tsx
@@ -2,10 +2,7 @@
 import React from 'react';
 
 import { useTranslation } from 'next-i18next';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
-import Divider from '@Components/common/divider';
 
 import { useModal } from '@app/components/modal-views/context';
 import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
@@ -19,23 +16,19 @@ import { upgradeConst } from '@app/constants/locales/upgrade';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
 import { IDrawerProps } from '@app/models/props/navbar';
 import { Progress } from '@app/shadcn/components/ui/progress';
-import { cn } from '@app/shadcn/util/lib';
 import { selectIsAdmin, selectIsProPlan } from '@app/store/auth/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { useGetWorkspaceStatsQuery } from '@app/store/workspaces/api';
 import { selectWorkspace } from '@app/store/workspaces/slice';
-import Globe from '@Components/icons/globe';
 import WorkspaceMenuDropdown from '@Components/workspace/workspace-menu-dropdown';
 
-const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
+const Drawer = ({ navGroups, isAdmin }: any) => {
     const { t } = useTranslation();
     const workspace: WorkspaceDto = useAppSelector(selectWorkspace);
     const { data } = useGetWorkspaceStatsQuery(workspace.id, { skip: !workspace.id });
     const { openModal: openFullScreenModal } = useFullScreenModal();
     const { openModal } = useModal();
     const isProPlan = useAppSelector(selectIsProPlan);
-    const pathname = usePathname();
-    const commonWorkspaceUrl = `/${workspace?.workspaceName}/dashboard`;
 
     return (
         <div className="flex flex-col h-full bg-white">
@@ -45,34 +38,24 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
             <div className="flex-1 overflow-auto h-full scrollbar-hide">
                 <div className="flex h-full flex-col justify-between">
                     <div className="px-4">
-                        {/* Replacement for List/ListItem containing WorkspaceMenuDropdown */}
-                        <div className="pt-5 pb-0">
+                        <div className="pt-5 pb-2">
                             <WorkspaceMenuDropdown fullWidth />
                         </div>
 
-                        {/* This is a link, so it speaks the one action colour —
-                            the old blue→pink gradient text was the loudest thing
-                            in the chrome and the exact "playful" note the trust
-                            language retires (Design-Language §1). */}
-                        <Link href={commonWorkspaceUrl} className={cn('hover:bg-black-100 mb-3 mt-2 flex cursor-pointer items-center gap-2 rounded-lg px-4 py-3 text-xs font-medium', pathname === commonWorkspaceUrl && 'bg-[#E9EFFC]')}>
-                            <Globe width={20} height={20} className="text-[#2456CC]" />
-                            <span className="p3-new text-[#2456CC]">Site</span>
-                        </Link>
-
-                        <div className="border-black-300 my-3 border-t" />
-
-                        <div className="py-2">
-                            <NavigationList navigationList={topNavList} />
-                        </div>
-
-                        {isAdmin && (
-                            <>
-                                <Divider className="text-black-600" />
-                                <div className="py-2">
-                                    <NavigationList navigationList={bottomNavList} />
+                        {/* Nav grouped by meaning (Collection · Your site ·
+                            Workspace), not by permission — the old split was
+                            "everyone" vs "admins", which separated Site from
+                            Site settings. Labels carry what dividers implied. */}
+                        {navGroups?.map((group: any) => {
+                            const items = group.items.filter((item: any) => !item.adminOnly || isAdmin);
+                            if (!items.length) return null;
+                            return (
+                                <div key={group.label} className="pb-1">
+                                    <div className="text-black-500 px-4 pb-1 pt-4 text-[11px] font-semibold uppercase tracking-wider">{group.label}</div>
+                                    <NavigationList navigationList={items} />
                                 </div>
-                            </>
-                        )}
+                            );
+                        })}
                     </div>
 
                     {/* Bottom section for free plan / ads */}
@@ -134,12 +117,12 @@ const Drawer = ({ topNavList, isAdmin, bottomNavList }: any) => {
     );
 };
 
-export default function DashboardDrawer({ drawerWidth, mobileOpen, handleDrawerToggle, bottomNavList, topNavList }: IDrawerProps) {
+export default function DashboardDrawer({ drawerWidth, mobileOpen, handleDrawerToggle, navGroups }: IDrawerProps) {
     const isAdmin = useAppSelector(selectIsAdmin);
 
     return (
         <MuiDrawer handleDrawerToggle={handleDrawerToggle} drawerWidth={drawerWidth} mobileOpen={mobileOpen}>
-            <Drawer topNavList={topNavList} isAdmin={isAdmin} bottomNavList={bottomNavList} />
+            <Drawer navGroups={navGroups} isAdmin={isAdmin} />
         </MuiDrawer>
     );
 }

--- a/webapp/src/components/sidebar/navigation-list.tsx
+++ b/webapp/src/components/sidebar/navigation-list.tsx
@@ -27,8 +27,11 @@ export default function NavigationList({ navigationList, className = '', sx = {}
             {navigationList?.map((element) => {
                 // Prefix match, not equality — nested routes (e.g.
                 // /responders-groups/all-responders, /members/collaborators)
-                // left the whole sidebar with nothing selected.
-                const active = pathname === element.url || pathname?.startsWith(element.url + '/');
+                // left the whole sidebar with nothing selected. Items whose URL
+                // prefixes everything (the dashboard root) opt into exact match;
+                // items whose active state isn't a route (Site settings is a
+                // view on the dashboard root) pass it in directly.
+                const active = element.isActive ?? (pathname === element.url || (!element.exactMatch && pathname?.startsWith(element.url + '/')));
                 return (
                     <li key={element.key}
                         className={cn(

--- a/webapp/src/components/sidebar/sidebar-layout.tsx
+++ b/webapp/src/components/sidebar/sidebar-layout.tsx
@@ -21,7 +21,7 @@ import { localesCommon } from '@app/constants/locales/common';
 import { formConstant } from '@app/constants/locales/form';
 import { members } from '@app/constants/locales/members';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
-import { INavbarItem } from '@app/models/props/navbar';
+import { INavGroup, INavbarItem } from '@app/models/props/navbar';
 import { Popover, PopoverContent } from '@app/shadcn/components/ui/popover';
 import { selectAuth } from '@app/store/auth/slice';
 import { useAppSelector } from '@app/store/hooks';
@@ -45,7 +45,7 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
     const auth = useAppSelector(selectAuth);
 
     const { openModal } = useFullScreenModal();
-    const { setSettingsViewOpen } = useWorkspaceSettingsView();
+    const { settingsViewOpen, setSettingsViewOpen } = useWorkspaceSettingsView();
 
     const [mobileOpen, setMobileOpen] = React.useState(false);
     const handleDrawerToggle = () => {
@@ -59,7 +59,9 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
     const { t } = useTranslation();
     const commonWorkspaceUrl = `/${workspace?.workspaceName}/dashboard`;
 
-    const topNavList: Array<INavbarItem> = [
+    // Nav grouped by meaning: the daily work first (Linear-style), then the
+    // public face, then administration.
+    const collectionItems: Array<INavbarItem> = [
         {
             key: 'forms',
             name: t(localesCommon.forms),
@@ -80,65 +82,100 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
         }
     ];
     auth?.roles?.includes('ADMIN') &&
-        topNavList.push({
+        collectionItems.push({
             key: 'templates',
             name: t('TEMPLATE.TEMPLATES'),
             url: `${commonWorkspaceUrl}/templates`,
             icon: <TemplateIcon className={'stroke-2'} />
         });
-    const bottomNavList: Array<INavbarItem> = [
-        {
-            key: 'workspace-settings',
-            // Settings live inside the Public Workspace frame (behind the
-            // address-bar gear) — this entry opens that view directly.
-            name: 'Site settings',
-            url: `/${workspace?.workspaceName}/dashboard/workspace-settings`,
-            icon: <Settings className="h-5 w-5 stroke-2" />,
-            onClick: () => {
-                setSettingsViewOpen(true);
-                router.push(commonWorkspaceUrl);
-            }
-        },
-        {
-            key: 'members',
-            name: t(members.default),
-            url: `/${workspace?.workspaceName}/dashboard/members`,
-            icon: <MembersIcon />
-        },
 
+    const navGroups: Array<INavGroup> = [
         {
-            key: 'custom-domain',
-            name: (
-                <div className="flex items-center gap-2">
-                    Custom Domain <ProLogo />
-                </div>
-            ),
-            icon: <Globe />,
-            url: `/${workspace?.workspaceName}/dashboard/custom-domain`,
-            onClick: () => {
-                if (workspace.isPro) {
-                    router.push(`/${workspace?.workspaceName}/dashboard/custom-domain`);
-                } else {
-                    openModal('UPGRADE_TO_PRO');
+            label: 'Collection',
+            items: collectionItems
+        },
+        {
+            label: 'Your site',
+            items: [
+                {
+                    key: 'site',
+                    name: 'Site',
+                    url: commonWorkspaceUrl,
+                    // The dashboard root prefixes every other route (exact
+                    // match only) — and when the settings view covers the
+                    // mirror, the highlight belongs to Site settings.
+                    exactMatch: true,
+                    isActive: pathname === commonWorkspaceUrl && !settingsViewOpen,
+                    icon: <Globe />,
+                    // Clicking Site returns to the page even when the settings
+                    // view (which lives on the same route) is open.
+                    onClick: () => {
+                        setSettingsViewOpen(false);
+                        router.push(commonWorkspaceUrl);
+                    }
+                },
+                {
+                    key: 'site-settings',
+                    // Settings live inside the site frame (behind the
+                    // address-bar gear) — this entry opens that view directly.
+                    name: 'Site settings',
+                    url: `${commonWorkspaceUrl}/site-settings`,
+                    adminOnly: true,
+                    // Not a route — active while its view is open on the root.
+                    isActive: pathname === commonWorkspaceUrl && settingsViewOpen,
+                    icon: <Settings className="h-5 w-5 stroke-2" />,
+                    onClick: () => {
+                        setSettingsViewOpen(true);
+                        router.push(commonWorkspaceUrl);
+                    }
+                },
+                {
+                    key: 'custom-domain',
+                    name: (
+                        <div className="flex items-center gap-2">
+                            Custom domain <ProLogo />
+                        </div>
+                    ),
+                    icon: <Globe />,
+                    url: `${commonWorkspaceUrl}/custom-domain`,
+                    adminOnly: true,
+                    onClick: () => {
+                        if (workspace.isPro) {
+                            router.push(`${commonWorkspaceUrl}/custom-domain`);
+                        } else {
+                            openModal('UPGRADE_TO_PRO');
+                        }
+                    }
                 }
-            }
+            ]
+        },
+        {
+            label: 'Workspace',
+            items: [
+                {
+                    key: 'members',
+                    name: t(members.default),
+                    url: `${commonWorkspaceUrl}/members`,
+                    adminOnly: true,
+                    icon: <MembersIcon />
+                }
+            ]
         }
     ];
 
-    const allNavList = [...topNavList, ...bottomNavList];
+    const allNavList = navGroups.flatMap((group) => group.items);
 
     const getHeader = () => {
-        const matchingNavList = allNavList.filter((item) => pathname?.includes(item.url));
+        // Longest matching URL wins — the Site item's URL (the dashboard root)
+        // is a prefix of every other route.
+        const matchingNavList = allNavList.filter((item) => pathname?.includes(item.url)).sort((a, b) => b.url.length - a.url.length);
         if (matchingNavList.length > 0) {
-            return matchingNavList[matchingNavList.length - 1]?.name;
+            return matchingNavList[0]?.key === 'site' ? (settingsViewOpen ? 'Site settings' : 'Your site') : matchingNavList[0]?.name;
         }
         // Routes that aren't represented in the sidebar nav still need a correct
         // title instead of the generic "My Workspace" fallback.
         if (pathname?.includes('/dashboard/templates')) return 'Templates';
         if (pathname?.includes('/dashboard/account-settings')) return 'Account Settings';
-        // The dashboard root is the public-workspace mirror — title it the same
-        // as the sidebar entry that leads here.
-        if (pathname?.endsWith('/dashboard')) return 'Your site';
         return 'My Workspace';
     };
 
@@ -148,7 +185,7 @@ export default function SidebarLayout({ children, DrawerComponent = DashboardDra
                 <div className="lg:hidden">
                     <AuthNavbar handleDrawerToggle={handleDrawerToggle} mobileOpen={mobileOpen} />
                 </div>
-                <DrawerComponent drawerWidth={drawerWidth} mobileOpen={mobileOpen} handleDrawerToggle={handleDrawerToggle} topNavList={topNavList} bottomNavList={bottomNavList} />
+                <DrawerComponent drawerWidth={drawerWidth} mobileOpen={mobileOpen} handleDrawerToggle={handleDrawerToggle} navGroups={navGroups} />
                 <main
                     className={cn(
                         "bg-black-100 float-none mt-[68px] flex min-h-[calc(100vh-68px)]",

--- a/webapp/src/models/props/navbar.ts
+++ b/webapp/src/models/props/navbar.ts
@@ -4,6 +4,20 @@ export interface INavbarItem {
     url: string;
     icon?: React.ReactNode;
     onClick?: () => void;
+    /** Highlight only on an exact pathname match — for items whose URL is a
+     *  prefix of every other route (e.g. the dashboard root). */
+    exactMatch?: boolean;
+    /** Only rendered for workspace admins. */
+    adminOnly?: boolean;
+    /** Overrides URL-based matching — for items whose active state isn't a
+     *  route (e.g. Site settings, which is a view on the dashboard root). */
+    isActive?: boolean;
+}
+
+export interface INavGroup {
+    /** Quiet uppercase section label; groups nav by meaning, not permission. */
+    label: string;
+    items: Array<INavbarItem>;
 }
 
 export interface IDrawerProps {
@@ -11,6 +25,5 @@ export interface IDrawerProps {
     mobileOpen?: boolean;
     className?: string;
     handleDrawerToggle: () => void;
-    topNavList: Array<any>;
-    bottomNavList: Array<any>;
+    navGroups: Array<INavGroup>;
 }


### PR DESCRIPTION
## Summary

A batch of refinements to the dashboard sidebar and the "Your site" browser-frame mirror.

### Sidebar grouped by meaning
The nav was split by permission ("everyone" vs "admins"), which stranded **Site** at the top away from **Site settings**. Now three labelled groups:
- **Collection** — Forms, Responders and Groups, Deletion requests, Templates (the daily work, first)
- **Your site** — Site, Site settings, Custom domain
- **Workspace** — Members

Quiet uppercase labels replace anonymous dividers; per-item admin gating replaces the all-or-nothing bottom cluster.

### Site / Site settings active state
Both share the dashboard-root route, so URL matching could never highlight settings (its `url` is a placeholder). An `isActive` override now drives it from whether the in-frame settings view is open — Site active with settings closed, Site settings active with it open; clicking Site hands the highlight back **and** closes the view, and the top-bar title follows the same signal.

### Browser-frame scroll
On desktop the frame is bounded to the viewport with fixed chrome, so the dashboard page never scrolls around it. Matching the responder portal, the **left column and tabs stay affixed** — only the tab content scrolls inside the frame (a first attempt scrolled the whole block, carrying the tabs and left column out of view). Verified with DOM measurements: content scrolls, tabs/left-column top positions unchanged, page not scrollable. Mobile keeps natural flow.

### Copy / content
- Dropped the redundant "you can view or delete your responses… anytime" line from the identity card — the tabs, receipt search, and "See your submissions" card already make that promise actionable; the card now does one job (identity + policies).
- Settings "Back to page" → **"Back to site"** — names the actual destination in our vocabulary.

## Test plan
- [x] All 149 webapp vitest tests pass
- [x] Browser-verified: nav groups render with admin gating; Site ↔ Site settings active state and title in both directions; frame bounded to viewport with page non-scrollable; tabs + left column affixed while tab content (My submissions, ~1600px) scrolls to its end; in-frame settings view scrolls internally; "Back to site" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)