### PR TITLE
fix(auth): fix Google login by requesting canonical OAuth scopes

### DIFF
--- a/auth/auth/app/services/google_auth_provider.py
+++ b/auth/auth/app/services/google_auth_provider.py
@@ -1,5 +1,7 @@
 import json
 
+import loguru
+
 from auth.app.exceptions import HTTPException
 from auth.app.repositories.user_repository import UserRepository
 from auth.app.services.base_auth_provider import BaseAuthProvider
@@ -38,6 +40,19 @@ client_config = {
     }
 }
 
+# Request the exact canonical scope URLs Google echoes back in the token
+# response. oauthlib compares requested vs granted scopes as a set and hard-
+# fails ("Scope has changed") on any mismatch unless OAUTHLIB_RELAX_TOKEN_SCOPE
+# is set. The old string mixed short names ("profile") with full URLs, and
+# Google expands "profile" -> ".../auth/userinfo.profile", so the sets never
+# matched — leaving login dependent on that env flag. Listing the canonical
+# URLs makes the sets equal, so token exchange succeeds regardless.
+GOOGLE_SCOPES = [
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile",
+]
+
 
 class GoogleAuthProvider(BaseAuthProvider):
     async def get_basic_auth_url(self, client_referer_url: str, *args, **kwargs):
@@ -49,7 +64,7 @@ class GoogleAuthProvider(BaseAuthProvider):
         state = crypto.encrypt(state_json)
         flow = google_auth_oauthlib.flow.Flow.from_client_config(
             client_config=client_config,
-            scopes="https://www.googleapis.com/auth/userinfo.email profile openid",
+            scopes=GOOGLE_SCOPES,
         )
         flow.redirect_uri = settings.google_settings.basic_auth_redirect
 
@@ -73,6 +88,12 @@ class GoogleAuthProvider(BaseAuthProvider):
         credentials = self.fetch_basic_token(
             auth_code=authorization_response, state=state
         )
+        if credentials is None:
+            # Token exchange failed (fetch_basic_token logged the cause). Fail
+            # with a clear 401 instead of passing None to get_google_user, where
+            # build(credentials=None) raises an uncaught DefaultCredentialsError
+            # that surfaces to the user as an opaque 500 "proxy server error".
+            raise HTTPException(401, "Google authentication failed. Please try again.")
         user = await self.get_google_user(credentials)
         if not user:
             return state_json
@@ -97,16 +118,21 @@ class GoogleAuthProvider(BaseAuthProvider):
     def fetch_basic_token(self, auth_code: str, state):
         flow = google_auth_oauthlib.flow.Flow.from_client_config(
             client_config=client_config,
-            scopes="https://www.googleapis.com/auth/userinfo.email profile openid",
+            scopes=GOOGLE_SCOPES,
             state=state,
         )
         flow.redirect_uri = settings.google_settings.basic_auth_redirect
         try:
             flow.fetch_token(authorization_response=auth_code)
-        except Exception:
+        except Exception as e:
+            # Never swallow this silently — the real cause (scope mismatch,
+            # invalid_client, redirect_uri mismatch, transport, …) is otherwise
+            # invisible because the caller only sees a None credential.
+            loguru.logger.error(
+                "Google token exchange failed: {}: {}", type(e).__name__, e
+            )
             return None
-        credentials = flow.credentials
-        return credentials
+        return flow.credentials
 
     async def get_google_user(self, credentials):
         try:
@@ -124,3 +150,10 @@ class GoogleAuthProvider(BaseAuthProvider):
             raise HTTPException(401, "State not found. Connect with google services.")
         except InvalidGrantError:
             raise HTTPException(401, "Invalid Grant error.")
+        except Exception as e:
+            # Catch-all so an unexpected error (e.g. DefaultCredentialsError)
+            # becomes a clear 401 rather than an opaque 500.
+            loguru.logger.error(
+                "Fetching Google user info failed: {}: {}", type(e).__name__, e
+            )
+            raise HTTPException(401, "Could not retrieve your Google account info.")


### PR DESCRIPTION
## Symptom

Google login failed with an opaque **500 → "Error Occurred in the proxy server"** after the Dependabot oauth bumps (`google-auth-oauthlib` 1.2.4→1.4.0, `requests-oauthlib`→2.0.0, `oauthlib` 3.3.1). OTP login was unaffected.

## Root cause

The requested scope string mixed a short name with full URLs:

```
"https://www.googleapis.com/auth/userinfo.email profile openid"
```

Google expands `profile` → `.../auth/userinfo.profile`, so the **granted** scope set never equals the **requested** set. oauthlib compares them as sets (`scope_changed = set(new) != set(old)`) and raises `Scope has changed` on any mismatch **unless `OAUTHLIB_RELAX_TOKEN_SCOPE` is set**. The newer `google-auth-oauthlib` stopped normalizing the requested scopes, so `fetch_token` began hard-failing.

**Fix:** request the canonical scope URLs Google echoes back, so the sets match and token exchange succeeds independent of the env flag:

```python
GOOGLE_SCOPES = [
    "openid",
    "https://www.googleapis.com/auth/userinfo.email",
    "https://www.googleapis.com/auth/userinfo.profile",
]
```

## Why it was opaque (two masking bugs, also fixed)

1. `fetch_basic_token` caught **every** exception and returned `None` **without logging** — the real token-exchange error was invisible.
2. `basic_auth_callback` then passed `None` to `get_google_user`, where `build(credentials=None)` raises an **uncaught** `google.auth.exceptions.DefaultCredentialsError` → unhandled 500 → the backend `HttpClient` wraps it as "Error Occurred in the proxy server."

Now: `fetch_basic_token` logs the real cause; `None` credentials raise a clear **401**; and `get_google_user` has a logged catch-all so no path 500s opaquely.

## How this was diagnosed

- OTP works ⇒ auth service is healthy; this is a real Google-specific bug.
- Reproduced locally: with the relax env flags set, `fetch_token` reaches Google and behaves correctly ⇒ the library **usage** is API-correct; the break is the scope-set mismatch + the swallowed error.
- `build("oauth2","v2")` constructs fine with valid credentials ⇒ not a discovery/googleapiclient break.
- `build(credentials=None)` raises `DefaultCredentialsError` ⇒ the exact uncaught-500 path.

## Verification

- Auth URL now requests exactly `openid userinfo.email userinfo.profile` (canonical set).
- Auth suite passes (2, incl. the callback test).

Worth confirming end-to-end on the deployment after merge (real Google sign-in). If anything still fails, the auth log will now show the **real** cause instead of an opaque 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)