### PR TITLE
fix(auth): send OTP mail on the main event loop (fixes cross-loop AsyncMongoClient crash)

### DIFF
--- a/auth/auth/app/controllers/auth_router.py
+++ b/auth/auth/app/controllers/auth_router.py
@@ -43,11 +43,11 @@ class AuthRoutes(Routable):
         background_tasks: BackgroundTasks,
     ):
         background_tasks.add_task(
-            self.auth_service.send_code_to_user_for_workspace_sync,
-            receiver_email,
-            workspace_title,
-            workspace_profile_image,
-            creator,
+            self.auth_service.send_otp_to_mail,
+            receiver_mail=receiver_email,
+            workspace_title=workspace_title,
+            workspace_profile_image=workspace_profile_image,
+            creator=creator,
         )
         return {"message": "Email set to be sent"}
 

--- a/auth/auth/app/services/auth_service.py
+++ b/auth/auth/app/services/auth_service.py
@@ -9,7 +9,6 @@ from common.enums.roles import Roles
 from common.models.user import User, UserResponseDto
 from common.models.user import UserInfo
 from common.services.http_client import HttpClient
-from common.utils.asyncio_run import asyncio_run
 from fastapi_mail import MessageSchema
 from pydantic import EmailStr
 
@@ -117,28 +116,6 @@ class AuthService:
         return await self.auth_provider_factory.get_auth_provider(
             provider
         ).basic_auth_callback(code, state, request=request)
-
-    def send_code_to_user_for_workspace_sync(
-        self,
-        receiver_mail: EmailStr,
-        workspace_title: str,
-        workspace_profile_image: str,
-        creator: bool,
-    ):
-        try:
-            asyncio_run(
-                self.send_otp_to_mail(
-                    receiver_mail=receiver_mail,
-                    workspace_title=workspace_title,
-                    workspace_profile_image=workspace_profile_image,
-                    creator=creator,
-                )
-            )
-        except TimeoutError:
-            raise HTTPException(
-                status_code=HTTPStatus.GATEWAY_TIMEOUT, content="Timeout Error"
-            )
-
 
     async def send_otp_to_mail(
         self,


### PR DESCRIPTION
## Problem

On the deployment, **OTP emails silently stopped sending** after the motor→pymongo migration (#575). The auth log shows:

```
auth_service.py:129  send_code_to_user_for_workspace_sync → asyncio_run(...)
asyncio_run.py:41    asyncio.run_coroutine_threadsafe(coro, _LOOP)
auth_service.py:153  await self.user_repository.get_user_by_email(...)
RuntimeError: Cannot use AsyncMongoClient in different event loop.
```

### Root cause

`/otp/send` queued the **sync** `send_code_to_user_for_workspace_sync` as a FastAPI `BackgroundTask`. Starlette runs sync background tasks in a **threadpool**, so the wrapper called `common.utils.asyncio_run`, which dispatches onto a **dedicated background-thread event loop** (`_LOOP`). The beanie query there used the singleton `AsyncMongoClient` created on the **main** startup loop — and pymongo (beanie 2.x) binds its async client to its creation loop and raises on cross-loop use.

The endpoint had already returned `{"message": "Email set to be sent"}`, so the failure was **silent** — no OTP, no user-visible error. Motor previously tolerated this via a `get_io_loop` shim that `init_db` no longer sets.

## Fix

Register the **async** `send_otp_to_mail` coroutine directly as the background task. Starlette awaits async background tasks on the **main event loop**, where the client is bound, so the query works. Remove the now-dead sync wrapper and its `asyncio_run` import.

This matches the invitation-mail path (`/invite/send/mail`), which already registers its async method directly and was never affected.

## Verification

- Reproduced locally against Mailpit: **before** → inbox empty + cross-loop `RuntimeError` in the log; **after** → verification email delivered.
- Auth test suite: 2 passed (incl. the Google-callback test).
- Confirmed zero remaining `asyncio_run`/threadpool-sync DB hazards in auth.

> Note: the Google-login "Error Occurred in the proxy server" reported alongside this was collateral of auth being down during the earlier startup crash (fixed in #575) — its code path is unchanged and entirely main-loop. It should be restored once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)