### PR TITLE
chore(backend): type nullable fields as Optional[...]

### DIFF
--- a/backend/backend/app/models/dtos/response_group_dto.py
+++ b/backend/backend/app/models/dtos/response_group_dto.py
@@ -5,11 +5,11 @@ from pydantic import BaseModel
 
 
 class ResponderGroupDto(BaseModel):
-    id: str = None
-    name: str = None
+    id: Optional[str] = None
+    name: Optional[str] = None
     description: Optional[str] = None
     regex: Optional[str] = None
-    emails: List[str] = None
+    emails: Optional[List[str]] = None
     forms: Optional[List] = None
 
     def __init__(self, _id: PydanticObjectId = None, id=None, *args, **kwargs):

--- a/backend/backend/app/models/dtos/user_info_dto.py
+++ b/backend/backend/app/models/dtos/user_info_dto.py
@@ -8,7 +8,7 @@ from common.enums.roles import Roles
 
 
 class UserInfoDto(BaseModel):
-    id: PydanticObjectId = None
+    id: Optional[PydanticObjectId] = None
     _id: str
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/backend/backend/config/template_settings.py
+++ b/backend/backend/config/template_settings.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from beanie import PydanticObjectId
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class DefaultResourcesWorkspaceSettings(BaseSettings):
-    WORKSPACE_ID: PydanticObjectId = None
+    WORKSPACE_ID: Optional[PydanticObjectId] = None
     SHOW_TEMPLATES: bool = False
     # Auto-seed the flow-native template gallery (scripts/seed_flow_templates.py)
     # on every app startup. Idempotent (skips templates that already exist) and


### PR DESCRIPTION
## What

Several pydantic fields in `backend` were annotated with a non-optional type but a `None` default:

- `config/template_settings.py` — `WORKSPACE_ID: PydanticObjectId = None`
- `app/models/dtos/response_group_dto.py` — `id`, `name`, `emails`
- `app/models/dtos/user_info_dto.py` — `id`

## Why

Pydantic v2 doesn't validate defaults unless configured to, so these don't crash today. But the annotations are inaccurate and are fragile in exactly the way that crashed `integrations/google`'s `APMSettings` on the pydantic v2 bump (#574): a `str = None` field breaks the moment it's validated against `None` (e.g. `validate_default=True`, or a Settings field with no env value under stricter parsing). Tightening them to `Optional[...]` makes the types honest and removes the latent fragility.

## Safety

No behavior change — verified the settings class and both DTOs import and instantiate cleanly (`ResponderGroupDto()` → all-None, `DefaultResourcesWorkspaceSettings()` resolves as before).

Found during the post-deploy-crash latent-pattern audit (follow-on to #574/#575/#578).

🤖 Generated with [Claude Code](https://claude.com/claude-code)