### PR TITLE
fix(analytics): update parameter names for Umami 3.x compatibility

### DIFF
--- a/backend/backend/app/controllers/analytics_router.py
+++ b/backend/backend/app/controllers/analytics_router.py
@@ -73,12 +73,14 @@ class FormAnalyticsRouter(Routable):
         params = {
             "startAt": start_at,
             "endAt": end_at,
-            "url": form_url,
+            # Umami 3.x calls the URL-path filter `path` (the old `url`
+            # parameter is ignored, which makes the response website-wide).
+            "path": form_url,
             "referrer": referrer,
             "title": title,
             "query": query,
             "event": event,
-            "host": host,
+            "hostname": host,
             "os": os,
             "browser": browser,
             "device": device,
@@ -128,10 +130,10 @@ class FormAnalyticsRouter(Routable):
         params = {
             "startAt": start_at,
             "endAt": end_at,
-            "url": form_url,
+            "path": form_url,
             "referrer": referrer,
             "title": title,
-            "host": host,
+            "hostname": host,
             "os": os,
             "browser": browser,
             "device": device,
@@ -186,10 +188,10 @@ class FormAnalyticsRouter(Routable):
         params = {
             "startAt": start_at,
             "endAt": end_at,
-            "url": form_url,
+            "path": form_url,
             "referrer": referrer,
             "title": title,
-            "host": host,
+            "hostname": host,
             "os": os,
             "browser": browser,
             "device": device,


### PR DESCRIPTION
## Summary

  Fixes Umami 3.1.0 analytics filtering so form statistics display correctly per slug.

  Umami 3.x renamed the URL filter from url to path and the host filter from host to hostname. Updated stats, pageviews, and metrics requests accordingly.

  ## Type of change

  - [x] 🐛 Bug fix

  ## Affected services

  - [x] webapp
  - [x] backend

  ## How was this tested?

  - Ran Python compilation checks.
  - Ran git diff --check.
  - Verified Umami 3.1.0 API filter names against the official documentation.
  - Confirmed all analytics endpoints use the canonical form path.

  ## Checklist

  - [x] I branched from and target develop
  - [x] Tests pass
  - [x] Lint/format pass
  - [x] I updated docs where needed
  - [x] No secrets committed
  - [x] I read the Contributing guide