### PR TITLE
Fix auth + googleform deploy crash (beanie 2.x → pymongo async client)

### DIFF
--- a/auth/auth/app/container.py
+++ b/auth/auth/app/container.py
@@ -1,7 +1,7 @@
 from common.services.http_client import HttpClient
 from common.services.jwt_service import JwtService
 from dependency_injector import containers, providers
-from motor.motor_asyncio import AsyncIOMotorClient
+from pymongo import AsyncMongoClient
 
 from auth.app.repositories.provider_repository import ProviderRepository
 from auth.app.repositories.user_repository import UserRepository
@@ -13,8 +13,10 @@ from auth.config import settings
 
 
 class AppContainer(containers.DeclarativeContainer):
-    database_client: AsyncIOMotorClient = providers.Singleton(
-        AsyncIOMotorClient, settings.mongo_settings.URI
+    # Beanie 2.x uses pymongo's native async client, not motor. Instantiated
+    # inside on_startup (a running event loop) via container.database_client().
+    database_client: AsyncMongoClient = providers.Singleton(
+        AsyncMongoClient, settings.mongo_settings.URI
     )
 
     # Define non-decorated objects here

--- a/auth/auth/app/services/database_service.py
+++ b/auth/auth/app/services/database_service.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 import logging
 
 import loguru
@@ -17,7 +17,8 @@ def entity(cls):
 
 
 async def init_db(database_client):
-    database_client.get_io_loop = asyncio.get_running_loop
+    # No motor `get_io_loop` shim — beanie 2.x / pymongo's async client
+    # doesn't use it, and it crashed init_beanie on the newer versions.
     db = database_client[settings.mongo_settings.DB]
     await init_beanie(database=db, document_models=document_models)
     loguru.logger.info("Database connected successfully.")
@@ -25,7 +26,9 @@ async def init_db(database_client):
 
 async def close_db(database_client):
     try:
-        database_client.close()
+        result = database_client.close()
+        if inspect.isawaitable(result):
+            await result
         loguru.logger.info("Database disconnected successfully.")
     except Exception as e:
         loguru.logger.error("Database disconnect failure.")

--- a/integrations/google/googleform/app/services/database_service.py
+++ b/integrations/google/googleform/app/services/database_service.py
@@ -1,15 +1,19 @@
-import asyncio
+import inspect
 import logging
 
 from beanie import init_beanie
+from pymongo import AsyncMongoClient
 
 from googleform.config import settings
 
-from motor.motor_asyncio import AsyncIOMotorClient
-
 log = logging.getLogger(__name__)
 mongo_settings = settings.mongo_settings
-_client = AsyncIOMotorClient(mongo_settings.URI)
+
+# Beanie 2.x dropped motor for pymongo's native async client. The client is
+# created inside init_db (a running event loop), not at import — constructing
+# an AsyncMongoClient outside the loop triggers an "AsyncMongoClient in a
+# different event loop" error when it's first used at startup.
+_client: "AsyncMongoClient | None" = None
 
 document_models = []
 
@@ -20,7 +24,8 @@ def entity(cls):
 
 
 async def init_db():
-    _client.get_io_loop = asyncio.get_running_loop
+    global _client
+    _client = AsyncMongoClient(mongo_settings.URI)
     db = _client[mongo_settings.DB]
     await init_beanie(database=db, document_models=document_models)
     log.info("Database connected successfully.")
@@ -28,7 +33,10 @@ async def init_db():
 
 async def close_db():
     try:
-        _client.close()
+        if _client is not None:
+            result = _client.close()
+            if inspect.isawaitable(result):
+                await result
         log.info("Database disconnected successfully.")
     except Exception as e:
         log.error("Database disconnect failure.")


### PR DESCRIPTION
## Summary

Follow-up to #574. With `fail-fast` now off, the develop deploy showed **backend, webapp and temporal deploy fine**, but `deploy (auth)` and `deploy (integrations/google)` still fail — each container crashes on startup, so Swarm reports *"task terminated early"*.

**Root cause (reproduced):** beanie 2.x dropped **motor** in favour of pymongo's native async client, but `auth` and `googleform` still construct a motor `AsyncIOMotorClient` and hand it to `init_beanie`, which then calls `client.append_metadata()` — a pymongo-async method motor doesn't have:

```
TypeError: MotorDatabase object is not callable ...
  'append_metadata' ... no such method exists
Application startup failed. Exiting.
```

`backend` was already migrated to `pymongo.AsyncMongoClient` (it has **no motor dependency**), which is exactly why it was unaffected.

## Changes
- **auth** (`container.py`, `database_service.py`): provider now builds `AsyncMongoClient`; dropped the motor `get_io_loop` shim in `init_db`; `close_db` awaits `close()` if awaitable.
- **googleform** (`database_service.py`): same migration; the client is now created **inside `init_db`** (a running event loop) rather than at import — building an `AsyncMongoClient` at import risks the "AsyncMongoClient in a different event loop" error at startup.

No `motor` usages remain in either service (only explanatory comments).

## Verification
- Booted **both** services against local Mongo: `Application startup complete`, DB connects, and endpoints return 200 — including auth's `/api/v1/ready` healthcheck (what the deployment healthcheck hits).
- **auth test suite passes** (2 passed).
- googleform's pre-existing test errors (unset `AUTH_JWT_SECRET`; a stale `ApplicationLoader` import from a past refactor) are unrelated to this change and aren't run in CI.

## After merge
- This was masked before #574 by fail-fast. With both PRs in, all six services should deploy. If motor is now fully unused in auth/google, dropping it from their `pyproject`/lock is a reasonable follow-up (left in place here to keep the hotfix minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)