### PR TITLE
Responder-form quality campaign: field fixes, a11y, appeal pass, theme styles, column widths, publish modal

### DIFF
--- a/backend/backend/app/models/workspace.py
+++ b/backend/backend/app/models/workspace.py
@@ -79,6 +79,14 @@ class WorkspaceThemeDto(BaseModel):
     tertiary: str
     accent: str
     background: Optional[WorkspaceThemeBackgroundDto] = None
+    style: Optional[str] = None
+
+    @field_validator("style")
+    @classmethod
+    def _known_style(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in ("classic", "sheet", "studio"):
+            raise ValueError("Style must be classic, sheet or studio.")
+        return v
 
     @field_validator("title")
     @classmethod

--- a/backend/tests/app/controllers/test_workspace.py
+++ b/backend/tests/app/controllers/test_workspace.py
@@ -36,7 +36,7 @@ class TestWorkspaces:
             json=[theme],
         )
         assert response.status_code == 200
-        assert response.json().get("customThemes") == [{**theme, "background": None}]
+        assert response.json().get("customThemes") == [{**theme, "background": None, "style": None}]
 
         # And it round-trips on the persisted document.
         saved = await WorkspaceDocument.get(workspace.id)

--- a/common/common/models/standard_form.py
+++ b/common/common/models/standard_form.py
@@ -387,6 +387,9 @@ class StandardFieldProperty(BaseModel):
     row_titles: Optional[List[str]] = None
     column_titles: Optional[List[str]] = None
     tabular_value: Optional[List[List[str]]] = None
+    # 12-grid width of the field on desktop (12 = full row, 6 = half…); the
+    # webapp sends camelCase colSpan via the alias generator.
+    col_span: Optional[int] = Field(None, ge=1, le=12)
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
 

--- a/common/common/models/standard_form.py
+++ b/common/common/models/standard_form.py
@@ -31,6 +31,9 @@ class Theme(BaseModel):
     tertiary: str
     accent: str
     background: Optional[ThemeBackground] = None
+    # How the form is dressed (classic/sheet/studio; open for future styles).
+    # Lenient here — strict validation lives on the workspace theme endpoint.
+    style: Optional[str] = None
 
 
 class EmbedProvider(str, enum.Enum):

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/themes/page.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/themes/page.tsx
@@ -13,7 +13,7 @@ import { selectIsAdmin } from '@app/store/auth/slice';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
 import { usePatchWorkspaceThemesMutation } from '@app/store/workspaces/api';
 import { selectWorkspace, setWorkspace } from '@app/store/workspaces/slice';
-import { ContrastNotes, THEME_ROLE_FIELDS, ThemeBackgroundEditor, ThemePreview } from '@app/views/molecules/theme/theme-shared';
+import { ContrastNotes, THEME_ROLE_FIELDS, ThemeBackgroundEditor, ThemePreview, ThemeStyleEditor } from '@app/views/molecules/theme/theme-shared';
 
 type Editing = { index: number | 'new'; draft: FormTheme } | null;
 
@@ -173,6 +173,8 @@ export default function ThemesPage() {
                                     </div>
                                 ))}
                             </div>
+
+                            <ThemeStyleEditor value={editing.draft.style} onChange={(style) => setEditing({ ...editing, draft: { ...editing.draft, style } })} />
 
                             <ThemeBackgroundEditor theme={editing.draft} onChange={(background) => setEditing({ ...editing, draft: { ...editing.draft, background } })} />
 

--- a/webapp/src/constants/theme.ts
+++ b/webapp/src/constants/theme.ts
@@ -25,6 +25,14 @@ export const ThemeColor = {
     primary: '#101826'
 };
 
+// How the form is DRESSED, independent of its colours/background. 'classic'
+// is today's look; 'sheet' sets questions like a printed document (serif
+// labels, margin numerals, ruled rows); 'studio' is the bold graphic register
+// (ghost numerals, heavy type, square edges, solid selection). Structural
+// styles (two-pane ledger, conversational receipts) can join this enum once
+// the renderer grows those modes — the model is deliberately open.
+export type ThemeStyle = 'classic' | 'sheet' | 'studio';
+
 export type ThemePattern = 'dots' | 'grid' | 'stripes';
 
 // Optional decoration for the page ground. `accent` stays the base colour
@@ -46,6 +54,7 @@ export interface FormTheme {
     tertiary: string;
     accent: string;
     background?: ThemeBackground;
+    style?: ThemeStyle;
 }
 
 export const ThemeColors: Array<FormTheme> = [

--- a/webapp/src/lib/hooks/use-dialog-modal.tsx
+++ b/webapp/src/lib/hooks/use-dialog-modal.tsx
@@ -87,7 +87,8 @@ const GetModalToRender = (view?: DIALOG_MODALS, props?: any) => {
 const getClassName = (view?: DIALOG_MODALS) => {
     switch (view) {
         case 'FORM_PUBLISHED':
-            return 'md:!min-w-[760px]';
+            // Matches the Share modal's width — this is the same link-forward moment.
+            return 'md:!min-w-[540px] md:!max-w-[540px]';
         case 'SHARE_FORM_MODAL':
             return 'md:!min-w-fit';
         case 'UNSPLASH_IMAGE_PICKER':

--- a/webapp/src/models/dtos/form.ts
+++ b/webapp/src/models/dtos/form.ts
@@ -21,6 +21,10 @@ export interface StandardFormFieldProperties {
     showQuestionNumbers?: boolean;
     allowMultipleSelection?: boolean;
     allowOtherChoice?: boolean;
+    // 12-grid width of the field on desktop (12 = full row, 6 = half, 4 = a
+    // third…). Adjacent fields whose spans fit pack into the same row; mobile
+    // always stacks full-width. Default 12.
+    colSpan?: number;
     layout?: FormSlideLayout;
     theme?: FormTheme;
     conditions?: any;

--- a/webapp/src/models/dtos/form.ts
+++ b/webapp/src/models/dtos/form.ts
@@ -22,13 +22,7 @@ export interface StandardFormFieldProperties {
     allowMultipleSelection?: boolean;
     allowOtherChoice?: boolean;
     layout?: FormSlideLayout;
-    theme?: {
-        title: string;
-        primary: string;
-        secondary: string;
-        tertiary: string;
-        accent: string;
-    };
+    theme?: FormTheme;
     conditions?: any;
     mentions?: any;
     logicalOperator?: any;

--- a/webapp/src/shadcn/components/ui/input.tsx
+++ b/webapp/src/shadcn/components/ui/input.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { StandardFormFieldDto } from '@app/models/dtos/form';
 import { cn } from '@app/shadcn/util/lib';
 import { IThemeState, useFormState } from '@app/store/jotai/form';
+import { styleTokens } from '@app/views/molecules/theme/theme-shared';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     textColor?: string;
@@ -53,13 +54,16 @@ const FieldInput = styled(ShadCNInput)<{
     // interpolation yields an inconsistent hook count under React 19.
     const themeColor = $formTheme?.tertiary;
     const secondaryColor = $formTheme?.secondary;
+    const tokens = styleTokens($formTheme?.style);
     return {
         // White field on the page surface gives the input real figure/ground —
         // the bordered box, not a wash, is what reads as "type here".
         background: '#ffffff',
-        // Fall back to a visible hairline when the form has no custom theme, so
-        // the field never disappears into the page (affordance).
-        borderColor: themeColor || '#CBD5E6',
+        borderRadius: tokens.inputRadius,
+        // Resting border is deliberately SUBTLE — the theme's border colour at
+        // 55% (hairline fallback) so the field sits calm at rest; hover and
+        // focus below carry the strong affordance.
+        borderColor: themeColor ? `${themeColor}8C` : '#CBD5E6',
         '&::placeholder': {
             // Legible neutral (ink-3), not the theme tint — placeholders are
             // text people read, not decoration.

--- a/webapp/src/shadcn/components/ui/input.tsx
+++ b/webapp/src/shadcn/components/ui/input.tsx
@@ -60,19 +60,18 @@ const FieldInput = styled(ShadCNInput)<{
         // the bordered box, not a wash, is what reads as "type here".
         background: '#ffffff',
         borderRadius: tokens.inputRadius,
-        // Resting border is deliberately SUBTLE — the theme's border colour at
-        // 55% (hairline fallback) so the field sits calm at rest; hover and
-        // focus below carry the strong affordance.
-        borderColor: themeColor ? `${themeColor}8C` : '#CBD5E6',
+        // Three-step border affordance: a light fixed grey at REST (fields sit
+        // calm on the page), the theme's border colour (tertiary) on HOVER — a
+        // clear but quiet "this is interactive" step — and the action-colour
+        // ring on FOCUS.
+        borderColor: '#E3E3E3',
         '&::placeholder': {
             // Legible neutral (ink-3), not the theme tint — placeholders are
             // text people read, not decoration.
             color: '#657085 !important'
         },
-        // A field that responds to the cursor reads as inviting — hover hints
-        // with the action colour; focus commits with the full ring below.
         '&:hover:not(:focus)': {
-            borderColor: secondaryColor || '#2456CC'
+            borderColor: themeColor || '#8A94A6'
         },
         '&:focus': {
             // Always show a focus ring for keyboard users (WCAG 2.4.7). The base

--- a/webapp/src/shadcn/components/ui/input.tsx
+++ b/webapp/src/shadcn/components/ui/input.tsx
@@ -22,7 +22,7 @@ const ShadCNInput = React.forwardRef<HTMLInputElement, InputProps>(({ className,
                 color: theme?.primary
             }}
             type={type}
-            className={cn(`w-full rounded-xl border bg-white px-4 py-3 text-base outline-none transition-shadow disabled:cursor-not-allowed disabled:opacity-50 lg:text-lg`, className)}
+            className={cn(`w-full rounded-md border bg-white px-4 py-3 text-base outline-none transition duration-150 disabled:cursor-not-allowed disabled:opacity-50 lg:text-lg`, className)}
             ref={ref}
             // Coerce null -> '' so a controlled input never receives a null value.
             value={value === null ? '' : value}
@@ -64,6 +64,11 @@ const FieldInput = styled(ShadCNInput)<{
             // Legible neutral (ink-3), not the theme tint — placeholders are
             // text people read, not decoration.
             color: '#657085 !important'
+        },
+        // A field that responds to the cursor reads as inviting — hover hints
+        // with the action colour; focus commits with the full ring below.
+        '&:hover:not(:focus)': {
+            borderColor: secondaryColor || '#2456CC'
         },
         '&:focus': {
             // Always show a focus ring for keyboard users (WCAG 2.4.7). The base

--- a/webapp/src/store/jotai/field-selectors.ts
+++ b/webapp/src/store/jotai/field-selectors.ts
@@ -257,6 +257,15 @@ export default function useFormFieldsAtom() {
         setFormFields(updatedSlides);
     };
 
+    const updateFieldColSpan = (fieldIndex: number, slideIndex: number, colSpan: number) => {
+        const existingSlide = formFields[slideIndex];
+        const slide = { ...existingSlide };
+        slide.properties!.fields![fieldIndex]['properties'] = { ...(slide.properties!.fields![fieldIndex].properties || { fields: [] }) };
+        slide.properties!.fields![fieldIndex]!.properties!.colSpan = Math.min(12, Math.max(1, colSpan));
+        const updatedSlides = [...formFields];
+        setFormFields(updatedSlides);
+    };
+
     const updateFieldPlaceholder = (fieldIndex: number, slideIndex: number, placeholderText: string) => {
         const existingSlide = formFields[slideIndex];
         const slide = { ...existingSlide };
@@ -765,6 +774,7 @@ export default function useFormFieldsAtom() {
         updateTitle,
         updateDescription,
         updateFieldPlaceholder,
+        updateFieldColSpan,
         updateChoiceFieldValue,
         addChoiceField,
         updateFieldRequired,

--- a/webapp/src/store/jotai/form.ts
+++ b/webapp/src/store/jotai/form.ts
@@ -1,4 +1,4 @@
-import { ThemeBackground } from '@app/constants/theme';
+import { ThemeBackground, ThemeStyle } from '@app/constants/theme';
 import { atom, useAtom } from 'jotai';
 
 import { ThemeColor } from '@app/constants/theme';
@@ -40,6 +40,7 @@ export interface IThemeState {
     tertiary: string;
     accent: string;
     background?: ThemeBackground;
+    style?: ThemeStyle;
 }
 
 

--- a/webapp/src/views/atoms/choice.tsx
+++ b/webapp/src/views/atoms/choice.tsx
@@ -35,16 +35,19 @@ export default function Choice({ isSelected, theme, index, choice, onClick }: Ch
             aria-pressed={isSelected}
             $theme={theme}
             style={{
-                background: isSelected ? theme?.tertiary + '55' : '',
+                // Selection wears the action colour (a soft tint + border) — colour
+                // is semantic here: it marks the responder's own answer. The old
+                // grey tertiary tint made selection read as disabled.
+                background: isSelected ? theme?.secondary + '1A' : '',
                 borderColor: isSelected ? theme?.secondary : theme?.tertiary,
-                // The answer wears ink (theme primary), never the action colour.
+                // The answer text wears ink (theme primary), never the action colour.
                 color: theme?.primary
             }}
-            className="flex w-full cursor-pointer items-center justify-between rounded-xl border p-2 px-4 text-left"
+            className="flex w-full cursor-pointer items-center justify-between rounded-md border p-2 px-4 text-left transition duration-150"
             key={choice.id}
             onClick={() => onClick && onClick(choice.id || '')}
         >
-            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" />}
+            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" style={{ color: theme?.secondary }} />}
         </StyledChoiceButton>
     );
 }

--- a/webapp/src/views/atoms/choice.tsx
+++ b/webapp/src/views/atoms/choice.tsx
@@ -27,14 +27,15 @@ export default function Choice({ isSelected, theme, index, choice, onClick }: Ch
             $theme={theme}
             style={{
                 background: isSelected ? theme?.tertiary + '55' : '',
-                borderColor: theme?.tertiary,
-                color: theme?.secondary
+                borderColor: isSelected ? theme?.secondary : theme?.tertiary,
+                // The answer wears ink (theme primary), never the action colour.
+                color: theme?.primary
             }}
             className="flex cursor-pointer justify-between rounded-xl border p-2 px-4 "
             key={choice.id}
             onClick={() => onClick && onClick(choice.id || '')}
         >
-            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check />}
+            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" />}
         </StyledDiv>
     );
 }

--- a/webapp/src/views/atoms/choice.tsx
+++ b/webapp/src/views/atoms/choice.tsx
@@ -2,6 +2,7 @@ import { Check } from 'lucide-react';
 import styled from 'styled-components';
 
 import { FormTheme } from '@app/constants/theme';
+import { styleTokens } from '@app/views/molecules/theme/theme-shared';
 import { FieldChoice } from '@app/models/dtos/form';
 
 interface ChoiceProps {
@@ -29,25 +30,27 @@ const StyledChoiceButton = styled.button<{ $theme: any }>(({ $theme }) => {
 });
 
 export default function Choice({ isSelected, theme, index, choice, onClick }: ChoiceProps) {
+    const tokens = styleTokens(theme?.style);
+    const solid = tokens.solidSelection && isSelected;
     return (
         <StyledChoiceButton
             type="button"
             aria-pressed={isSelected}
             $theme={theme}
             style={{
-                // Selection wears the action colour (a soft tint + border) — colour
-                // is semantic here: it marks the responder's own answer. The old
-                // grey tertiary tint made selection read as disabled.
-                background: isSelected ? theme?.secondary + '1A' : '',
+                // Selection wears the action colour — a soft tint + border in the
+                // quiet styles, a solid fill with white text in the studio style.
+                // Colour is semantic here: it marks the responder's own answer.
+                background: solid ? theme?.secondary : isSelected ? theme?.secondary + '1A' : '',
                 borderColor: isSelected ? theme?.secondary : theme?.tertiary,
-                // The answer text wears ink (theme primary), never the action colour.
-                color: theme?.primary
+                color: solid ? '#ffffff' : theme?.primary,
+                borderRadius: tokens.inputRadius
             }}
-            className="flex w-full cursor-pointer items-center justify-between rounded-md border p-2 px-4 text-left transition duration-150"
+            className="flex w-full cursor-pointer items-center justify-between border p-2 px-4 text-left transition duration-150"
             key={choice.id}
             onClick={() => onClick && onClick(choice.id || '')}
         >
-            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" style={{ color: theme?.secondary }} />}
+            {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" style={{ color: solid ? '#ffffff' : theme?.secondary }} />}
         </StyledChoiceButton>
     );
 }

--- a/webapp/src/views/atoms/choice.tsx
+++ b/webapp/src/views/atoms/choice.tsx
@@ -12,18 +12,27 @@ interface ChoiceProps {
     onClick?: (choiceId: string) => any;
 }
 
-const StyledDiv = styled.div<{ $theme: any }>(({ $theme }) => {
+const StyledChoiceButton = styled.button<{ $theme: any }>(({ $theme }) => {
     const secondaryColor = $theme?.secondary;
     return {
         '&:hover': {
             borderColor: secondaryColor + '!important'
+        },
+        // Keyboard users get the same affordance as hover (WCAG 2.4.7) — the
+        // options were plain clickable divs with no focus state at all.
+        '&:focus-visible': {
+            outline: 'none',
+            borderColor: secondaryColor + '!important',
+            boxShadow: secondaryColor ? `0 0 0 3px ${secondaryColor}40` : undefined
         }
     };
 });
 
 export default function Choice({ isSelected, theme, index, choice, onClick }: ChoiceProps) {
     return (
-        <StyledDiv
+        <StyledChoiceButton
+            type="button"
+            aria-pressed={isSelected}
             $theme={theme}
             style={{
                 background: isSelected ? theme?.tertiary + '55' : '',
@@ -31,11 +40,11 @@ export default function Choice({ isSelected, theme, index, choice, onClick }: Ch
                 // The answer wears ink (theme primary), never the action colour.
                 color: theme?.primary
             }}
-            className="flex cursor-pointer justify-between rounded-xl border p-2 px-4 "
+            className="flex w-full cursor-pointer items-center justify-between rounded-xl border p-2 px-4 text-left"
             key={choice.id}
             onClick={() => onClick && onClick(choice.id || '')}
         >
             {choice.value ? choice.value : `Item ${index + 1}`} {isSelected && <Check className="h-5 w-5 shrink-0" />}
-        </StyledDiv>
+        </StyledChoiceButton>
     );
 }

--- a/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
+++ b/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
@@ -36,10 +36,10 @@ export default function FormPublishedModal(props: any) {
         setTimeout(() => setCopied(false), 2000);
     };
 
+    // min-w-0 on the root matters: DialogContent is display:grid, and a grid
+    // item's implicit min-width:auto lets the unbreakable URL dictate the
+    // width — overflowing the dialog instead of truncating.
     return (
-        {/* min-w-0 matters: DialogContent is display:grid, and a grid item's
-            implicit min-width:auto lets the unbreakable URL dictate the width —
-            overflowing the dialog instead of truncating. */}
         <div className="flex w-full min-w-0 max-w-full flex-col gap-6 overflow-hidden p-6 sm:p-8">
             <div className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2.5">

--- a/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
+++ b/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
@@ -37,7 +37,10 @@ export default function FormPublishedModal(props: any) {
     };
 
     return (
-        <div className="flex w-full flex-col gap-6 p-6 sm:p-8">
+        {/* min-w-0 matters: DialogContent is display:grid, and a grid item's
+            implicit min-width:auto lets the unbreakable URL dictate the width —
+            overflowing the dialog instead of truncating. */}
+        <div className="flex w-full min-w-0 max-w-full flex-col gap-6 overflow-hidden p-6 sm:p-8">
             <div className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2.5">
                     <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#E7F4EE]">

--- a/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
+++ b/webapp/src/views/molecules/dialogs/form-publised-modal.tsx
@@ -1,74 +1,92 @@
-"use client";
-import { useToast } from '@app/shadcn/components/ui/use-toast';
+'use client';
 
-import { Button, buttonVariants } from '@app/shadcn/components/ui/button';
+import { useState } from 'react';
+
+import { Check, Copy, ExternalLink } from 'lucide-react';
+
+import { Button } from '@app/shadcn/components/ui/button';
+import { useToast } from '@app/shadcn/components/ui/use-toast';
 import { selectAuth } from '@app/store/auth/slice';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
 import getFormShareURL from '@app/utils/form-utils';
-import GreenCheckedCircle from '@Components/icons/green-checked-circle';
 
+/**
+ * Post-publish moment, on the trust system and matching the Share modal's
+ * idiom: one calm confirmation, the link front-and-centre with copy/open,
+ * and honest next steps as quiet links — no double celebration, no dead-end
+ * "go to dashboard" as the only exit.
+ */
 export default function FormPublishedModal(props: any) {
     const { toast } = useToast();
     const workspace = useAppSelector(selectWorkspace);
-
     const standardForm = useAppSelector(selectForm);
     const authState = useAppSelector(selectAuth);
+    const [copied, setCopied] = useState(false);
+
+    const shareUrl = getFormShareURL(standardForm, workspace);
+    const settingsUrl = `${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms/${standardForm.formId}?view=FormLinks`;
+    const dashboardUrl = `${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms`;
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(shareUrl);
+        setCopied(true);
+        toast({ description: 'Link copied to clipboard' });
+        setTimeout(() => setCopied(false), 2000);
+    };
 
     return (
-        <div className="w-full">
-            <div className="border-b-black-300 text-black-700 border-b p-4 text-xs">Form Published</div>
-            <div className="flex w-full flex-col items-center gap-6 px-5 py-6">
-                <GreenCheckedCircle />
-                <div className="flex flex-col items-center gap-1">
-                    <div className="flex items-center gap-2 text-[32px]">
-                        🎉
-                        <span className="h2-new font-bold">Your form has been published</span>
-                    </div>
-                    <span className="p4-new text-black-700">Anyone with the link can fill your form</span>
-                </div>
-                <div className="flex items-center  gap-2">
-                    <div className="text-black-700 p4-new bg-black-100 rounded-md px-3 py-2">
-                        {window.PUBLIC_CONFIG?.HTTP_SCHEME}
-                        {window.PUBLIC_CONFIG?.FORM_DOMAIN}/{workspace.workspaceName}
-                        /forms/
-                        <span className="text-pink-500">{standardForm.settings?.customUrl}</span>
-                    </div>
-                    <Button
-                        data-umami-event={'PublishModal Copy Button'}
-                        data-umami-event-email={authState.email}
-                        variant={'v2Button'}
-                        onClick={() => {
-                            navigator.clipboard.writeText(getFormShareURL(standardForm, workspace));
-                            toast({ description: 'Copied!' });
-                        }}
-                    >
-                        Copy
-                    </Button>
-                </div>
-                <div className="p2-new mt-5 flex flex-col items-center gap-2 md:w-[250px]">
-                    <span className="h5-new">What’s Next?</span>
-                    <span className="p4-new break-words text-center">
-                        Add your custom domain, add integration or change form privacy,{' '}
-                        <a
-                            data-umami-event={'PublishModal Goto Settings Link'}
-                            data-umami-event-email={authState.email}
-                            href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms/${standardForm.formId}?view=FormLinks`}
-                            className="text-blue-500"
-                        >
-                            Go to form settings
-                        </a>
+        <div className="flex w-full flex-col gap-6 p-6 sm:p-8">
+            <div className="flex flex-col gap-1.5">
+                <div className="flex items-center gap-2.5">
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#E7F4EE]">
+                        <Check className="h-4 w-4 text-[#0E8A5F]" strokeWidth={3} />
                     </span>
+                    <h2 className="text-black-900 text-lg font-semibold leading-snug">Your form is live</h2>
                 </div>
-                <div className="mb-5 mt-5">
+                {/* Honest about what publishing means — same line the Share modal uses. */}
+                <p className="text-black-600 text-sm leading-relaxed">Anyone with this link can open and respond to your form.</p>
+            </div>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <div className="border-black-300 bg-black-100 flex min-w-0 flex-1 items-center gap-2 rounded-lg border px-3.5 py-3">
+                    <span className="text-black-800 min-w-0 flex-1 truncate text-sm" title={shareUrl}>
+                        {shareUrl}
+                    </span>
                     <a
-                        data-umami-event={'PublishModal Goto Dashboard Link'}
+                        href={shareUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Open form in a new tab"
+                        data-umami-event={'PublishModal Open Form Link'}
                         data-umami-event-email={authState.email}
-                        href={`${window.PUBLIC_CONFIG?.HTTP_SCHEME}${window.PUBLIC_CONFIG?.DASHBOARD_DOMAIN}/${workspace.workspaceName}/dashboard/forms`}
-                        className={buttonVariants({ size: 'medium', className: 'cursor-pointer' })}
+                        className="text-black-500 hover:text-brand-500 shrink-0 transition-colors"
                     >
-                        Done! Go to dashboard
+                        <ExternalLink className="h-4 w-4" />
+                    </a>
+                </div>
+                <Button
+                    size="medium"
+                    variant="primary"
+                    onClick={handleCopy}
+                    icon={copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+                    className="shrink-0"
+                    data-umami-event={'PublishModal Copy Button'}
+                    data-umami-event-email={authState.email}
+                >
+                    {copied ? 'Copied' : 'Copy link'}
+                </Button>
+            </div>
+
+            <div className="border-t-black-200 flex flex-col gap-2.5 border-t pt-5">
+                <span className="text-black-500 text-xs font-medium uppercase tracking-wide">Next steps</span>
+                <div className="text-black-700 flex flex-col gap-2 text-sm">
+                    <a href={settingsUrl} data-umami-event={'PublishModal Goto Settings Link'} data-umami-event-email={authState.email} className="hover:text-brand-600 text-brand-500 w-fit font-medium underline-offset-2 hover:underline">
+                        Form settings — custom domain, privacy, integrations
+                    </a>
+                    <a href={dashboardUrl} data-umami-event={'PublishModal Goto Dashboard Link'} data-umami-event-email={authState.email} className="hover:text-brand-600 text-brand-500 w-fit font-medium underline-offset-2 hover:underline">
+                        Back to dashboard
                     </a>
                 </div>
             </div>

--- a/webapp/src/views/molecules/responder-form-fields/date-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/date-field.tsx
@@ -79,9 +79,10 @@ function DateFieldSection({ field, isBuilder }: IDateField) {
                             style={{ color: secondaryColor }}
                         />
                         {date ? (
-                            <span style={{ color: secondaryColor }}>{format(date, 'PPP')}</span>
+                            // The chosen date is the answer — ink, not the action colour.
+                            <span style={{ color: theme?.primary }}>{format(date, 'PPP')}</span>
                         ) : (
-                            <span style={{ color: tertiaryColor }}>Pick a date</span>
+                            <span style={{ color: '#657085' }}>Pick a date</span>
                         )}
                     </button>
                 </PopoverTrigger>

--- a/webapp/src/views/molecules/responder-form-fields/date-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/date-field.tsx
@@ -65,11 +65,12 @@ function DateFieldSection({ field, isBuilder }: IDateField) {
                     <button
                         type="button"
                         className={cn(
-                            'flex w-full cursor-pointer items-center gap-2 rounded-md border bg-white px-4 py-3 text-base outline-none transition duration-150 hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg',
+                            'flex w-full cursor-pointer items-center gap-2 rounded-md border bg-white px-4 py-3 text-base outline-none transition duration-150 hover:!border-[color:var(--hover-border)] hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg',
                             isBuilder && 'pointer-events-none'
                         )}
                         style={{
-                            borderColor: tertiaryColor,
+                            ['--hover-border' as string]: tertiaryColor ?? '#8A94A6',
+                            borderColor: '#E3E3E3',
                             // Chosen date is content (ink); empty state a legible neutral.
                             color: date ? theme?.primary : '#657085'
                         }}

--- a/webapp/src/views/molecules/responder-form-fields/date-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/date-field.tsx
@@ -65,7 +65,7 @@ function DateFieldSection({ field, isBuilder }: IDateField) {
                     <button
                         type="button"
                         className={cn(
-                            'flex w-full cursor-pointer items-center gap-2 rounded-xl border bg-white px-4 py-3 text-base outline-none transition-shadow focus-visible:ring-2 lg:text-lg',
+                            'flex w-full cursor-pointer items-center gap-2 rounded-md border bg-white px-4 py-3 text-base outline-none transition duration-150 hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg',
                             isBuilder && 'pointer-events-none'
                         )}
                         style={{

--- a/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
@@ -64,10 +64,14 @@ export default function DropDownField({ field, slideIndex }: { field: StandardFo
         <QuestionWrapper field={field}>
             <Collapsible open={isOpen} onOpenChange={setIsOpen} className=" space-y-2">
                 <CollapsibleTrigger asChild>
-                    <div style={getTextStyle()} className="flex cursor-pointer items-center justify-between space-x-4 border-b-[1px] text-3xl">
-                        {choiceValue ? choiceValue : 'Select an Option'}
-                        <ChevronDown className={`duration-400 h-6 w-7 transition ${isOpen ? 'rotate-180' : ''}`} style={{ color: theme?.secondary }} />
-                    </div>
+                    {/* Same input language as every other field: bordered white
+                        rounded-xl box, base/lg type, real button semantics — the old
+                        trigger was a text-3xl underline-only div with no keyboard
+                        affordance, a different species from the rest of the form. */}
+                    <button type="button" style={getTextStyle()} className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-xl border bg-white px-4 py-3 text-left text-base outline-none transition-shadow focus-visible:ring-2 lg:text-lg">
+                        <span className="truncate">{choiceValue ? choiceValue : 'Select an option'}</span>
+                        <ChevronDown className={`duration-400 h-5 w-5 shrink-0 transition ${isOpen ? 'rotate-180' : ''}`} style={{ color: theme?.secondary }} />
+                    </button>
                 </CollapsibleTrigger>
                 <CollapsibleContent className="space-y-2">
                     {field.properties?.choices?.map((choice, index) => {

--- a/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
@@ -65,10 +65,10 @@ export default function DropDownField({ field, slideIndex }: { field: StandardFo
             <Collapsible open={isOpen} onOpenChange={setIsOpen} className=" space-y-2">
                 <CollapsibleTrigger asChild>
                     {/* Same input language as every other field: bordered white
-                        rounded-xl box, base/lg type, real button semantics — the old
+                        rounded-md box, base/lg type, real button semantics — the old
                         trigger was a text-3xl underline-only div with no keyboard
                         affordance, a different species from the rest of the form. */}
-                    <button type="button" style={getTextStyle()} className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-xl border bg-white px-4 py-3 text-left text-base outline-none transition-shadow focus-visible:ring-2 lg:text-lg">
+                    <button type="button" style={getTextStyle()} className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border bg-white px-4 py-3 text-left text-base outline-none transition duration-150 hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg">
                         <span className="truncate">{choiceValue ? choiceValue : 'Select an option'}</span>
                         <ChevronDown className={`duration-400 h-5 w-5 shrink-0 transition ${isOpen ? 'rotate-180' : ''}`} style={{ color: theme?.secondary }} />
                     </button>

--- a/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/drop-down-field.tsx
@@ -56,8 +56,8 @@ export default function DropDownField({ field, slideIndex }: { field: StandardFo
                 color: theme?.primary
             };
         }
-        // Placeholder state: legible neutral (ink-3), not the theme tint.
-        return { borderColor: theme?.tertiary, color: '#657085' };
+        // Placeholder state: calm light border at rest, legible neutral text.
+        return { borderColor: '#E3E3E3', color: '#657085' };
     };
 
     return (
@@ -68,7 +68,11 @@ export default function DropDownField({ field, slideIndex }: { field: StandardFo
                         rounded-md box, base/lg type, real button semantics — the old
                         trigger was a text-3xl underline-only div with no keyboard
                         affordance, a different species from the rest of the form. */}
-                    <button type="button" style={getTextStyle()} className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border bg-white px-4 py-3 text-left text-base outline-none transition duration-150 hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg">
+                    <button
+                        type="button"
+                        style={{ ...getTextStyle(), ['--hover-border' as string]: theme?.tertiary ?? '#8A94A6' }}
+                        className="flex w-full cursor-pointer items-center justify-between gap-4 rounded-md border bg-white px-4 py-3 text-left text-base outline-none transition duration-150 hover:!border-[color:var(--hover-border)] hover:shadow-[0_1px_3px_rgba(16,24,38,0.10)] focus-visible:ring-2 lg:text-lg"
+                    >
                         <span className="truncate">{choiceValue ? choiceValue : 'Select an option'}</span>
                         <ChevronDown className={`duration-400 h-5 w-5 shrink-0 transition ${isOpen ? 'rotate-180' : ''}`} style={{ color: theme?.secondary }} />
                     </button>

--- a/webapp/src/views/molecules/responder-form-fields/file-upload-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/file-upload-field.tsx
@@ -150,7 +150,7 @@ export default function FileUpload({ field }: { field: StandardFormFieldDto }) {
                             borderColor: isDragging ? theme?.secondary : theme?.tertiary
                         }}
                         htmlFor={`${fileMetaData.id}-file-input`}
-                        className="flex cursor-pointer items-center justify-center space-x-2  rounded-2xl border border-dashed px-3  py-2 "
+                        className="flex cursor-pointer items-center justify-center space-x-2  rounded-md border border-dashed px-3  py-2 "
                     >
                         <div className={`flex w-full flex-col items-center justify-center space-y-3  py-10 `}>
                             <FolderUploadIcon

--- a/webapp/src/views/molecules/responder-form-fields/file-upload-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/file-upload-field.tsx
@@ -112,21 +112,25 @@ export default function FileUpload({ field }: { field: StandardFormFieldDto }) {
     const getFilePreview = () => {
         return (
             <div className="flex w-full space-x-2">
-                <div style={{ backgroundColor: theme?.tertiary }} className="p1 flex w-full cursor-pointer items-center justify-between rounded px-3 py-2" onClick={downloadFormFile}>
+                {/* Tinted fill + ink text — a solid tertiary block under ink text is
+                    the same legibility defect the yes/no chips had. */}
+                <div style={{ backgroundColor: theme?.tertiary + '55', color: theme?.primary }} className="p1 flex w-full cursor-pointer items-center justify-between rounded px-3 py-2" onClick={downloadFormFile}>
                     <p className="mr-5 flex-1 truncate">{fileMetaData?.name}</p>
                     <p className="text-sm">{fileMetaData?.size} MB</p>
                 </div>
 
-                <div
+                <button
+                    type="button"
+                    aria-label="Remove uploaded file"
                     style={{
-                        backgroundColor: theme?.tertiary,
+                        backgroundColor: theme?.tertiary + '55',
                         color: theme?.primary
                     }}
                     className="items-center justify-center rounded p-2"
                     onClick={handleDeleteFile}
                 >
                     <DeleteIcon />
-                </div>
+                </button>
             </div>
         );
     };

--- a/webapp/src/views/molecules/responder-form-fields/linear-rating.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/linear-rating.tsx
@@ -14,17 +14,21 @@ import QuestionWrapper from './question-wrapper';
 
 const StyledDiv = styled.div<{
     $slide?: StandardFormFieldDto;
-    isBuilder: boolean;
-}>(({ $slide, isBuilder = false }) => {
-    const { theme } = useFormState();
-    const tertiaryColor = $slide?.properties?.theme?.tertiary || theme?.tertiary;
-    const secondaryColor = $slide?.properties?.theme?.secondary || theme?.secondary;
+    $formTheme?: ReturnType<typeof useFormState>['theme'];
+    $isBuilder?: boolean;
+}>(({ $slide, $formTheme, $isBuilder = false }) => {
+    // Theme via props ($ = transient, never leaks to the DOM). Calling the
+    // useFormState() hook inside a styled interpolation produces an
+    // inconsistent hook count under React 19 ("Rendered fewer hooks than
+    // expected") — this crashed the form preview for linear-rating fields.
+    const tertiaryColor = $slide?.properties?.theme?.tertiary || $formTheme?.tertiary;
+    const secondaryColor = $slide?.properties?.theme?.secondary || $formTheme?.secondary;
 
     return {
         color: secondaryColor,
-        borderColor: isBuilder ? tertiaryColor : secondaryColor,
+        borderColor: $isBuilder ? tertiaryColor : secondaryColor,
         '&:hover': {
-            background: isBuilder ? '' : tertiaryColor
+            background: $isBuilder ? '' : tertiaryColor
         }
     };
 });
@@ -44,7 +48,8 @@ const LinearRatingSection = ({ field, slide, isBuilder = false }: { field: Stand
                 return (
                     <StyledDiv
                         $slide={slide}
-                        isBuilder={isBuilder}
+                        $formTheme={theme}
+                        $isBuilder={isBuilder}
                         style={{
                             background: answer === index ? secondaryColor : '',
                             color: answer === index ? '#ffffff' : ''

--- a/webapp/src/views/molecules/responder-form-fields/linear-rating.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/linear-rating.tsx
@@ -12,7 +12,7 @@ import { useAppSelector } from '@app/store/hooks';
 import { scrollToDivById } from '@app/utils/scroll-utils';
 import QuestionWrapper from './question-wrapper';
 
-const StyledDiv = styled.div<{
+const StyledRatingButton = styled.button<{
     $slide?: StandardFormFieldDto;
     $formTheme?: ReturnType<typeof useFormState>['theme'];
     $isBuilder?: boolean;
@@ -29,6 +29,11 @@ const StyledDiv = styled.div<{
         borderColor: $isBuilder ? tertiaryColor : secondaryColor,
         '&:hover': {
             background: $isBuilder ? '' : tertiaryColor
+        },
+        // Keyboard affordance (the cells were divs with no focus state).
+        '&:focus-visible': {
+            outline: 'none',
+            boxShadow: secondaryColor ? `0 0 0 3px ${secondaryColor}40` : undefined
         }
     };
 });
@@ -46,7 +51,11 @@ const LinearRatingSection = ({ field, slide, isBuilder = false }: { field: Stand
         <div className="flex flex-row flex-wrap gap-1">
             {_.range(field.properties?.startFrom ?? 1, +(field.properties?.steps ?? 10) + 1, 1).map((index) => {
                 return (
-                    <StyledDiv
+                    <StyledRatingButton
+                        type="button"
+                        aria-label={`${index}`}
+                        aria-pressed={answer === index}
+                        disabled={isBuilder}
                         $slide={slide}
                         $formTheme={theme}
                         $isBuilder={isBuilder}
@@ -66,7 +75,7 @@ const LinearRatingSection = ({ field, slide, isBuilder = false }: { field: Stand
                         className="flex h-12 w-12  cursor-pointer items-center justify-center rounded-sm border-[1px]"
                     >
                         <span>{index}</span>
-                    </StyledDiv>
+                    </StyledRatingButton>
                 );
             })}
         </div>

--- a/webapp/src/views/molecules/responder-form-fields/multiple-choice-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/multiple-choice-field.tsx
@@ -51,7 +51,7 @@ const MultipleChoiceField = ({ field, slideIndex }: { field: StandardFormFieldDt
                             }
                             addOtherChoiceAnswer(field.id, e.target.value);
                         }}
-                        className={`flex justify-between rounded-xl border p-2 px-4 text-base`}
+                        className={`flex justify-between rounded-md border p-2 px-4 text-base`}
                     />
                 )}
             </div>

--- a/webapp/src/views/molecules/responder-form-fields/multiple-choice-with-multiple-selections.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/multiple-choice-with-multiple-selections.tsx
@@ -67,7 +67,7 @@ export default function MultipleChoiceWithMultipleSelection({ field, slideIndex 
                             }
                             addOtherChoicesAnswer(field.id, e.target.value);
                         }}
-                        className={`flex justify-between rounded-xl border p-2 px-4 text-base `}
+                        className={`flex justify-between rounded-md border p-2 px-4 text-base `}
                     />
                 )}
             </div>

--- a/webapp/src/views/molecules/responder-form-fields/multiple-choice-with-multiple-selections.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/multiple-choice-with-multiple-selections.tsx
@@ -43,7 +43,9 @@ export default function MultipleChoiceWithMultipleSelection({ field, slideIndex 
             <div className="w-full space-y-2 overflow-hidden border-0 p-0">
                 <h1
                     style={{
-                        color: currentSlide.properties?.theme?.secondary || theme?.secondary
+                        // currentSlide can be undefined (e.g. legacy/preview data
+                        // where the slide index doesn't resolve) — never crash for a hint.
+                        color: currentSlide?.properties?.theme?.secondary || theme?.secondary
                     }}
                     className="mb-1 mt-2 text-[12px] font-medium"
                 >

--- a/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
@@ -73,7 +73,7 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                     dropdownStyle={{ background: '#ffffff' }}
                     inputStyle={{
                         border: `1px solid ${theme?.tertiary}`,
-                        borderRadius: '12px',
+                        borderRadius: '6px',
                         background: '#ffffff',
                         color: theme?.primary
                     }}

--- a/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
@@ -13,6 +13,18 @@ import { useAppSelector } from '@app/store/hooks';
 import { scrollToDivById } from '@app/utils/scroll-utils';
 import QuestionWrapper from './question-wrapper';
 
+
+// Default the flag to the responder's own region (from the browser locale)
+// instead of a hardcoded country; falls back to the previous default when the
+// locale carries no region.
+const defaultCountry = (): string => {
+    if (typeof navigator !== 'undefined') {
+        const region = navigator.language?.split('-')[1];
+        if (region && region.length === 2) return region.toLowerCase();
+    }
+    return 'np';
+};
+
 const CustomPhoneInputField = styled(PhoneInput)<{ $formTheme?: IThemeState }>(({ $formTheme }) => {
     // Theme is passed as a prop; a hook inside the styled interpolation breaks
     // the hook count under React 19 ("Rendered fewer hooks").
@@ -51,7 +63,7 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                     $formTheme={theme}
                     value={(formResponse.answers && formResponse.answers[field.id]?.phone_number) || ''}
                     onChange={(e) => handleChange(e)}
-                    country={'np'}
+                    country={defaultCountry()}
                     buttonStyle={{
                         border: '0px',
                         borderRight: `1px solid ${theme?.tertiary}`,
@@ -67,7 +79,10 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                     }}
                     placeholder={field?.properties?.placeholder || getPlaceholderValueForField(field.type)}
                     inputProps={{
-                        className: 'text-base lg:text-lg py-3 mx-14 w-[93%] ',
+                        // Exact width math: the flag button occupies 3.5rem, so the
+                        // input takes the rest — mx-14 + w-[93%] double-counted the
+                        // gutter and drifted at wider viewports.
+                        className: 'text-base lg:text-lg py-3 ml-14 w-[calc(100%-3.5rem)]',
                         id: `input-field-${field.id}`
                     }}
                 />

--- a/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/phone-number-field.tsx
@@ -66,13 +66,13 @@ export default function PhoneNumberField({ field }: { field: StandardFormFieldDt
                     country={defaultCountry()}
                     buttonStyle={{
                         border: '0px',
-                        borderRight: `1px solid ${theme?.tertiary}`,
+                        borderRight: '1px solid #E3E3E3',
                         background: '#ffffff',
                         height: '100%'
                     }}
                     dropdownStyle={{ background: '#ffffff' }}
                     inputStyle={{
-                        border: `1px solid ${theme?.tertiary}`,
+                        border: '1px solid #E3E3E3',
                         borderRadius: '6px',
                         background: '#ffffff',
                         color: theme?.primary

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -3,6 +3,7 @@ import parse from 'html-react-parser';
 import { FieldTypes, StandardFormFieldDto, V2InputFields } from '@app/models/dtos/form';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
+import { useFormState } from '@app/store/jotai/form';
 import { useFormResponse } from '@app/store/jotai/responder-form-response';
 import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { resolvePipesInText, resolvePipesInTitle } from '@app/utils/answer-piping';
@@ -13,6 +14,7 @@ import { getPlaceholderValueForTitle } from '../rich-text-editor';
 
 export default function QuestionWrapper({ field, children }: { field: StandardFormFieldDto; children?: React.ReactNode }) {
     const { formResponse } = useFormResponse();
+    const { theme } = useFormState();
     const { hiddenValues } = useHiddenFieldValues();
     const standardForm = useAppSelector(selectForm);
 
@@ -66,19 +68,20 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
                 : {})}
         >
             <div className="">
-                {questionNumber !== null && (
-                    <div aria-hidden="true" className="text-black-600 mb-1 text-xs font-semibold tracking-widest tabular-nums">
-                        {String(questionNumber).padStart(2, '0')}
-                    </div>
-                )}
-                <div className="flex flex-wrap items-baseline gap-x-2">
-                    {/* The question owns the screen: 24px/600 ink (Design-Language §2) —
-                        bigger and darker than anything else, including the answer.
-                        The required mark sits INLINE right after the last word of the
-                        title ([&_p]:inline keeps the parsed paragraph in flow) — the old
-                        absolutely-positioned icon floated at the container's far right
-                        edge, visually orphaned from short labels. */}
-                    <div id={`q-title-${field.id}`} className="text-xl font-semibold leading-snug lg:text-2xl [&_p]:inline">
+                <div className="flex flex-wrap items-baseline gap-x-2.5">
+                    {/* The ordinal is the accent: a small mono number in the theme's
+                        action colour on the label's own baseline — the page's rhythm
+                        marker (numbers encode a real sequence). Question labels sit at
+                        16/18px semibold ink: on multi-question pages the old 24px
+                        repeated per question read as a wall of headings; weight and
+                        contrast carry the hierarchy, not size (ratified 2026-07-08
+                        against the form-redesign mocks). */}
+                    {questionNumber !== null && (
+                        <span aria-hidden="true" style={{ color: theme?.secondary }} className="font-mono text-[13px] font-medium tabular-nums">
+                            {String(questionNumber).padStart(2, '0')}
+                        </span>
+                    )}
+                    <div id={`q-title-${field.id}`} className="text-base font-semibold leading-snug lg:text-lg [&_p]:inline">
                         {parse(getHtmlFromJson(resolvedTitle) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}
                         {isAnswerable && isRequired && (
                             <>

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -27,6 +27,23 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
     const isAnswerable = field?.type ? V2InputFields.includes(field.type) : false;
     const isRequired = !!field?.validations?.required;
 
+    // Quiet ordinal for answerable questions ("01" meta label, Design-Language
+    // §2). Numbering encodes a real sequence, and it's the structural anchor
+    // that makes the generous question spacing read composed rather than empty.
+    // Counted among answerable siblings on the same page, so statements and
+    // media don't consume numbers; restarts per page, matching page context.
+    const questionNumber = (() => {
+        if (!isAnswerable) return null;
+        for (const slide of standardForm?.fields ?? []) {
+            const siblings = slide?.properties?.fields ?? [];
+            const position = siblings.findIndex((sibling) => sibling.id === field.id);
+            if (position >= 0) {
+                return siblings.slice(0, position).filter((sibling) => sibling.type && V2InputFields.includes(sibling.type)).length + 1;
+            }
+        }
+        return null;
+    })();
+
     // Answer piping: swap pipe tokens for the responder's earlier answers (or
     // captured hidden-field values) before the title/description hit the DOM.
     const pipeContext = { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues };
@@ -49,6 +66,11 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
                 : {})}
         >
             <div className="">
+                {questionNumber !== null && (
+                    <div aria-hidden="true" className="text-black-600 mb-1 text-xs font-semibold tracking-widest tabular-nums">
+                        {String(questionNumber).padStart(2, '0')}
+                    </div>
+                )}
                 <div className="flex flex-wrap items-baseline gap-x-2">
                     {/* The question owns the screen: 24px/600 ink (Design-Language §2) —
                         bigger and darker than anything else, including the answer.

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -9,12 +9,14 @@ import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { resolvePipesInText, resolvePipesInTitle } from '@app/utils/answer-piping';
 import { getHtmlFromJson } from '@app/utils/richTextEditorExtenstion/get-html-from-json';
 
+import { styleTokens } from '@app/views/molecules/theme/theme-shared';
 import { RenderImage } from '@app/views/organism/form-builder/fields/render-field';
 import { getPlaceholderValueForTitle } from '../rich-text-editor';
 
 export default function QuestionWrapper({ field, children }: { field: StandardFormFieldDto; children?: React.ReactNode }) {
     const { formResponse } = useFormResponse();
     const { theme } = useFormState();
+    const tokens = styleTokens(theme?.style);
     const { hiddenValues } = useHiddenFieldValues();
     const standardForm = useAppSelector(selectForm);
 
@@ -54,7 +56,8 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
 
     return (
         <div
-            className="relative flex flex-col gap-1 lg:gap-2"
+            className={`relative flex flex-col gap-1 lg:gap-2 ${tokens.divider ? 'border-b pb-7' : ''}`}
+            style={tokens.divider ? { borderColor: (theme?.tertiary ?? '#818CA0') + '40' } : undefined}
             id={field.id}
             // Give assistive tech an accessible name/description for the field.
             // Answerable fields become a labelled group so the question (and any
@@ -67,21 +70,31 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
                   }
                 : {})}
         >
-            <div className="">
-                <div className="flex flex-wrap items-baseline gap-x-2.5">
+            <div className="relative">
+                {/* Studio: an oversized ghost numeral behind the block. */}
+                {questionNumber !== null && tokens.ordinal === 'ghost' && (
+                    <span aria-hidden="true" className="pointer-events-none absolute -left-2 -top-7 hidden select-none text-[72px] font-extrabold leading-none lg:block" style={{ color: (theme?.secondary ?? '#2456CC') + '17' }}>
+                        {String(questionNumber).padStart(2, '0')}
+                    </span>
+                )}
+                <div className="relative flex flex-wrap items-baseline gap-x-2.5">
                     {/* The ordinal is the accent: a small mono number in the theme's
-                        action colour on the label's own baseline — the page's rhythm
-                        marker (numbers encode a real sequence). Question labels sit at
-                        16/18px semibold ink: on multi-question pages the old 24px
-                        repeated per question read as a wall of headings; weight and
-                        contrast carry the hierarchy, not size (ratified 2026-07-08
-                        against the form-redesign mocks). */}
-                    {questionNumber !== null && (
+                        action colour on the label's own baseline (classic), a pale
+                        serif numeral in the margin register (sheet), or the ghost
+                        numeral above (studio). Numbers encode a real sequence — the
+                        page's rhythm marker. Labels: weight and contrast carry the
+                        hierarchy, not size (ratified 2026-07-08 against the mocks). */}
+                    {questionNumber !== null && tokens.ordinal === 'inline' && (
                         <span aria-hidden="true" style={{ color: theme?.secondary }} className="font-mono text-[13px] font-medium tabular-nums">
                             {String(questionNumber).padStart(2, '0')}
                         </span>
                     )}
-                    <div id={`q-title-${field.id}`} className="text-base font-semibold leading-snug lg:text-lg [&_p]:inline">
+                    {questionNumber !== null && tokens.ordinal === 'gutter' && (
+                        <span aria-hidden="true" style={{ color: (theme?.primary ?? '#101826') + '4D' }} className="font-serif text-[15px] tabular-nums">
+                            {String(questionNumber).padStart(2, '0')}
+                        </span>
+                    )}
+                    <div id={`q-title-${field.id}`} className={`${tokens.labelClass} [&_p]:inline`}>
                         {parse(getHtmlFromJson(resolvedTitle) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}
                         {isAnswerable && isRequired && (
                             <>

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -31,23 +31,6 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
     const isAnswerable = field?.type ? V2InputFields.includes(field.type) : false;
     const isRequired = !!field?.validations?.required;
 
-    // Quiet ordinal for answerable questions ("01" meta label, Design-Language
-    // §2). Numbering encodes a real sequence, and it's the structural anchor
-    // that makes the generous question spacing read composed rather than empty.
-    // Counted among answerable siblings on the same page, so statements and
-    // media don't consume numbers; restarts per page, matching page context.
-    const questionNumber = (() => {
-        if (!isAnswerable) return null;
-        for (const slide of standardForm?.fields ?? []) {
-            const siblings = slide?.properties?.fields ?? [];
-            const position = siblings.findIndex((sibling) => sibling.id === field.id);
-            if (position >= 0) {
-                return siblings.slice(0, position).filter((sibling) => sibling.type && V2InputFields.includes(sibling.type)).length + 1;
-            }
-        }
-        return null;
-    })();
-
     // Answer piping: swap pipe tokens for the responder's earlier answers (or
     // captured hidden-field values) before the title/description hit the DOM.
     const pipeContext = { slides: standardForm?.fields, answers: formResponse.answers ?? {}, hiddenValues };
@@ -71,29 +54,9 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
                 : {})}
         >
             <div className="relative">
-                {/* Studio: an oversized ghost numeral behind the block. */}
-                {questionNumber !== null && tokens.ordinal === 'ghost' && (
-                    <span aria-hidden="true" className="pointer-events-none absolute -left-2 -top-7 hidden select-none text-[72px] font-extrabold leading-none lg:block" style={{ color: (theme?.secondary ?? '#2456CC') + '17' }}>
-                        {String(questionNumber).padStart(2, '0')}
-                    </span>
-                )}
                 <div className="relative flex flex-wrap items-baseline gap-x-2.5">
-                    {/* The ordinal is the accent: a small mono number in the theme's
-                        action colour on the label's own baseline (classic), a pale
-                        serif numeral in the margin register (sheet), or the ghost
-                        numeral above (studio). Numbers encode a real sequence — the
-                        page's rhythm marker. Labels: weight and contrast carry the
-                        hierarchy, not size (ratified 2026-07-08 against the mocks). */}
-                    {questionNumber !== null && tokens.ordinal === 'inline' && (
-                        <span aria-hidden="true" style={{ color: theme?.secondary }} className="font-mono text-[13px] font-medium tabular-nums">
-                            {String(questionNumber).padStart(2, '0')}
-                        </span>
-                    )}
-                    {questionNumber !== null && tokens.ordinal === 'gutter' && (
-                        <span aria-hidden="true" style={{ color: (theme?.primary ?? '#101826') + '4D' }} className="font-serif text-[15px] tabular-nums">
-                            {String(questionNumber).padStart(2, '0')}
-                        </span>
-                    )}
+                    {/* Labels: weight and contrast carry the hierarchy, not size
+                        (ratified 2026-07-08 against the form-redesign mocks). */}
                     <div id={`q-title-${field.id}`} className={`${tokens.labelClass} [&_p]:inline`}>
                         {parse(getHtmlFromJson(resolvedTitle) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}
                         {isAnswerable && isRequired && (

--- a/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/question-wrapper.tsx
@@ -7,7 +7,6 @@ import { useFormResponse } from '@app/store/jotai/responder-form-response';
 import { useHiddenFieldValues } from '@app/store/jotai/responder-hidden-fields';
 import { resolvePipesInText, resolvePipesInTitle } from '@app/utils/answer-piping';
 import { getHtmlFromJson } from '@app/utils/richTextEditorExtenstion/get-html-from-json';
-import RequiredIcon from '@Components/icons/required';
 
 import { RenderImage } from '@app/views/organism/form-builder/fields/render-field';
 import { getPlaceholderValueForTitle } from '../rich-text-editor';
@@ -49,17 +48,25 @@ export default function QuestionWrapper({ field, children }: { field: StandardFo
                   }
                 : {})}
         >
-            {isRequired && (
-                <div className="absolute -right-2 top-2">
-                    <RequiredIcon className="text-black-900" />
-                </div>
-            )}
             <div className="">
                 <div className="flex flex-wrap items-baseline gap-x-2">
                     {/* The question owns the screen: 24px/600 ink (Design-Language §2) —
-                        bigger and darker than anything else, including the answer. */}
-                    <div id={`q-title-${field.id}`} className="text-xl font-semibold leading-snug lg:text-2xl">
+                        bigger and darker than anything else, including the answer.
+                        The required mark sits INLINE right after the last word of the
+                        title ([&_p]:inline keeps the parsed paragraph in flow) — the old
+                        absolutely-positioned icon floated at the container's far right
+                        edge, visually orphaned from short labels. */}
+                    <div id={`q-title-${field.id}`} className="text-xl font-semibold leading-snug lg:text-2xl [&_p]:inline">
                         {parse(getHtmlFromJson(resolvedTitle) ?? getPlaceholderValueForTitle(field?.type || FieldTypes.TEXT))}
+                        {isAnswerable && isRequired && (
+                            <>
+                                <span aria-hidden="true" className="text-[#C43D3D]">
+                                    {' '}
+                                    *
+                                </span>
+                                <span className="sr-only"> (required)</span>
+                            </>
+                        )}
                     </div>
                     {isAnswerable && !isRequired && <span className="text-black-700 text-xs font-normal tracking-wide">Optional</span>}
                 </div>

--- a/webapp/src/views/molecules/responder-form-fields/rating-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/rating-field.tsx
@@ -22,26 +22,18 @@ export default function RatingField({ field, slide, isBuilder = false }: { field
     const { currentSlide } = useResponderState();
 
     const { theme } = useFormState();
-    const [mouseOver, setMouseOver] = useState(false);
+    const steps = field.properties?.steps || 5;
     const RatingSection = () => {
         return (
-            <div
-                className="relative !mb-0 flex w-fit  flex-wrap gap-3"
-                onMouseOut={() => {
-                    setMouseOver(false);
-                }}
-                onMouseOver={() => {
-                    !isBuilder && setMouseOver(true);
-                }}
-            >
-                {_.range(field.properties?.steps || 5).map((index) => {
-                    // const Component = index <= hovered ? Star : StarBorder;
+            <div className="relative !mb-0 flex w-fit  flex-wrap gap-3">
+                {_.range(steps).map((index) => {
                     return (
-                        <span
-                            style={{
-                                color: mouseOver || isBuilder ? theme?.tertiary : theme?.secondary
-                            }}
+                        <button
+                            type="button"
+                            aria-label={`Rate ${index + 1} of ${steps}`}
+                            aria-pressed={index <= (answer ?? 0) - 1}
                             key={index}
+                            disabled={isBuilder}
                             onMouseOut={() => {
                                 if (!isBuilder) setHovered(-1);
                             }}
@@ -53,13 +45,18 @@ export default function RatingField({ field, slide, isBuilder = false }: { field
                                     }, 200);
                                 }
                             }}
-                            className="cursor-pointer"
+                            className="cursor-pointer rounded outline-none focus-visible:ring-2"
                             onMouseOver={() => {
                                 if (!isBuilder) setHovered(index);
                             }}
                         >
-                            <StarIcon fill={index <= hovered ? theme?.tertiary : index <= (answer ?? 0) - 1 && hovered < 0 ? theme?.secondary : theme?.accent} stroke={theme?.secondary} />
-                        </span>
+                            {/* Hover previews per star (up to the hovered one); empty stars
+                                are TRANSPARENT so they read as outlines on any ground —
+                                accent-filled stars became opaque boxes over the new
+                                gradient/pattern/image backgrounds. The old group-level
+                                mouseOver recolour flipped the whole row at once. */}
+                            <StarIcon fill={index <= hovered ? theme?.tertiary : index <= (answer ?? 0) - 1 && hovered < 0 ? theme?.secondary : 'transparent'} stroke={theme?.secondary} />
+                        </button>
                     );
                 })}
             </div>

--- a/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
@@ -28,13 +28,15 @@ const StyledAutoSizeTextArea = styled(AutosizeTextarea)<{
         // Short/long text previously opted back into an underline-only look,
         // which fragmented the input language and had no focus indicator.
         background: '#ffffff',
-        borderColor: themeColor,
+        // Rest light and calm; hover steps to the theme's border colour; focus
+        // commits with the ring (matches shadcn/ui/input.tsx).
+        borderColor: '#E3E3E3',
         color: $formTheme?.primary,
         '&::placeholder': {
             color: '#657085 !important'
         },
         '&:hover:not(:focus)': {
-            borderColor: secondaryColor
+            borderColor: themeColor || '#8A94A6'
         },
         '&:focus': {
             borderColor: secondaryColor,

--- a/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/text-area-field.tsx
@@ -33,6 +33,9 @@ const StyledAutoSizeTextArea = styled(AutosizeTextarea)<{
         '&::placeholder': {
             color: '#657085 !important'
         },
+        '&:hover:not(:focus)': {
+            borderColor: secondaryColor
+        },
         '&:focus': {
             borderColor: secondaryColor,
             boxShadow: secondaryColor ? `0 0 0 3px ${secondaryColor}33` : undefined
@@ -71,7 +74,7 @@ export default function TextAreaField({ field }: { field: StandardFormFieldDto }
                     rows={1}
                     value={inputVal}
                     onChange={(e) => setInputVal(e.target.value)}
-                    className="rounded-xl border px-4 py-3 text-base leading-normal outline-none transition-shadow lg:text-lg"
+                    className="rounded-md border px-4 py-3 text-base leading-normal outline-none transition-shadow lg:text-lg"
                     style={{
                         resize: 'none'
                     }}

--- a/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
@@ -59,14 +59,15 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
                                                 // under secondary-colour text was illegible, and painting it
                                                 // on `active` too made mere keyboard focus look selected.
                                                 borderColor: active || checked ? theme?.secondary : theme?.tertiary,
-                                                background: checked ? theme?.tertiary + '55' : '',
+                                                // Selection wears the action colour — semantic, not decorative.
+                                                background: checked ? theme?.secondary + '1A' : '',
                                                 // The answer wears ink (theme primary), never the action colour.
                                                 color: theme?.primary
                                             }}
-                                            className={`flex min-w-[100px] max-w-full cursor-pointer items-center justify-between gap-2 rounded-xl border p-2 px-4`}
+                                            className={`flex min-w-[100px] max-w-full cursor-pointer items-center justify-between gap-2 rounded-md border p-2 px-4 transition duration-150`}
                                         >
                                             {choice.value}
-                                            {checked && <Check className="h-5 w-5 shrink-0" />}
+                                            {checked && <Check className="h-5 w-5 shrink-0" style={{ color: theme?.secondary }} />}
                                         </StyledDiv>
                                     );
                                 }}

--- a/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
@@ -30,10 +30,8 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
     const form = useAppSelector(selectForm);
     const { currentSlide } = useResponderState();
 
-    const getValue = () => {
-        if (formResponse?.answers?.[field.id]?.boolean !== null || formResponse?.answers?.[field.id]?.boolean !== undefined) return formResponse?.answers?.[field.id]?.boolean;
-        else return null;
-    };
+    // null (not undefined) when unanswered, so the RadioGroup stays controlled.
+    const getValue = () => formResponse?.answers?.[field.id]?.boolean ?? null;
 
     return (
         <QuestionWrapper field={field}>
@@ -56,14 +54,19 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
                                         <StyledDiv
                                             $theme={theme}
                                             style={{
-                                                borderColor: theme?.tertiary,
-                                                background: active || checked ? theme?.tertiary : '',
-                                                color: theme?.secondary
+                                                // Selection = a tinted fill + action-colour border (same
+                                                // treatment as multiple choice). The old solid-tertiary fill
+                                                // under secondary-colour text was illegible, and painting it
+                                                // on `active` too made mere keyboard focus look selected.
+                                                borderColor: active || checked ? theme?.secondary : theme?.tertiary,
+                                                background: checked ? theme?.tertiary + '55' : '',
+                                                // The answer wears ink (theme primary), never the action colour.
+                                                color: theme?.primary
                                             }}
-                                            className={`flex w-[100px] cursor-pointer justify-between rounded-xl border p-2 px-4`}
+                                            className={`flex w-[100px] cursor-pointer items-center justify-between gap-2 rounded-xl border p-2 px-4`}
                                         >
                                             {choice.value}
-                                            {checked && <Check />}
+                                            {checked && <Check className="h-5 w-5 shrink-0" />}
                                         </StyledDiv>
                                     );
                                 }}

--- a/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from '@app/store/hooks';
 import { useFormState } from '@app/store/jotai/form';
 import { scrollToDivById } from '@app/utils/scroll-utils';
 import { Check } from 'lucide-react';
+import { styleTokens } from '@app/views/molecules/theme/theme-shared';
 import QuestionWrapper from './question-wrapper';
 
 const StyledDiv = styled.div<{ $theme: any }>(({ $theme }) => {
@@ -28,6 +29,7 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
     const { theme } = useFormState();
 
     const form = useAppSelector(selectForm);
+    const tokens = styleTokens(theme?.style);
     const { currentSlide } = useResponderState();
 
     // null (not undefined) when unanswered, so the RadioGroup stays controlled.
@@ -54,20 +56,19 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
                                         <StyledDiv
                                             $theme={theme}
                                             style={{
-                                                // Selection = a tinted fill + action-colour border (same
-                                                // treatment as multiple choice). The old solid-tertiary fill
-                                                // under secondary-colour text was illegible, and painting it
-                                                // on `active` too made mere keyboard focus look selected.
+                                                // Selection = action-colour tint + border (solid fill with
+                                                // white text in the studio style). Focus borders only —
+                                                // painting the fill on `active` made keyboard focus look
+                                                // like selection.
                                                 borderColor: active || checked ? theme?.secondary : theme?.tertiary,
-                                                // Selection wears the action colour — semantic, not decorative.
-                                                background: checked ? theme?.secondary + '1A' : '',
-                                                // The answer wears ink (theme primary), never the action colour.
-                                                color: theme?.primary
+                                                background: tokens.solidSelection && checked ? theme?.secondary : checked ? theme?.secondary + '1A' : '',
+                                                color: tokens.solidSelection && checked ? '#ffffff' : theme?.primary,
+                                                borderRadius: tokens.inputRadius
                                             }}
-                                            className={`flex min-w-[100px] max-w-full cursor-pointer items-center justify-between gap-2 rounded-md border p-2 px-4 transition duration-150`}
+                                            className={`flex min-w-[100px] max-w-full cursor-pointer items-center justify-between gap-2 border p-2 px-4 transition duration-150`}
                                         >
                                             {choice.value}
-                                            {checked && <Check className="h-5 w-5 shrink-0" style={{ color: theme?.secondary }} />}
+                                            {checked && <Check className="h-5 w-5 shrink-0" style={{ color: tokens.solidSelection ? '#ffffff' : theme?.secondary }} />}
                                         </StyledDiv>
                                     );
                                 }}

--- a/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
+++ b/webapp/src/views/molecules/responder-form-fields/yes-no-field.tsx
@@ -63,7 +63,7 @@ const YesNoField = ({ field }: { field: StandardFormFieldDto }) => {
                                                 // The answer wears ink (theme primary), never the action colour.
                                                 color: theme?.primary
                                             }}
-                                            className={`flex w-[100px] cursor-pointer items-center justify-between gap-2 rounded-xl border p-2 px-4`}
+                                            className={`flex min-w-[100px] max-w-full cursor-pointer items-center justify-between gap-2 rounded-xl border p-2 px-4`}
                                         >
                                             {choice.value}
                                             {checked && <Check className="h-5 w-5 shrink-0" />}

--- a/webapp/src/views/molecules/theme/theme-shared.tsx
+++ b/webapp/src/views/molecules/theme/theme-shared.tsx
@@ -1,6 +1,6 @@
 import { CSSProperties } from 'react';
 
-import { FormTheme, ThemeBackground, ThemePattern } from '@app/constants/theme';
+import { FormTheme, ThemeBackground, ThemePattern, ThemeStyle } from '@app/constants/theme';
 import { cn } from '@app/shadcn/util/lib';
 
 // Each editable colour, labelled by what it actually controls on the responder
@@ -54,17 +54,18 @@ export function themeBackgroundStyle(theme?: Partial<FormTheme>): CSSProperties 
  */
 export const ThemePreview = ({ color }: { color: FormTheme }) => {
     const { primary, secondary, tertiary } = color;
+    const tokens = styleTokens(color.style);
     return (
         <div style={themeBackgroundStyle(color)} className="flex flex-col items-start gap-1.5 px-4 py-3">
-            <span style={{ color: primary }} className="text-[13px] font-semibold leading-tight">
+            <span style={{ color: primary }} className={cn('text-[13px] leading-tight', tokens.key === 'sheet' ? 'font-serif font-medium' : tokens.key === 'studio' ? 'font-bold tracking-tight' : 'font-semibold')}>
                 Question
             </span>
             {/* Answer text wears primary on a white input, exactly like the
                 runtime — so an illegible combination is visible right here. */}
-            <span style={{ borderColor: tertiary, color: primary }} className="w-full rounded border bg-white px-2 py-1 text-[11px] leading-tight">
+            <span style={{ borderColor: tertiary, color: primary, borderRadius: tokens.inputRadius }} className="w-full border bg-white px-2 py-1 text-[11px] leading-tight">
                 Answer
             </span>
-            <span style={{ background: secondary }} className="rounded px-2 py-0.5 text-[10px] font-semibold leading-tight text-white">
+            <span style={{ background: secondary, borderRadius: tokens.inputRadius }} className="px-2 py-0.5 text-[10px] font-semibold leading-tight text-white">
                 Continue
             </span>
         </div>
@@ -125,6 +126,75 @@ export const ContrastNotes = ({ theme }: { theme: FormTheme }) => {
                     {note}
                 </p>
             ))}
+        </div>
+    );
+};
+
+/**
+ * Appearance tokens per theme STYLE — how the form is dressed, resolved in one
+ * place so the runtime, the previews and the editors always agree. Colours and
+ * background stay orthogonal; a style only changes register (type, numerals,
+ * edges, selection weight).
+ */
+export function styleTokens(style?: ThemeStyle) {
+    switch (style) {
+        case 'sheet':
+            return {
+                key: 'sheet' as const,
+                labelClass: 'font-serif text-[17px] font-medium leading-snug lg:text-lg',
+                ordinal: 'gutter' as const, // pale serif numeral in a left gutter
+                inputRadius: '4px',
+                divider: true, // ruled rows, like a printed questionnaire
+                solidSelection: false
+            };
+        case 'studio':
+            return {
+                key: 'studio' as const,
+                labelClass: 'text-[19px] font-bold tracking-tight leading-snug lg:text-[21px]',
+                ordinal: 'ghost' as const, // oversized numeral behind the block
+                inputRadius: '0px',
+                divider: false,
+                solidSelection: true // chosen options fill solid with white text
+            };
+        default:
+            return {
+                key: 'classic' as const,
+                labelClass: 'text-base font-semibold leading-snug lg:text-lg',
+                ordinal: 'inline' as const, // small accent mono number on the baseline
+                inputRadius: '6px',
+                divider: false,
+                solidSelection: false
+            };
+    }
+}
+
+const STYLE_OPTIONS: Array<{ key: ThemeStyle; label: string; hint: string }> = [
+    { key: 'classic', label: 'Classic', hint: 'Clean and quiet — the default.' },
+    { key: 'sheet', label: 'Sheet', hint: 'Like a printed document: serif questions, ruled rows.' },
+    { key: 'studio', label: 'Studio', hint: 'Bold and graphic: heavy type, square edges.' }
+];
+
+/** Shared style picker for the theme editors (builder Design tab, Themes page). */
+export const ThemeStyleEditor = ({ value, onChange }: { value?: ThemeStyle; onChange: (style: ThemeStyle) => void }) => {
+    const current = value ?? 'classic';
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-black-700 text-xs">Style</span>
+            <div className="border-black-300 flex overflow-hidden rounded-md border" role="group" aria-label="Form style">
+                {STYLE_OPTIONS.map((option) => (
+                    <button
+                        key={option.key}
+                        type="button"
+                        aria-pressed={current === option.key}
+                        title={option.hint}
+                        onClick={() => onChange(option.key)}
+                        className={cn('flex-1 px-2 py-1.5 text-[11px] font-medium transition-colors', current === option.key ? 'bg-brand-100 text-brand-600' : 'text-black-600 hover:bg-black-100 bg-white')}
+                    >
+                        {option.label}
+                    </button>
+                ))}
+            </div>
+            <p className="text-black-500 text-[11px] leading-relaxed">{STYLE_OPTIONS.find((o) => o.key === current)?.hint}</p>
         </div>
     );
 };

--- a/webapp/src/views/molecules/theme/theme-shared.tsx
+++ b/webapp/src/views/molecules/theme/theme-shared.tsx
@@ -142,7 +142,6 @@ export function styleTokens(style?: ThemeStyle) {
             return {
                 key: 'sheet' as const,
                 labelClass: 'font-serif text-[17px] font-medium leading-snug lg:text-lg',
-                ordinal: 'gutter' as const, // pale serif numeral in a left gutter
                 inputRadius: '4px',
                 divider: true, // ruled rows, like a printed questionnaire
                 solidSelection: false
@@ -151,7 +150,6 @@ export function styleTokens(style?: ThemeStyle) {
             return {
                 key: 'studio' as const,
                 labelClass: 'text-[19px] font-bold tracking-tight leading-snug lg:text-[21px]',
-                ordinal: 'ghost' as const, // oversized numeral behind the block
                 inputRadius: '0px',
                 divider: false,
                 solidSelection: true // chosen options fill solid with white text
@@ -160,7 +158,6 @@ export function styleTokens(style?: ThemeStyle) {
             return {
                 key: 'classic' as const,
                 labelClass: 'text-base font-semibold leading-snug lg:text-lg',
-                ordinal: 'inline' as const, // small accent mono number on the baseline
                 inputRadius: '6px',
                 divider: false,
                 solidSelection: false

--- a/webapp/src/views/molecules/theme/theme-shared.tsx
+++ b/webapp/src/views/molecules/theme/theme-shared.tsx
@@ -62,7 +62,7 @@ export const ThemePreview = ({ color }: { color: FormTheme }) => {
             </span>
             {/* Answer text wears primary on a white input, exactly like the
                 runtime — so an illegible combination is visible right here. */}
-            <span style={{ borderColor: tertiary, color: primary, borderRadius: tokens.inputRadius }} className="w-full border bg-white px-2 py-1 text-[11px] leading-tight">
+            <span style={{ borderColor: '#E3E3E3', color: primary, borderRadius: tokens.inputRadius }} className="w-full border bg-white px-2 py-1 text-[11px] leading-tight">
                 Answer
             </span>
             <span style={{ background: secondary, borderRadius: tokens.inputRadius }} className="px-2 py-0.5 text-[10px] font-semibold leading-tight text-white">

--- a/webapp/src/views/organism/field-settings.tsx
+++ b/webapp/src/views/organism/field-settings.tsx
@@ -13,7 +13,7 @@ import FieldConditionalLogicEditor from '@app/views/molecules/form-builder/field
 
 export default function FieldSettings() {
     const { setActiveFieldComponent } = useActiveFieldComponent();
-    const { updateFieldRequired, activeSlide, activeField, updateDescription, updateFieldProperty, updateRatingSteps, updateFieldImage, updateAllowMultipleSelectionMatrixField } = useFormFieldsAtom();
+    const { updateFieldRequired, activeSlide, activeField, updateDescription, updateFieldProperty, updateFieldColSpan, updateRatingSteps, updateFieldImage, updateAllowMultipleSelectionMatrixField } = useFormFieldsAtom();
 
     const [errorMsg, setErrorMsg] = useState('');
     const [stepValue, setStepValue] = useState(activeField?.properties?.steps);
@@ -58,6 +58,37 @@ export default function FieldSettings() {
                 )}
             </div>
             <div className="text-black-600 text-xs font-semibold uppercase tracking-wide">Settings</div>
+            <div className="flex w-full flex-col gap-1.5">
+                <div className="text-black-700 text-xs">Width</div>
+                {/* 12-column grid: Full = 12, 1/2 = 6, … — adjacent fields whose
+                    spans fit share a row on desktop; mobile always stacks. */}
+                <div className="border-black-300 flex overflow-hidden rounded-md border" role="group" aria-label="Field width">
+                    {(
+                        [
+                            { label: 'Full', span: 12 },
+                            { label: '2/3', span: 8 },
+                            { label: '1/2', span: 6 },
+                            { label: '1/3', span: 4 },
+                            { label: '1/4', span: 3 }
+                        ] as const
+                    ).map((option) => {
+                        const current = Math.min(12, Math.max(1, activeField?.properties?.colSpan ?? 12));
+                        const selected = current === option.span;
+                        return (
+                            <button
+                                key={option.span}
+                                type="button"
+                                aria-pressed={selected}
+                                onClick={() => updateFieldColSpan(activeField!.index, activeSlide!.index, option.span)}
+                                className={`flex-1 px-1 py-1.5 text-[11px] font-medium transition-colors ${selected ? 'bg-brand-100 text-brand-600' : 'text-black-600 hover:bg-black-100 bg-white'}`}
+                            >
+                                {option.label}
+                            </button>
+                        );
+                    })}
+                </div>
+                <p className="text-black-500 text-[11px] leading-relaxed">Fields that fit side by side share a row. Phones always stack.</p>
+            </div>
             <div className="flex w-full items-center justify-between">
                 <div className="text-black-700 text-xs">Description</div>
                 <Switch

--- a/webapp/src/views/organism/form-builder/fields/drop-down-field.tsx
+++ b/webapp/src/views/organism/form-builder/fields/drop-down-field.tsx
@@ -60,7 +60,7 @@ const DropDownField = ({ field, slide, disabled }: { field: StandardFormFieldDto
                                     value={choice.value}
                                     placeholder={`Item ${index + 1}`}
                                     onChange={(value: any) => updateChoiceFieldValue(field.index, slide.index, choice.id, value)}
-                                    className={`flex justify-between rounded-xl border p-2 px-4 text-base`}
+                                    className={`flex justify-between rounded-md border p-2 px-4 text-base`}
                                     style={{ color: slide.properties?.theme?.secondary || theme?.secondary }}
                                     isOptionsInput
                                 />
@@ -75,7 +75,7 @@ const DropDownField = ({ field, slide, disabled }: { field: StandardFormFieldDto
                         color: slide.properties?.theme?.tertiary || theme?.tertiary,
                         borderColor: slide.properties?.theme?.tertiary || theme?.tertiary
                     }}
-                    className={'flex justify-between rounded-xl border p-2 px-4 text-base'}
+                    className={'flex justify-between rounded-md border p-2 px-4 text-base'}
                 >
                     Other
                 </div>

--- a/webapp/src/views/organism/form-builder/fields/file-upload-field.tsx
+++ b/webapp/src/views/organism/form-builder/fields/file-upload-field.tsx
@@ -16,7 +16,7 @@ const FileUpload = ({ field, slide, disabled }: { field: StandardFormFieldDto; s
                 style={{
                     borderColor: slide.properties?.theme?.tertiary || theme?.tertiary
                 }}
-                className={'flex h-[200px] w-full max-w-[800px] cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dotted'}
+                className={'flex h-[200px] w-full max-w-[800px] cursor-pointer flex-col items-center justify-center gap-2 rounded-md border-2 border-dotted'}
             >
                 <FolderUploadIcon
                     style={{

--- a/webapp/src/views/organism/form-builder/fields/matrix.tsx
+++ b/webapp/src/views/organism/form-builder/fields/matrix.tsx
@@ -211,6 +211,7 @@ const StyledMatrixHeaderInput = styled(AppInput)<{ $theme?: IThemeState }>(({ $t
         resize: 'none',
         overflow: 'auto',
         width: '100%',
+        borderRadius: '6px',
         '&::placeholder': {
             color: secondaryColor
         },

--- a/webapp/src/views/organism/form-builder/fields/matrix.tsx
+++ b/webapp/src/views/organism/form-builder/fields/matrix.tsx
@@ -67,7 +67,7 @@ function MatrixFieldComponent({ field, disabled }: IMatrixFieldProps) {
                                         }}
                                     />
                                 ) : (
-                                    <div className="max-h-full max-w-full text-clip break-all text-center text-sm">{choice?.value || `Column ${index + 1}`}</div>
+                                    <div className="max-h-full max-w-full break-words text-center text-sm">{choice?.value || `Column ${index + 1}`}</div>
                                 )}
 
                                 {disabled && activeField?.id === field.id && (
@@ -107,7 +107,7 @@ function MatrixFieldComponent({ field, disabled }: IMatrixFieldProps) {
                                     opacity: 1
                                 }}
                                 className={cn(
-                                    'relative z-[40000] flex max-h-[150px] w-full flex-col items-center justify-center overflow-auto border-[1px] border-l-[2px] p-2',
+                                    'relative z-10 flex max-h-[150px] w-full flex-col items-center justify-center overflow-auto border-[1px] border-l-[2px] p-2',
                                     index === 0 && 'rounded-tl-lg border-t-[2px]',
                                     field?.properties?.fields?.length === index + 1 && 'rounded-bl-lg border-b-[2px]'
                                 )}
@@ -122,7 +122,7 @@ function MatrixFieldComponent({ field, disabled }: IMatrixFieldProps) {
                                         }}
                                     />
                                 ) : (
-                                    <div className="max-h-full max-w-full text-clip break-all text-center text-sm">{row?.title?.toString() || `Row ${index + 1}`}</div>
+                                    <div className="max-h-full max-w-full break-words text-center text-sm">{row?.title?.toString() || `Row ${index + 1}`}</div>
                                 )}
                                 {disabled && activeField?.id === field.id && (field?.properties?.fields?.length || -1) > 1 && (
                                     <div

--- a/webapp/src/views/organism/form-builder/fields/video-field.test.ts
+++ b/webapp/src/views/organism/form-builder/fields/video-field.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { toEmbedUrl } from './video-field';
+
+describe('toEmbedUrl', () => {
+    it('turns a schemeless YouTube watch URL into a playable embed URL', () => {
+        expect(toEmbedUrl('www.youtube.com/watch?v=abc123')).toBe('https://www.youtube.com/embed/abc123');
+    });
+
+    it('does not double the scheme when the href already has one (old bug: https://https://…)', () => {
+        expect(toEmbedUrl('https://www.youtube.com/watch?v=abc123')).toBe('https://www.youtube.com/embed/abc123');
+    });
+
+    it('handles youtu.be short links', () => {
+        expect(toEmbedUrl('https://youtu.be/abc123')).toBe('https://www.youtube.com/embed/abc123');
+    });
+
+    it('handles Vimeo links', () => {
+        expect(toEmbedUrl('https://vimeo.com/12345678')).toBe('https://player.vimeo.com/video/12345678');
+    });
+
+    it('leaves other hosts untouched, even when the URL contains "watch" (old bug: naive replace)', () => {
+        expect(toEmbedUrl('https://example.com/watchtower/video.mp4')).toBe('https://example.com/watchtower/video.mp4');
+    });
+
+    it('adds a scheme to bare hosts and returns empty for missing href', () => {
+        expect(toEmbedUrl('example.com/clip')).toBe('https://example.com/clip');
+        expect(toEmbedUrl(undefined)).toBe('');
+        expect(toEmbedUrl('')).toBe('');
+    });
+});

--- a/webapp/src/views/organism/form-builder/fields/video-field.tsx
+++ b/webapp/src/views/organism/form-builder/fields/video-field.tsx
@@ -3,8 +3,41 @@
 import { StandardFormFieldDto } from '@app/models/dtos/form';
 import QuestionWrapper from '@app/views/molecules/responder-form-fields/question-wrapper';
 
+/**
+ * Build a safe iframe src from the stored video href.
+ *
+ * The old construction ('https://' + href.replace('watch', 'embed')) broke in
+ * two ways: an href that already carried a scheme became "https://https://…",
+ * and the naive watch→embed replace corrupted any non-YouTube URL containing
+ * the word "watch" (and produced youtube.com/embed?v=… — not a playable embed
+ * URL — for YouTube itself).
+ */
+export function toEmbedUrl(href?: string): string {
+    if (!href) return '';
+    const withScheme = /^https?:\/\//i.test(href) ? href : `https://${href}`;
+    try {
+        const url = new URL(withScheme);
+        const host = url.hostname.replace(/^www\.|^m\./, '');
+        if (host === 'youtube.com') {
+            const id = url.searchParams.get('v');
+            if (id) return `https://www.youtube.com/embed/${id}`;
+        }
+        if (host === 'youtu.be') {
+            const id = url.pathname.split('/').filter(Boolean)[0];
+            if (id) return `https://www.youtube.com/embed/${id}`;
+        }
+        if (host === 'vimeo.com') {
+            const id = url.pathname.split('/').filter(Boolean)[0];
+            if (id && /^\d+$/.test(id)) return `https://player.vimeo.com/video/${id}`;
+        }
+        return url.toString();
+    } catch {
+        return withScheme;
+    }
+}
+
 const VideoField = ({ field, isBuilder = false }: { field: StandardFormFieldDto; isBuilder?: boolean }) => {
-    const videoUrl = 'https://' + field.attachment?.href?.replace('watch', 'embed');
+    const videoUrl = toEmbedUrl(field.attachment?.href);
     return isBuilder ? (
         <iframe src={videoUrl} width="100%" className="aspect-video"></iframe>
     ) : (

--- a/webapp/src/views/organism/form-builder/fields/yes-no-field.tsx
+++ b/webapp/src/views/organism/form-builder/fields/yes-no-field.tsx
@@ -16,7 +16,8 @@ const YesNoField = ({ field, slide, disabled }: { field: StandardFormFieldDto; s
                                 <div
                                     style={{
                                         borderColor: slide.properties?.theme?.tertiary || theme?.tertiary,
-                                        color: theme?.secondary
+                                        // Ink, matching the responder rendering.
+                                        color: slide.properties?.theme?.primary || theme?.primary
                                     }}
                                     className={`flex w-[100px] justify-between rounded-xl border p-2 px-4`}
                                 >

--- a/webapp/src/views/organism/form-builder/fields/yes-no-field.tsx
+++ b/webapp/src/views/organism/form-builder/fields/yes-no-field.tsx
@@ -2,6 +2,7 @@ import { RadioGroup } from '@headlessui/react';
 
 import { StandardFormFieldDto } from '@app/models/dtos/form';
 import { useFormState } from '@app/store/jotai/form';
+import { styleTokens } from '@app/views/molecules/theme/theme-shared';
 
 const YesNoField = ({ field, slide, disabled }: { field: StandardFormFieldDto; slide: StandardFormFieldDto; disabled: boolean }) => {
     const { theme } = useFormState();
@@ -17,9 +18,13 @@ const YesNoField = ({ field, slide, disabled }: { field: StandardFormFieldDto; s
                                     style={{
                                         borderColor: slide.properties?.theme?.tertiary || theme?.tertiary,
                                         // Ink, matching the responder rendering.
-                                        color: slide.properties?.theme?.primary || theme?.primary
+                                        color: slide.properties?.theme?.primary || theme?.primary,
+                                        // Radius from the theme's style — the canvas previews what
+                                        // responders get (hardcoded rounded-xl left the builder with
+                                        // mixed radii next to the token-driven shared inputs).
+                                        borderRadius: styleTokens((slide.properties?.theme || theme)?.style).inputRadius
                                     }}
-                                    className={`flex w-[100px] justify-between rounded-xl border p-2 px-4`}
+                                    className={`flex w-[100px] justify-between border p-2 px-4`}
                                 >
                                     {choice.value}
                                 </div>

--- a/webapp/src/views/organism/form-builder/page-design-tab.tsx
+++ b/webapp/src/views/organism/form-builder/page-design-tab.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrig
 import { useAppSelector } from '@app/store/hooks';
 import { useFormState } from '@app/store/jotai/form';
 import { selectWorkspace } from '@app/store/workspaces/slice';
-import { ContrastNotes, Swatch, THEME_ROLE_FIELDS, ThemeBackgroundEditor, ThemePreview } from '@app/views/molecules/theme/theme-shared';
+import { ContrastNotes, Swatch, THEME_ROLE_FIELDS, ThemeBackgroundEditor, ThemePreview, ThemeStyleEditor } from '@app/views/molecules/theme/theme-shared';
 
 const CUSTOM_TITLE = 'Custom';
 
@@ -26,7 +26,8 @@ export default function PageDesignTab() {
         secondary: theme?.secondary ?? ThemeColors[0].secondary,
         tertiary: theme?.tertiary ?? ThemeColors[0].tertiary,
         accent: theme?.accent ?? ThemeColors[0].accent,
-        background: theme?.background
+        background: theme?.background,
+        style: theme?.style
     });
 
     const applyCustom = (next: FormTheme) => {
@@ -47,7 +48,7 @@ export default function PageDesignTab() {
         const title = rest.join(':');
         const source = group === 'saved' ? savedThemes : ThemeColors;
         const picked = source.find((t) => t.title === title);
-        if (picked) updateFormTheme({ ...picked });
+        if (picked) updateFormTheme({ ...picked, style: picked.style ?? theme?.style });
     };
 
     // What the preview shows: the active theme, whatever its source — including
@@ -58,7 +59,8 @@ export default function PageDesignTab() {
         secondary: theme?.secondary ?? ThemeColors[0].secondary,
         tertiary: theme?.tertiary ?? ThemeColors[0].tertiary,
         accent: theme?.accent ?? ThemeColors[0].accent,
-        background: theme?.background
+        background: theme?.background,
+        style: theme?.style
     };
 
     return (
@@ -109,6 +111,9 @@ export default function PageDesignTab() {
                             </SelectGroup>
                         </SelectContent>
                     </Select>
+
+                    {/* Style dresses whatever theme is active — orthogonal to colours. */}
+                    <ThemeStyleEditor value={theme?.style} onChange={(style) => updateFormTheme({ ...activeTheme, style })} />
 
                     {/* Only the selected theme is previewed — the dropdown is the
                         catalogue; this shows what the form actually wears. */}

--- a/webapp/src/views/organism/form-builder/page-properties-tab.tsx
+++ b/webapp/src/views/organism/form-builder/page-properties-tab.tsx
@@ -95,7 +95,7 @@ export default function PagePropertiesTab({ }: {}) {
     }
     const { layout } = useGetPageAttributes(getPageIndex() ?? -10);
 
-    const { updateFieldRequired } = useFormFieldsAtom();
+    const { updateFieldRequired, updateFieldColSpan } = useFormFieldsAtom();
 
     const getLayoutList = () => {
         if (layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND || layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN) {
@@ -318,16 +318,33 @@ export default function PagePropertiesTab({ }: {}) {
                                         >
                                             {extractTextfromJSON(field)}
                                         </div>
-                                        {field.type !== FieldTypes.TEXT && (
-                                            <div
-                                                className="h-5 w-5"
-                                                onClick={() => {
-                                                    updateFieldRequired(field.index, activeSlideComponent.index, !field?.validations?.required);
-                                                }}
+                                        <div className="flex shrink-0 items-center gap-1.5">
+                                            {/* 12-grid width: full row, halves, thirds… adjacent
+                                                fields whose spans fit share a row on desktop. */}
+                                            <select
+                                                aria-label="Field width"
+                                                title="Field width (12-column grid)"
+                                                value={String(Math.min(12, Math.max(1, field?.properties?.colSpan ?? 12)))}
+                                                onChange={(e) => updateFieldColSpan(field.index, activeSlideComponent.index, Number(e.target.value))}
+                                                className="border-black-300 text-black-700 hover:border-black-400 h-5 cursor-pointer rounded border bg-white px-0.5 text-[10px] outline-none"
                                             >
-                                                <RequiredIcon className={cn('cursor-pointer', field?.validations?.required ? 'text-black-900' : 'text-[#DBDBDB]')} />
-                                            </div>
-                                        )}
+                                                <option value="12">Full</option>
+                                                <option value="8">2/3</option>
+                                                <option value="6">1/2</option>
+                                                <option value="4">1/3</option>
+                                                <option value="3">1/4</option>
+                                            </select>
+                                            {field.type !== FieldTypes.TEXT && (
+                                                <div
+                                                    className="h-5 w-5"
+                                                    onClick={() => {
+                                                        updateFieldRequired(field.index, activeSlideComponent.index, !field?.validations?.required);
+                                                    }}
+                                                >
+                                                    <RequiredIcon className={cn('cursor-pointer', field?.validations?.required ? 'text-black-900' : 'text-[#DBDBDB]')} />
+                                                </div>
+                                            )}
+                                        </div>
                                     </div>
                                 );
                             })}

--- a/webapp/src/views/organism/form-builder/slide-builder.tsx
+++ b/webapp/src/views/organism/form-builder/slide-builder.tsx
@@ -41,7 +41,14 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                 sees (WYSIWYG). The old stack doubled up: gap-20 twice, py-[10vh]
                 on top of LayoutWrapper's own py-[60px], and px-6 twice. */}
             <div className="flex h-full w-full flex-col justify-center px-6 py-4">
-                <div className="flex w-full flex-col gap-16 lg:grid lg:grid-cols-12 lg:gap-x-6 lg:gap-y-16">
+                <div
+                    className={cn(
+                        'flex w-full max-w-[800px] flex-col gap-16 lg:grid lg:grid-cols-12 lg:gap-x-6 lg:gap-y-16',
+                        // The grid IS the 800px question column (same as the runtime);
+                        // page alignment positions the column, not each field.
+                        slide.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? '' : 'mx-auto'
+                    )}
+                >
                     <AnimatePresence>
                         {Array.isArray(slideFields) && slideFields.length ? (
                             slideFields.map((field, index) => {
@@ -58,14 +65,14 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                                             style: { gridColumn: `span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))} / span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))}` },
                                             // Rows size to content — h-full made every row stretch to an
                                             // equal share of the slide, so spacing changed with field count.
-                                            className: cn('relative flex w-full flex-row items-center', slide.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')
+                                            className: 'relative flex w-full min-w-0 flex-row items-center'
                                         } as any)
                                         }
                                     >
                                         <div
                                             key={index}
                                             tabIndex={0}
-                                            className={cn(activeFieldComponent?.id === field.id && 'rounded-lg ring-2 ring-[#2456CC]', 'w-full max-w-[800px] cursor-pointer p-1')}
+                                            className={cn(activeFieldComponent?.id === field.id && 'rounded-lg ring-2 ring-[#2456CC]', 'w-full cursor-pointer p-1')}
                                             onFocus={(event) => {
                                                 event.preventDefault();
                                                 event.stopPropagation();

--- a/webapp/src/views/organism/form-builder/slide-builder.tsx
+++ b/webapp/src/views/organism/form-builder/slide-builder.tsx
@@ -41,7 +41,7 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                 sees (WYSIWYG). The old stack doubled up: gap-20 twice, py-[10vh]
                 on top of LayoutWrapper's own py-[60px], and px-6 twice. */}
             <div className="flex h-full w-full flex-col justify-center px-6 py-4">
-                <div className="flex w-full flex-col gap-16">
+                <div className="flex w-full flex-col gap-16 lg:grid lg:grid-cols-12 lg:gap-x-6 lg:gap-y-16">
                     <AnimatePresence>
                         {Array.isArray(slideFields) && slideFields.length ? (
                             slideFields.map((field, index) => {
@@ -54,6 +54,8 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                                             animate: { x: 0 },
                                             transition: { duration: 0.5 },
                                             id: disabled ? field.id : `scroll-field-${field.id}`,
+                                            // WYSIWYG: the canvas packs columns exactly like the runtime.
+                                            style: { gridColumn: `span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))} / span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))}` },
                                             // Rows size to content — h-full made every row stretch to an
                                             // equal share of the slide, so spacing changed with field count.
                                             className: cn('relative flex w-full flex-row items-center', slide.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')
@@ -145,7 +147,7 @@ const SlideBuilder = ({ slide, isScaledDown = false, disabled = false }: { slide
                         ) : !disabled && !isScaledDown ? (
                             // An empty page shouldn't be a dead rectangle — give
                             // first-run creators a direct way in (audit B4).
-                            <div className="flex h-full w-full items-center justify-center">
+                            <div className="flex h-full w-full items-center justify-center lg:col-span-12">
                                 <button
                                     type="button"
                                     className="border-black-400 text-black-700 hover:border-black-600 hover:text-black-900 flex flex-col items-center gap-2 rounded-xl border border-dashed bg-white/60 px-10 py-8 text-sm font-medium transition-colors"

--- a/webapp/src/views/organism/form-preview/form-slide-preview.smoke.test.tsx
+++ b/webapp/src/views/organism/form-preview/form-slide-preview.smoke.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { Provider as ReduxProvider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { store } from '@app/store/store';
+import FormSlidePreview from './form-slide-preview';
+
+/**
+ * The dashboard preview path (FormSlidePreview -> SlideLayoutWrapper ->
+ * FormFieldComponent) with NOTHING mocked — the responder smoke test mocks the
+ * builder field registry, which is exactly where a preview-only crash hides
+ * (found the hard way with the kitchen-sink form).
+ */
+
+const choices = (...values: string[]) => values.map((value, i) => ({ id: `choice-${i}`, value }));
+
+const f = (type: FieldTypes, index: number, overrides: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({
+    id: `field-${type}-${index}`,
+    index,
+    type,
+    title: `Question for ${type}`,
+    ...overrides
+});
+
+const SLIDES: StandardFormFieldDto[] = [
+    {
+        id: 'slide-basics',
+        index: 0,
+        type: FieldTypes.SLIDE,
+        properties: {
+            fields: [
+                f(FieldTypes.SHORT_TEXT, 0),
+                f(FieldTypes.LONG_TEXT, 1),
+                f(FieldTypes.EMAIL, 2),
+                f(FieldTypes.NUMBER, 3),
+                f(FieldTypes.LINK, 4),
+                f(FieldTypes.PHONE_NUMBER, 5),
+                f(FieldTypes.DATE, 6)
+            ]
+        }
+    },
+    {
+        id: 'slide-choices',
+        index: 1,
+        type: FieldTypes.SLIDE,
+        properties: {
+            fields: [
+                f(FieldTypes.YES_NO, 0, { properties: { fields: [], choices: choices('Yes', 'No') } }),
+                f(FieldTypes.MULTIPLE_CHOICE, 1, { properties: { fields: [], choices: choices('Red', 'Green', 'Blue') } }),
+                f(FieldTypes.MULTIPLE_CHOICE, 2, { properties: { fields: [], choices: choices('Docs', 'Design'), allowMultipleSelection: true } }),
+                f(FieldTypes.DROP_DOWN, 3, { properties: { fields: [], choices: choices('One', 'Two') } }),
+                f(FieldTypes.RATING, 4, { properties: { fields: [], steps: 5 } }),
+                f(FieldTypes.LINEAR_RATING, 5, { properties: { fields: [], steps: 10 } })
+            ]
+        }
+    },
+    {
+        id: 'slide-rich',
+        index: 2,
+        type: FieldTypes.SLIDE,
+        properties: {
+            fields: [
+                f(FieldTypes.TEXT, 0),
+                f(FieldTypes.MATRIX, 1, {
+                    properties: {
+                        fields: [
+                            { id: 'row-1', index: 0, type: FieldTypes.MATRIX_ROW_INPUT, title: 'Quality', properties: { fields: [], choices: choices('Poor', 'Great') } },
+                            { id: 'row-2', index: 1, type: FieldTypes.MATRIX_ROW_INPUT, title: 'Speed', properties: { fields: [], choices: choices('Poor', 'Great') } }
+                        ]
+                    }
+                }),
+                f(FieldTypes.TABULAR_INPUT, 2, { properties: { fields: [], rowTitles: ['Item 1'], columnTitles: ['Name', 'Amount'] } }),
+                f(FieldTypes.FILE_UPLOAD, 3),
+                f(FieldTypes.IMAGE_CONTENT, 4, { attachment: { href: 'https://example.com/picture.png' } as any }),
+                f(FieldTypes.VIDEO_CONTENT, 5, { attachment: { href: 'www.youtube.com/watch?v=abc123' } as any })
+            ]
+        }
+    }
+];
+
+describe('FormSlidePreview renders every kitchen-sink slide without crashing', () => {
+    it.each(SLIDES.map((slide) => ({ name: slide.id, slide })))('$name', ({ slide }) => {
+        const { container } = render(
+            <ReduxProvider store={store}>
+                <Provider>
+                    <FormSlidePreview slide={slide} />
+                </Provider>
+            </ReduxProvider>
+        );
+        expect(container.firstChild).not.toBeNull();
+    });
+});

--- a/webapp/src/views/organism/form-preview/form-slide-preview.tsx
+++ b/webapp/src/views/organism/form-preview/form-slide-preview.tsx
@@ -23,7 +23,7 @@ export default function FormSlidePreview({ slide, theme }: { slide: StandardForm
         <SlideLayoutWrapper showDesktopLayout slide={slide} theme={slideTheme} disabled>
             <div className={cn('flex w-full ', slide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')}>
                 {/* Same 64px group rhythm as the builder canvas and the live form. */}
-                <div className="relative my-10 grid h-full w-full max-w-[800px] flex-1 grid-cols-1 content-center gap-16 px-5 lg:my-20 lg:px-20">
+                <div className="relative my-10 grid h-full w-full max-w-[800px] flex-1 grid-cols-1 content-center gap-[48px] px-5 lg:my-20 lg:gap-[56px] lg:px-20">
                     {slide?.properties?.fields?.map((field) => {
                         return <FormFieldComponent key={field.id} field={field} slideIndex={slide!.index} />;
                     })}

--- a/webapp/src/views/organism/form-preview/form-slide-preview.tsx
+++ b/webapp/src/views/organism/form-preview/form-slide-preview.tsx
@@ -23,9 +23,14 @@ export default function FormSlidePreview({ slide, theme }: { slide: StandardForm
         <SlideLayoutWrapper showDesktopLayout slide={slide} theme={slideTheme} disabled>
             <div className={cn('flex w-full ', slide?.properties?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'justify-start' : 'justify-center')}>
                 {/* Same 64px group rhythm as the builder canvas and the live form. */}
-                <div className="relative my-10 grid h-full w-full max-w-[800px] flex-1 grid-cols-1 content-center gap-[48px] px-5 lg:my-20 lg:gap-[56px] lg:px-20">
+                <div className="relative my-10 flex h-full w-full max-w-[800px] flex-1 flex-col content-center gap-[48px] px-5 lg:my-20 lg:grid lg:grid-cols-12 lg:gap-x-6 lg:gap-y-[56px] lg:px-20">
                     {slide?.properties?.fields?.map((field) => {
-                        return <FormFieldComponent key={field.id} field={field} slideIndex={slide!.index} />;
+                        const span = Math.min(12, Math.max(1, field.properties?.colSpan ?? 12));
+                        return (
+                            <div key={field.id} className="min-w-0" style={{ gridColumn: `span ${span} / span ${span}` }}>
+                                <FormFieldComponent field={field} slideIndex={slide!.index} />
+                            </div>
+                        );
                     })}
                 </div>
             </div>

--- a/webapp/src/views/organism/form/form-field-component.smoke.test.tsx
+++ b/webapp/src/views/organism/form/form-field-component.smoke.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { Provider as ReduxProvider } from 'react-redux';
+import { describe, expect, it, vi } from 'vitest';
+
+// RenderImage drags in the whole builder field registry — irrelevant here.
+vi.mock('@app/views/organism/form-builder/fields/render-field', () => ({
+    RenderImage: () => null,
+    default: () => null
+}));
+
+import { FieldTypes, StandardFormFieldDto } from '@app/models/dtos/form';
+import { store } from '@app/store/store';
+import { FormFieldComponent } from './form-slide';
+
+/**
+ * Render-crash smoke test for every field type the responder runtime can
+ * show, through the exact production mapping (FormFieldComponent). A field
+ * type that throws while rendering — undefined property access, a bad hook,
+ * a broken import — fails here before anyone finds it on a live form
+ * (the yes/no field regression is what prompted this net).
+ */
+
+const base = (type: FieldTypes, overrides: Partial<StandardFormFieldDto> = {}): StandardFormFieldDto => ({
+    id: `field-${type}`,
+    index: 0,
+    type,
+    title: `Question for ${type}`,
+    ...overrides
+});
+
+const choices = (...values: string[]) => values.map((value, i) => ({ id: `choice-${i}`, value }));
+
+const FIELDS: Array<{ name: string; field: StandardFormFieldDto }> = [
+    { name: 'text (statement)', field: base(FieldTypes.TEXT) },
+    { name: 'short_text', field: base(FieldTypes.SHORT_TEXT) },
+    { name: 'long_text', field: base(FieldTypes.LONG_TEXT) },
+    { name: 'email', field: base(FieldTypes.EMAIL) },
+    { name: 'number', field: base(FieldTypes.NUMBER) },
+    { name: 'url', field: base(FieldTypes.LINK) },
+    { name: 'phone_number', field: base(FieldTypes.PHONE_NUMBER) },
+    { name: 'date', field: base(FieldTypes.DATE) },
+    { name: 'yes_no', field: base(FieldTypes.YES_NO, { properties: { fields: [], choices: choices('Yes', 'No') } }) },
+    { name: 'multiple_choice (single)', field: base(FieldTypes.MULTIPLE_CHOICE, { properties: { fields: [], choices: choices('Red', 'Green', 'Blue') } }) },
+    { name: 'multiple_choice (multi-select)', field: base(FieldTypes.MULTIPLE_CHOICE, { properties: { fields: [], choices: choices('Red', 'Green', 'Blue'), allowMultipleSelection: true } }) },
+    { name: 'dropdown', field: base(FieldTypes.DROP_DOWN, { properties: { fields: [], choices: choices('One', 'Two') } }) },
+    { name: 'rating', field: base(FieldTypes.RATING, { properties: { fields: [], steps: 5 } }) },
+    { name: 'linear_rating', field: base(FieldTypes.LINEAR_RATING, { properties: { fields: [], steps: 10 } }) },
+    { name: 'file_upload', field: base(FieldTypes.FILE_UPLOAD) },
+    {
+        name: 'matrix',
+        field: base(FieldTypes.MATRIX, {
+            properties: {
+                fields: [
+                    { id: 'row-1', index: 0, type: FieldTypes.MATRIX_ROW_INPUT, title: 'Quality', properties: { fields: [], choices: choices('Poor', 'Great') } },
+                    { id: 'row-2', index: 1, type: FieldTypes.MATRIX_ROW_INPUT, title: 'Speed', properties: { fields: [], choices: choices('Poor', 'Great') } }
+                ]
+            }
+        })
+    },
+    { name: 'tabular_input', field: base(FieldTypes.TABULAR_INPUT, { properties: { fields: [], rowTitles: ['Row 1', 'Row 2'], columnTitles: ['Name', 'Amount'] } }) },
+    { name: 'image_content', field: base(FieldTypes.IMAGE_CONTENT, { attachment: { href: 'https://example.com/picture.png' } as any }) },
+    { name: 'video_content', field: base(FieldTypes.VIDEO_CONTENT, { attachment: { href: 'www.youtube.com/watch?v=abc123' } as any }) }
+];
+
+const renderField = (field: StandardFormFieldDto) =>
+    render(
+        <ReduxProvider store={store}>
+            <Provider>
+                <FormFieldComponent field={field} slideIndex={0} />
+            </Provider>
+        </ReduxProvider>
+    );
+
+describe('FormFieldComponent renders every responder field type without crashing', () => {
+    it.each(FIELDS)('$name', ({ field }) => {
+        const { container } = renderField(field);
+        expect(container.firstChild).not.toBeNull();
+    });
+
+    it('a field with NO properties at all still renders (legacy/imported forms)', () => {
+        // Imported or hand-migrated forms can carry fields with missing
+        // properties — the runtime must degrade, not crash.
+        for (const type of [FieldTypes.YES_NO, FieldTypes.MULTIPLE_CHOICE, FieldTypes.DROP_DOWN, FieldTypes.MATRIX, FieldTypes.TABULAR_INPUT, FieldTypes.RATING, FieldTypes.LINEAR_RATING]) {
+            const { container } = renderField(base(type));
+            expect(container.firstChild).not.toBeNull();
+        }
+    });
+});

--- a/webapp/src/views/organism/form/form-slide.tsx
+++ b/webapp/src/views/organism/form/form-slide.tsx
@@ -250,11 +250,18 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                         group) — 120px broke proximity grouping: pairs read as
                         separate screens, and long pages scrolled far more than
                         their content needed. */}
-                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 lg:gap-[56px] py-[60px]', isPreviewMode ? '' : 'lg:px-10')}>
+                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 py-[60px] lg:grid lg:grid-cols-12 lg:content-center lg:gap-x-6 lg:gap-y-[56px]', isPreviewMode ? '' : 'lg:px-10')}>
                         {formSlide?.properties?.fields
                             ?.filter((field: StandardFormFieldDto) => !hiddenFieldIds.has(field.id))
-                            .map((field: StandardFormFieldDto) => <FormFieldComponent key={field.id} field={field} slideIndex={formSlide!.index} />)}
-                        <div>
+                            .map((field: StandardFormFieldDto) => (
+                                // 12-grid width on desktop: adjacent spans that fit pack
+                                // into one row (two 6s sit side by side); mobile stays a
+                                // flex column, where the span style is inert.
+                                <div key={field.id} className="min-w-0" style={{ gridColumn: `span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))} / span ${Math.min(12, Math.max(1, field.properties?.colSpan ?? 12))}` }}>
+                                    <FormFieldComponent field={field} slideIndex={formSlide!.index} />
+                                </div>
+                            ))}
+                        <div style={{ gridColumn: 'span 12 / span 12' }}>
                             {(standardForm?.fields?.length || 0) - 1 === currentSlide && currentSlide === index && (
                                 <div className="flex flex-col lg:mb-4 ">
                                     {authState.id && !standardForm.settings?.requireVerifiedIdentity && (

--- a/webapp/src/views/organism/form/form-slide.tsx
+++ b/webapp/src/views/organism/form/form-slide.tsx
@@ -250,7 +250,7 @@ export default function FormSlide({ index, formSlideData, isPreviewMode = false,
                         group) — 120px broke proximity grouping: pairs read as
                         separate screens, and long pages scrolled far more than
                         their content needed. */}
-                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 lg:gap-[64px] py-[60px]', isPreviewMode ? '' : 'lg:px-10')}>
+                    <div className={cn('relative flex h-full w-full max-w-[800px] flex-col gap-[48px] overflow-hidden px-4 lg:gap-[56px] py-[60px]', isPreviewMode ? '' : 'lg:px-10')}>
                         {formSlide?.properties?.fields
                             ?.filter((field: StandardFormFieldDto) => !hiddenFieldIds.has(field.id))
                             .map((field: StandardFormFieldDto) => <FormFieldComponent key={field.id} field={field} slideIndex={formSlide!.index} />)}


### PR DESCRIPTION
Follow-on to #584 (same branch, new work since it merged). One arc: a responder-form quality campaign driven by a live "kitchen sink" form containing **every field type**, created via the API and used to find and fix issues end to end — plus the theme-style dimension and 12-grid column layouts that grew out of it.

## Rendering bugs (found by the kitchen-sink sweep)

- **Yes/No selected state was illegible** — solid tertiary fill under action-colour text (~1.8:1 on Default), and the fill also painted on keyboard focus, so focus looked like selection. Fixed to match multiple choice (tinted fill, ink text, focus = border only); builder preview and the shared Choice atom aligned.
- **Multi-select multiple choice crashed** on unresolvable slide indexes (unguarded `currentSlide.properties`).
- **The dashboard form preview crashed** with React 19's "Rendered fewer hooks than expected" — `useFormState()` inside linear-rating's styled-components interpolation, the exact trap already fixed-with-comments elsewhere; it only bites when a form contains a linear_rating. Fixed via transient props; a static sweep confirms **no styled callback in the codebase calls hooks anymore**.
- **Two permanent smoke-test nets** added: every responder field type through the production mapping, and the full preview path with nothing mocked.

## Field audit (P1 + P2)

- Date answers wore action-blue instead of ink; file-upload chips were solid tertiary (same defect class as yes/no); the dropdown was a `text-3xl` underline `<div>` with no keyboard affordance — rebuilt in the standard input language; `toEmbedUrl()` replaces the broken video URL construction (`https://https://…`, corrupting `watch→embed` replace) with real YouTube/Vimeo embed URLs — 6 unit tests; yes/no chips no longer clip long labels.
- **Keyboard access**: choices, rating stars and linear-rating cells were clickable divs — now real `<button>`s with `aria-pressed` and theme-tinted focus rings. Per-star hover (the whole row used to recolour); empty stars are transparent outlines (accent-filled ones became opaque boxes over decorated backgrounds); phone layout math fixed + locale-based default country; matrix `break-words`.
- **Required mark** — inline muted-red asterisk right after the question text (+ sr-only "(required)") instead of an icon floating at the container's far edge.

## Appeal pass (vs Typeform/Tally, inside the trust language)

6px corners across all inputs/chips/triggers, 48/56px question rhythm, calmer 16/18px labels (24px repeated per question read as a wall of headings), **selection wears the action colour** (soft tint + border; the grey tertiary tint read as disabled), hover/motion micro-polish, and `#E3E3E3` resting borders with a clear tertiary hover step. Question ordinals were tried in three treatments and **removed on review**. Builder-canvas radii unified with the runtime (it's a second render path and had drifted).

## Theme styles as a dimension

From a live 4-direction design prototype (kept local, never committed), the decision was to make the *look* the creator's choice: `theme.style` = **classic / sheet / studio** — one `styleTokens()` resolver dresses runtime, previews and editors (sheet: serif labels, ruled rows, 4px; studio: heavy type, square edges, solid-fill selection). Pickable in the builder Design tab and on saved workspace themes; persisted on the form (lenient) and validated on the workspace endpoint. The two structural directions from the prototype (ledger spine, receipts trail) are deferred behind the open enum.

## 12-grid field widths (columns)

`colSpan` (1–12) per field; **columns emerge from spans** — two 6s share a row via grid auto-flow, with no row containers, so drag-drop, conditional logic, answer ordering and tab order stay linear. Mobile always stacks (containers stay flex below `lg`). Runtime, dashboard preview and the builder canvas share the same packing — including the fix for centre-aligned pages, where the canvas grid is now the 800px question column itself rather than the full canvas width. Width control (Full/⅔/½/⅓/¼) in the field-settings panel + a compact overview in Used Fields. Backend `col_span` validated 1–12; camelCase round-trip verified.

## Published modal

Redesigned to the trust system, matching the Share modal's idiom: consent-green check + "Your form is live", truncating link field with open-in-new-tab, primary Copy→Copied ✓, specific next-step links instead of a paragraph, 540px. Includes the `min-w-0` fix for the grid-item overflow that pushed the Copy button outside the dialog (and the honest follow-up fixing a JSX-comment syntax error that briefly shipped with it).

## Verification

- Webapp: **178 tests** (20 field-type smoke tests, 3 preview-path, 6 `toEmbedUrl`), `tsc` 0 errors throughout.
- Backend: **157 passed** (style validation, colSpan bounds 1–12).
- Live-verified on the local stack: the kitchen-sink form's 19 fields round-tripping the API, published form serving, publish→slug upgrade.

**Reviewer notes**
- Highest-value click-throughs: the kitchen-sink form (selection states, borders, half-width field pairs on centred and left-aligned pages), the builder field-settings Width control, Design tab Style picker, and the publish flow.
- Deferrals: structural form styles (ledger/receipts), Unsplash picker + scrim for image backgrounds, a separate input-text theme role for a true dark preset, Enter-to-advance pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
