### PR TITLE
Fix googleform deploy crash on pydantic v2; don't fail-fast deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,9 @@ jobs:
     deploy:
         needs: build-and-push
         strategy:
+            # One service failing to converge must not cancel the others'
+            # deploys — each service updates independently.
+            fail-fast: false
             matrix:
                 service:
                     - auth

--- a/integrations/google/googleform/config/apm_settings.py
+++ b/integrations/google/googleform/config/apm_settings.py
@@ -1,10 +1,16 @@
+from typing import Optional
+
 from pydantic_settings import BaseSettings
 
 
 class APMSettings(BaseSettings):
-    api_key: str = None
-    service_name: str = None
-    server_url: str = None
+    # Optional[str], not str: these are unset unless ELASTIC_APM_* env vars
+    # are provided. Pydantic v2 rejects a bare `str` field defaulting to None
+    # (v1 tolerated it), which crashed the service on import after the pydantic
+    # v1 → v2 dependency bump.
+    api_key: Optional[str] = None
+    service_name: Optional[str] = None
+    server_url: Optional[str] = None
 
     class Config:
         env_prefix = "ELASTIC_APM_"


### PR DESCRIPTION
## Summary

The `deploy (integrations/google)` job has failed on **every develop merge since the pydantic dependency bump** (#568–#573), which cancelled the other services' deploys too (fail-fast). None of those PRs touched `integrations/google` — each deploy just rebuilds develop HEAD and hits the same wall.

**Root cause (reproduced):** the container crashes at **import time** with a pydantic `ValidationError`. `APMSettings` declared its fields as `str = None`:

```python
class APMSettings(BaseSettings):
    api_key: str = None
    service_name: str = None
    server_url: str = None
```

Pydantic v1 tolerated `str = None`; **v2 rejects it** (None isn't a valid `str`). The recent Dependabot batch moved this service from pydantic v1 → v2 (`2.13.4`). Because `ELASTIC_APM_*` env vars aren't set (APM is optional), the fields default to `None` → `APMSettings()` raises on import → `python3 -m googleform` exits immediately → Swarm sees the task terminate early and pauses/fails the update. This crash is env-independent, which is why it's the actual blocker.

## Changes

1. **`apm_settings.py`** — the three fields are now `Optional[str] = None` (they're genuinely optional). Verified locally: before, `get_application()` raised the `APMSettings` ValidationError; after, it proceeds past config import to the normal runtime-secret stage.
2. **`deploy.yml`** — `fail-fast: false` on the deploy matrix, so one service failing to converge no longer cancels every other service's deploy.

## Scope / notes
- Only `integrations/google` is affected (it's on pydantic `2.13.4`); `backend`/`auth` are on `2.12.5` and don't use the `str = None` pattern.
- With fail-fast off, the other services' deploys will now actually run instead of being cancelled — if any has its own latent issue it'll surface independently rather than being masked.

## Test plan
- [x] Reproduced the crash and confirmed the fix locally (`get_application()` no longer raises the pydantic error)
- [x] `deploy.yml` indentation verified (`fail-fast`/`matrix` both under `strategy`)
- [ ] Confirm the develop deploy goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)