### PR TITLE
Dashboard polish: workspace-identity navbar, forms toolbar, change-link modal

### DIFF
--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
@@ -122,7 +122,7 @@ export default function FormDashboardLayoutClient({
     }
 
     return (
-        <TopNavLayout isCustomDomain={false} isClientDomain={false} showNavbar={true} hideMenu={false} showAuthAccount={true} className="flex w-full flex-col !bg-white !p-0">
+        <TopNavLayout isCustomDomain={false} isClientDomain={false} showNavbar={true} workspaceIdentity hideMenu={false} showAuthAccount={true} className="flex w-full flex-col !bg-white !p-0">
             <div className="my-2 w-full">
                 <div className="mt-6 flex flex-col gap-1 sm:mt-12">
                     <FormPageLayer className="px-4 md:px-10 lg:px-28">

--- a/webapp/src/components/auth/auth-navbar.tsx
+++ b/webapp/src/components/auth/auth-navbar.tsx
@@ -7,6 +7,9 @@ import { Button } from '@app/shadcn/components/ui/button';
 import AuthAccountMenuDropdown from '@app/components/auth/account-menu-dropdown';
 import Hamburger from '@app/components/ui/hamburger';
 import Logo from '@app/components/ui/logo';
+import Link from 'next/link';
+import { useAppSelector } from '@app/store/hooks';
+import { selectWorkspace } from '@app/store/workspaces/slice';
 import { buttonConstant } from '@app/constants/locales/button';
 import { useIsMobile } from '@app/lib/hooks/use-breakpoint';
 import { useIsMounted } from '@app/lib/hooks/use-is-mounted';
@@ -24,6 +27,7 @@ interface IAuthNavbarProps {
     mobileOpen?: boolean;
     showAuthAccount?: boolean;
     handleDrawerToggle?: () => void;
+    workspaceIdentity?: boolean;
 }
 
 AuthNavbar.defaultProps = {
@@ -48,7 +52,24 @@ export function Header(props: any) {
     return <nav className={`!fixed top-0 !z-30 border-b-[1px] border-black-400 flex w-full items-center justify-between px-5 transition-all duration-300 ltr:right-0 rtl:left-0 h-[68px] ${navClassNames} ${propClassNames}`}>{props.children}</nav>;
 }
 
-function AuthNavbar({ showHamburgerIcon, showPlans, mobileOpen, handleDrawerToggle, isCustomDomain = false, isFooter = false, isClientDomain = false, hideMenu = false, showAuthAccount }: IAuthNavbarProps) {
+function WorkspaceIdentity() {
+    const workspace = useAppSelector(selectWorkspace);
+    if (!workspace?.workspaceName) return null;
+    const title = workspace?.title || workspace?.workspaceName;
+    return (
+        <Link href={`/${workspace.workspaceName}/dashboard`} className="flex min-w-0 items-center gap-2.5 outline-none">
+            {workspace?.profileImage ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={workspace.profileImage} alt="" className="h-7 w-7 shrink-0 rounded-md object-cover" />
+            ) : (
+                <span className="bg-brand-100 text-brand-600 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-xs font-bold">{(title?.[0] || 'W').toUpperCase()}</span>
+            )}
+            <span className="text-black-900 truncate text-sm font-semibold">{title}</span>
+        </Link>
+    );
+}
+
+function AuthNavbar({ showHamburgerIcon, showPlans, mobileOpen, handleDrawerToggle, isCustomDomain = false, isFooter = false, isClientDomain = false, hideMenu = false, showAuthAccount, workspaceIdentity = false }: IAuthNavbarProps) {
     const { t } = useTranslation();
     const inMobile = useIsMobile();
     return (
@@ -56,7 +77,11 @@ function AuthNavbar({ showHamburgerIcon, showPlans, mobileOpen, handleDrawerTogg
             <div className="flex flex-row w-full h-full py-2 md:py-0 justify-between items-center">
                 <div className="flex gap-4">
                     {inMobile && showHamburgerIcon && <Hamburger isOpen={mobileOpen} className="!shadow-none mr-2 !bg-white hover:!bg-white !text-black-900 !flex !justify-start" onClick={handleDrawerToggle} />}
-                    <Logo isCustomDomain={isCustomDomain} isFooter={isFooter} isClientDomain={isClientDomain} />
+                    {/* Admin surfaces lead with the WORKSPACE identity, not the
+                        product logo (de-brand decision — bettercollected appears only
+                        as a subtle "Powered by"). The login page keeps the brand, so
+                        this is opt-in per surface. */}
+                    {workspaceIdentity ? <WorkspaceIdentity /> : <Logo isCustomDomain={isCustomDomain} isFooter={isFooter} isClientDomain={isClientDomain} />}
                 </div>
                 <div className="flex items-center justify-center gap-7">
                     {!inMobile && (

--- a/webapp/src/components/dashboard/form-settings.tsx
+++ b/webapp/src/components/dashboard/form-settings.tsx
@@ -259,7 +259,7 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
                         <div className={'mt-1 flex flex-col items-start  gap-2 py-1 '}>
                             <Tooltip label={t('CLICK_TO_COPY')}>
                                 <p className="body4 !text-black-700 max-w-full cursor-pointer truncate" onClick={handleOnCopy}>
-                                    {firstPart}/ <span className="text-pink-500">{lastPart}</span>
+                                    {firstPart}/ <span className="text-black-900 font-medium">{lastPart}</span>
                                 </p>
                             </Tooltip>
                             <div className={'flex gap-8'}>
@@ -269,9 +269,11 @@ export default function FormSettingsTab({ view = 'DEFAULT' }: IFormSettingsTabPr
                                     className={'!py-0'}
                                     icon={<Pencil className="h-4 w-4" />}
                                     onClick={() => {
-                                        openBottomSheetModal('FORM_CREATE_SLUG_VIEW', {
-                                            link: isCustomDomain ? customDomain : form?.builderVersion === 'v2' ? V2FormDomain : clientHost,
-                                            customSlug: customUrl
+                                        // The trust-styled Customize-URL modal (same one the form
+                                        // options menu opens) — the old bottom sheet was off-system.
+                                        openModal('CUSTOMIZE_URL', {
+                                            url: firstPart,
+                                            form: form
                                         });
                                     }}
                                     variant="ghost"

--- a/webapp/src/components/workspace-dashboard/workspace-dashboard-forms.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-dashboard-forms.tsx
@@ -44,13 +44,12 @@ function EmptyFormsView() {
 interface IWorkspaceDashboardFormsProps {
     workspace: WorkspaceDto;
     hasCustomDomain: boolean;
-    title?: string;
     showButtons?: boolean;
     showPagination?: boolean;
     isWorkspace?: boolean;
 }
 
-export default function WorkspaceDashboardForms({ title, showButtons, hasCustomDomain, showPagination, isWorkspace = false }: IWorkspaceDashboardFormsProps) {
+export default function WorkspaceDashboardForms({ showButtons, hasCustomDomain, showPagination, isWorkspace = false }: IWorkspaceDashboardFormsProps) {
     const { t } = useTranslation();
     const workspace = useAppSelector(selectWorkspace);
 
@@ -106,12 +105,18 @@ export default function WorkspaceDashboardForms({ title, showButtons, hasCustomD
         <div className="mb-10 flex h-fit w-full flex-col gap-5">
             {workspaceForms?.data?.total > 0 ? (
                 <>
-                    <div className="mb-5 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-                        <div className="sh1 flex flex-row items-center gap-6">
-                            <div className={'flex flex-row gap-1'}>
-                                <h1>{title || t(localesCommon.forms)}</h1>
-                                {showPagination && <h2>{`(${showSearchedResults ? searchedForms?.length || 0 : workspaceForms?.data?.total || 0})`}</h2>}
-                            </div>
+                    {/* The page heading lives in the top navbar (getHeader) — repeating
+                        it here read as a stutter. The toolbar keeps the useful part: a
+                        quiet count beside search. */}
+                    <div className="mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                        <div className="flex flex-row items-center gap-4">
+                            {showPagination && (
+                                <span className="text-black-600 whitespace-nowrap text-sm tabular-nums">
+                                    {(showSearchedResults ? searchedForms?.length || 0 : workspaceForms?.data?.total || 0) === 1
+                                        ? '1 form'
+                                        : `${showSearchedResults ? searchedForms?.length || 0 : workspaceForms?.data?.total || 0} forms`}
+                                </span>
+                            )}
                             <SearchInput placeholder={'Search Form'} handleSearch={handleSearch} />
                         </div>
                         {showButtons && <NewFormButton />}

--- a/webapp/src/components/workspace-dashboard/workspace-dashboard-forms.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-dashboard-forms.tsx
@@ -105,19 +105,22 @@ export default function WorkspaceDashboardForms({ showButtons, hasCustomDomain, 
         <div className="mb-10 flex h-fit w-full flex-col gap-5">
             {workspaceForms?.data?.total > 0 ? (
                 <>
-                    {/* The page heading lives in the top navbar (getHeader) — repeating
-                        it here read as a stutter. The toolbar keeps the useful part: a
-                        quiet count beside search. */}
+                    {/* The page heading lives in the top navbar (getHeader). The toolbar
+                        leads with a real-width search (the flex parent previously never
+                        grew, collapsing the w-full input to ~200px) and carries the count
+                        as a quiet, search-aware suffix aligned to the control. */}
                     <div className="mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-                        <div className="flex flex-row items-center gap-4">
+                        <div className="flex w-full min-w-0 flex-1 items-center gap-3">
+                            <div className="w-full max-w-[420px]">
+                                <SearchInput placeholder={'Search forms'} handleSearch={handleSearch} />
+                            </div>
                             {showPagination && (
-                                <span className="text-black-600 whitespace-nowrap text-sm tabular-nums">
+                                <span className="text-black-600 shrink-0 whitespace-nowrap text-sm tabular-nums">
                                     {(showSearchedResults ? searchedForms?.length || 0 : workspaceForms?.data?.total || 0) === 1
                                         ? '1 form'
                                         : `${showSearchedResults ? searchedForms?.length || 0 : workspaceForms?.data?.total || 0} forms`}
                                 </span>
                             )}
-                            <SearchInput placeholder={'Search Form'} handleSearch={handleSearch} />
                         </div>
                         {showButtons && <NewFormButton />}
                     </div>

--- a/webapp/src/layouts/top-navbar-layout.tsx
+++ b/webapp/src/layouts/top-navbar-layout.tsx
@@ -14,6 +14,7 @@ interface LayoutProps {
     showAuthAccount?: boolean;
     hideSignIn?: boolean;
     showNavbar?: boolean;
+    workspaceIdentity?: boolean;
     isFooter?: boolean;
 }
 
@@ -26,12 +27,13 @@ export default function TopNavLayout({
     className = '',
     childClassName = '',
     showNavbar = false,
+    workspaceIdentity = false,
     isFooter = false,
     showAuthAccount
 }: React.PropsWithChildren<LayoutProps>) {
     return (
         <div className="!bg-black-200 dark:bg-dark z-20 !min-h-screen !min-w-full">
-            {showNavbar && <AuthNavbar isFooter={isFooter} isCustomDomain={isCustomDomain} isClientDomain={isClientDomain} showHamburgerIcon={showHamburgerIcon} hideMenu={hideMenu} showPlans={false} showAuthAccount={showAuthAccount} />}
+            {showNavbar && <AuthNavbar isFooter={isFooter} isCustomDomain={isCustomDomain} isClientDomain={isClientDomain} showHamburgerIcon={showHamburgerIcon} hideMenu={hideMenu} showPlans={false} showAuthAccount={showAuthAccount} workspaceIdentity={workspaceIdentity} />}
             <main
                 className={cn(
                     "bg-black-100 float-none flex w-full px-5 lg:float-right lg:px-10",


### PR DESCRIPTION
Follow-on to #585 (same branch, the four commits since it merged) — small dashboard UX fixes, each user-reported:

- **Form details navbar shows the workspace identity, not the product logo.** The details pages (preview/responses/settings) still led with the bettercollected wordmark — a surface the de-brand pass missed. `AuthNavbar` gains an opt-in `workspaceIdentity` mode (workspace avatar/initial + title, linking back to the dashboard), threaded through `TopNavLayout`; the details layout opts in. Opt-in on purpose: the login page keeps its brand intentionally, other callers untouched.
- **Forms list heading deduped.** The top navbar already titles the page; the content opened with its own `Forms (12)` h1 right underneath. The toolbar now carries a quiet, search-aware count instead; legacy `sh1` type and the dead `title` prop removed.
- **Forms toolbar: real-width search.** `SearchInput` is `w-full` but its flex parent never grew, collapsing it to ~200px with the count floating at a mismatched baseline. The left group now grows; search leads at up to 420px with the count as an aligned tabular suffix. Placeholder: "Search forms".
- **Change link opens the trust Customize-URL modal** (same surface as the form-options menu) instead of the off-system `FORM_CREATE_SLUG_VIEW` bottom sheet; the displayed slug moves off the off-system pink onto ink. The now-orphaned bottom sheet is a deletion follow-up.

Verified per commit: webapp **178 tests**, `tsc` **0 errors**; form details page serves with the identity chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)