### PR TITLE
fix(backend): connect the Temporal client on the main event loop

### DIFF
--- a/backend/backend/app/services/temporal_service.py
+++ b/backend/backend/app/services/temporal_service.py
@@ -10,7 +10,6 @@ from beanie import PydanticObjectId
 from common.configs.crypto import Crypto
 from common.models.standard_form import StandardFormResponse, StandardForm
 from common.models.user import User
-from common.utils.asyncio_run import asyncio_run
 from temporalio.client import (
     Client,
     Schedule,
@@ -44,13 +43,19 @@ class TemporalService:
         self.server_uri = server_uri
         self.namespace = namespace
         self.crypto = crypto
+        # Connect lazily on first use (see
+        # check_temporal_client_and_try_to_connect_if_not_connected), on the
+        # main event loop where the client is awaited, rather than eagerly here
+        # via asyncio_run's background loop. The temporalio client binds to the
+        # loop it's created on; connecting off the request loop is a latent
+        # cross-loop hazard (the same shape that broke the auth OTP send once
+        # motor's cross-loop tolerance was dropped for pymongo).
         self.temporal_client = None
-        self.connect_to_temporal_server(server_uri=server_uri, namespace=namespace)
 
-    def connect_to_temporal_server(self, server_uri: str, namespace: str):
+    async def connect_to_temporal_server(self):
         try:
-            self.temporal_client: Client = asyncio_run(
-                Client.connect(server_uri, namespace=namespace)
+            self.temporal_client: Client = await Client.connect(
+                self.server_uri, namespace=self.namespace
             )
         except Exception as e:
             self.temporal_client: Client = None
@@ -58,7 +63,7 @@ class TemporalService:
 
     async def check_temporal_client_and_try_to_connect_if_not_connected(self):
         if not self.temporal_client:
-            self.connect_to_temporal_server(self.server_uri, self.namespace)
+            await self.connect_to_temporal_server()
             if not self.temporal_client:
                 raise HTTPException(
                     status_code=HTTPStatus.SERVICE_UNAVAILABLE,


### PR DESCRIPTION
## Problem

`TemporalService.__init__` connected eagerly via `asyncio_run(Client.connect(...))`, which runs on `common.utils.asyncio_run`'s dedicated **background-thread event loop** (`_LOOP`). The resulting client was then `await`ed from main-loop request handlers (`start_workflow`, `create_schedule`, `get_schedule_handle`, …) — a **cross-loop** use of a loop-bound client.

This is the same shape that silently broke the auth OTP send (#577) once the motor→pymongo migration removed motor's cross-loop tolerance. temporalio's client happens to tolerate it today, but it's a latent hazard — if the SDK ever tightens loop binding (as pymongo did), workflow scheduling would break silently.

## Fix

Connect lazily on the main loop:
- `__init__` no longer connects — just sets `temporal_client = None`.
- `connect_to_temporal_server` is now **async** and `await`s `Client.connect` directly.
- The existing async guard `check_temporal_client_and_try_to_connect_if_not_connected` awaits it.
- Dropped the now-unused `asyncio_run` import.

The client now binds to the loop it's used from.

## Why it's safe

- **Every** use of `self.temporal_client` is already preceded by the async connect-guard (verified for all four call sites: `start_user_deletion_workflow`, `add_scheduled_job_for_deleting_response`, `delete_response_delete_schedule`, `start_action_execution`).
- Nothing outside the service accesses `.temporal_client`.
- `TemporalService` is a **lazy** DI singleton, so construction already happened inside a request loop; this only defers the first *connect* to the first workflow call (which already runs the guard).
- Verified: constructs without connecting, both connect methods are coroutines, backend app + DI container build cleanly.

## Note for review

I can't exercise a **live Temporal server** locally, so this is verified by static analysis + import/build checks. Worth a smoke test on the deployment: trigger one workflow path (e.g. a response-deletion schedule or user-deletion) after merge to confirm the connect-on-main-loop path works end to end.

Found during the post-deploy-crash latent-pattern audit (follow-on to #574/#575/#577/#578).

🤖 Generated with [Claude Code](https://claude.com/claude-code)