### PR TITLE
AI P3: response insights, settings + logic ops, RustFS storage, KYC-exercise hardening

### DIFF
--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -48,6 +48,7 @@ from backend.app.services.ai.api_keys import APIKeyService
 from backend.app.services.ai.chat import FormAIChatService
 from backend.app.services.ai.memory import AIMemoryService
 from backend.app.services.ai.profile import AIProfileService
+from backend.app.services.ai.insights import FormAIInsightsService
 from backend.app.services.ai.review import FormAIReviewService
 from backend.app.services.openai_service import OpenAIService
 from backend.app.services.integration_action_service import IntegrationActionService
@@ -270,6 +271,14 @@ class AppContainer(containers.DeclarativeContainer):
 
     form_ai_review_service: FormAIReviewService = providers.Singleton(
         FormAIReviewService,
+        workspace_user_service=workspace_user_service,
+        provider_resolver=providers.Callable(
+            lambda svc: svc._get_provider, openai_service
+        ),
+    )
+
+    form_ai_insights_service: FormAIInsightsService = providers.Singleton(
+        FormAIInsightsService,
         workspace_user_service=workspace_user_service,
         provider_resolver=providers.Callable(
             lambda svc: svc._get_provider, openai_service

--- a/backend/backend/app/controllers/workspace_forms.py
+++ b/backend/backend/app/controllers/workspace_forms.py
@@ -1,5 +1,6 @@
 import json
 from http import HTTPStatus
+from typing import Optional
 
 from beanie import PydanticObjectId
 from classy_fastapi import Routable, get, patch, post, delete
@@ -15,6 +16,10 @@ from starlette.requests import Request
 
 from backend.app.container import container
 from backend.app.services.ai.chat import FormAIChatRequest, FormAIChatResponse
+from backend.app.services.ai.insights import (
+    FormAIInsightsRequest,
+    FormAIInsightsResponse,
+)
 from backend.app.services.ai.review import (
     ApplyReviewFixRequest,
     ApplyReviewFixResponse,
@@ -159,6 +164,33 @@ class WorkspaceFormsRouter(Routable):
         """Compliance copilot: review the draft against the org's compliance
         profile + baseline privacy checks. Read-only — changes nothing."""
         return await container.form_ai_review_service().review(
+            workspace_id=workspace_id, form_id=form_id, request=request, user=user
+        )
+
+    @get("/{form_id}/ai/insights")
+    async def get_ai_insights(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        user=Depends(get_logged_user),
+    ) -> Optional[FormAIInsightsResponse]:
+        """Cached response summary, if one was ever generated. Reads the
+        cache only — never respondent data."""
+        return await container.form_ai_insights_service().get_cached(
+            workspace_id=workspace_id, form_id=form_id, user=user
+        )
+
+    @post("/{form_id}/ai/insights")
+    async def generate_ai_insights(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        request: FormAIInsightsRequest,
+        user=Depends(get_logged_user),
+    ) -> FormAIInsightsResponse:
+        """The explicit opt-in action (plan principle #2): the ONLY moment
+        the AI reads this form's responses. Result is cached."""
+        return await container.form_ai_insights_service().generate(
             workspace_id=workspace_id, form_id=form_id, request=request, user=user
         )
 

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -163,7 +163,10 @@ async def update_form(form_id: str, ops: List[Dict[str, Any]]) -> str:
     {"op":"remove_field","fieldId":str} ·
     {"op":"move_field","fieldId":str,"toPageId"?:str,"index":int} ·
     {"op":"add_page","index"?:int,"fields"?:[field]} · {"op":"remove_page","pageId":str} ·
-    {"op":"update_form_info","title"?:str,"description"?:str}.
+    {"op":"update_form_info","title"?:str,"description"?:str} ·
+    {"op":"update_form_settings","patch":{"purpose"?:str,"retentionText"?:str,
+    "privacyPolicyUrl"?:str,"requireVerifiedIdentity"?:bool,"allowEditingResponse"?:bool,
+    "showSubmissionNumber"?:bool}} (trust metadata; "" clears a text value).
     Field types: short_text, long_text, email, number, url, phone_number, date,
     yes_no, multiple_choice, dropdown, rating, linear_rating, file_upload, text."""
     key = _key("forms:write")
@@ -172,10 +175,10 @@ async def update_form(form_id: str, ops: List[Dict[str, Any]]) -> str:
     form_document = await FormDocument.find_one({"form_id": form_id})
     parsed = parse_ops(ops)
     form = StandardForm(**form_document.model_dump())
-    _, results = await persist_ops_to_form(form_document, form, parsed)
+    _, results, updated_settings = await persist_ops_to_form(form_document, form, parsed)
     payload = [r.model_dump(by_alias=True) for r in results]
     await _audit("update_form", all(r.ok for r in results), f"{form_id}: {len(results)} ops")
-    return json.dumps({"results": payload})
+    return json.dumps({"results": payload, "settings": updated_settings})
 
 
 @mcp.tool()

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -138,6 +138,42 @@ async def get_form(form_id: str) -> str:
 
 
 @mcp.tool()
+async def create_form(title: str, description: str = "") -> str:
+    """Create a blank draft form (one empty page) — for building precisely
+    with update_form ops. Use create_form_with_ai when you want the platform
+    to design the form from a prompt instead."""
+    key = _key("forms:write")
+    import uuid as _uuid
+
+    from common.models.standard_form import (
+        StandardFieldProperty,
+        StandardFormField,
+        StandardFormFieldType,
+    )
+
+    from backend.app.container import container
+
+    blank = StandardForm(
+        title=title,
+        description=description or None,
+        builder_version="v2",
+        fields=[
+            StandardFormField(
+                id=str(_uuid.uuid4()),
+                index=0,
+                type=StandardFormFieldType.SLIDE,
+                properties=StandardFieldProperty(fields=[]),
+            )
+        ],
+    )
+    form = await container.workspace_form_service().create_form(
+        workspace_id=key.workspace_id, form=blank, user=_acting_user(key)
+    )
+    await _audit("create_form", True, form.form_id)
+    return json.dumps({"formId": form.form_id, "title": form.title, "published": False})
+
+
+@mcp.tool()
 async def create_form_with_ai(prompt: str) -> str:
     """Create a new draft form from a natural-language prompt. Generation is
     grounded in the workspace's AI profile (guidelines + compliance)."""
@@ -166,7 +202,13 @@ async def update_form(form_id: str, ops: List[Dict[str, Any]]) -> str:
     {"op":"update_form_info","title"?:str,"description"?:str} ·
     {"op":"update_form_settings","patch":{"purpose"?:str,"retentionText"?:str,
     "privacyPolicyUrl"?:str,"requireVerifiedIdentity"?:bool,"allowEditingResponse"?:bool,
-    "showSubmissionNumber"?:bool}} (trust metadata; "" clears a text value).
+    "showSubmissionNumber"?:bool}} (trust metadata; "" clears a text value) ·
+    {"op":"set_field_logic","fieldId":str,"logic":{"action":"SHOW"|"HIDE","operator":"AND"|"OR",
+    "conditions":[{"fieldId":str,"comparison":"IS_EQUAL"|"IS_NOT_EQUAL"|"CONTAINS"|"IS_EMPTY"|...,
+    "value"?:any}]}|null} (conditional visibility; choice values use the LABEL, yes/no uses "Yes"/"No") ·
+    {"op":"set_page_jumps","pageId":str,"jumps":[{"operator":"AND"|"OR","conditions":[...],
+    "target":"<page id or __SUBMIT__>"}]|null} (branching) ·
+    {"op":"duplicate_page","pageId":str,"index"?:int} (clone a page, fresh ids).
     Field types: short_text, long_text, email, number, url, phone_number, date,
     yes_no, multiple_choice, dropdown, rating, linear_rating, file_upload, text."""
     key = _key("forms:write")

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -216,7 +216,9 @@ async def list_responses(form_id: str, limit: int = 20) -> str:
         {
             "responseId": r.response_id,
             "submittedAt": str(getattr(r, "created_at", "")),
-            "answerCount": len(r.answers or {}),
+            # Answers are encrypted at rest (str/bytes) — len() of ciphertext
+            # is meaningless, so only count when they are a readable dict.
+            "answerCount": len(r.answers) if isinstance(r.answers, dict) else None,
         }
         for r in responses
     ]
@@ -232,13 +234,22 @@ async def get_response(response_id: str) -> str:
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     if not response or response.form_id not in workspace_forms:
         raise ValueError("Response not found in this workspace.")
+    # Answers are encrypted at rest — decrypt on this read path (the same
+    # rule as the dashboard's response views).
+    answers = response.answers
+    if isinstance(answers, (bytes, str)):
+        from common.services.crypto_service import crypto_service
+
+        answers = json.loads(
+            crypto_service.decrypt(workspace_id=key.workspace_id, form_id=response.form_id, data=answers)
+        )
     await _audit("get_response", True, response_id)
     return json.dumps(
         {
             "responseId": response.response_id,
             "formId": response.form_id,
             "submittedAt": str(getattr(response, "created_at", "")),
-            "answers": json.loads(json.dumps({k: v for k, v in (response.answers or {}).items()}, default=str)),
+            "answers": json.loads(json.dumps(answers if isinstance(answers, dict) else {}, default=str)),
         }
     )
 

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -146,23 +146,31 @@ async def create_form(title: str, description: str = "") -> str:
     import uuid as _uuid
 
     from common.models.standard_form import (
+        LayoutType,
         StandardFieldProperty,
         StandardFormField,
         StandardFormFieldType,
+        ThankYouPageField,
+        WelcomePageField,
     )
 
     from backend.app.container import container
 
+    # Mirror the builder's defaultForm (webapp constants/form.ts): forms need a
+    # welcome + thank-you page — the responder's post-submit screen renders
+    # thankyouPage, and API-born forms must behave like builder-born ones.
     blank = StandardForm(
         title=title,
         description=description or None,
         builder_version="v2",
+        welcome_page=WelcomePageField(title="", layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND),
+        thankyou_page=[ThankYouPageField(layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND)],
         fields=[
             StandardFormField(
                 id=str(_uuid.uuid4()),
                 index=0,
                 type=StandardFormFieldType.SLIDE,
-                properties=StandardFieldProperty(fields=[]),
+                properties=StandardFieldProperty(fields=[], layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND),
             )
         ],
     )

--- a/backend/backend/app/schemas/form_ai_insight.py
+++ b/backend/backend/app/schemas/form_ai_insight.py
@@ -1,0 +1,33 @@
+import datetime as dt
+from typing import Any, Dict, Optional
+
+from beanie import PydanticObjectId
+from common.configs.mongo_document import MongoDocument
+
+from backend.app.handlers.database import entity
+
+
+@entity
+class FormAIInsightDocument(MongoDocument):
+    """Cached AI summary of a form's responses (plan §2 'response summaries',
+    phase P3). One document per form, replaced on each regeneration.
+
+    Exists so viewing insights is free after the one explicit, creator-
+    triggered generation — the AI reads respondent data ONLY at that moment,
+    never in the background.
+    """
+
+    workspace_id: PydanticObjectId
+    form_id: str
+    payload: Dict[str, Any]
+    # How much of the data the summary actually saw — shown to the creator.
+    response_count: int
+    total_responses: int
+    generated_by: Optional[str] = None
+    generated_at: dt.datetime
+
+    class Settings:
+        name = "form_ai_insights"
+        bson_encoders = {
+            dt.datetime: lambda o: dt.datetime.isoformat(o),
+        }

--- a/backend/backend/app/services/ai/chat.py
+++ b/backend/backend/app/services/ai/chat.py
@@ -27,7 +27,13 @@ from backend.app.schemas.form_ai_session import FormAISessionDocument
 from backend.app.schemas.standard_form import FormDocument
 from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.ai.memory import AIMemoryService
-from backend.app.services.ai.ops import OpResult, apply_form_ops, parse_ops
+from backend.app.models.dtos.response_dtos import WorkspaceFormSettingsCamelModal
+from backend.app.services.ai.ops import (
+    OpResult,
+    UpdateFormSettingsOp,
+    apply_form_ops,
+    parse_ops,
+)
 from backend.app.services.ai.profile import AIProfileService
 from backend.app.services.ai.prompt_builder import (
     build_chat_system_prompt,
@@ -56,13 +62,60 @@ class FormAIChatResponse(_CamelModel):
     results: List[OpResult] = []
     # The updated draft, camelised by the controller's response model.
     form: dict
+    # Present when a turn changed form settings (purpose/retention/…) — the
+    # Form tab's metadata lives on the workspace-form association, not the
+    # form body, so the client updates it from here.
+    settings: Optional[dict] = None
+
+
+def _clear_or_set(value: Optional[str]) -> Optional[str]:
+    """Trust-layer text semantics (mirrors patch_settings): '' clears."""
+    return value or None
+
+
+async def _persist_settings_ops(form_id: str, ops, results: List[OpResult]) -> Optional[dict]:
+    """Write applied update_form_settings ops to the association document.
+
+    Returns the camelised updated settings, or None when no settings op
+    applied."""
+    patches = [
+        op.patch
+        for op, result in zip(ops, results)
+        if result.ok and isinstance(op, UpdateFormSettingsOp)
+    ]
+    if not patches:
+        return None
+    workspace_form = await WorkspaceFormDocument.find_one(
+        WorkspaceFormDocument.form_id == form_id
+    )
+    if not workspace_form:
+        return None
+    settings = workspace_form.settings
+    for patch in patches:
+        if patch.purpose is not None:
+            settings.purpose = _clear_or_set(patch.purpose.strip())
+        if patch.retention_text is not None:
+            settings.retention_text = _clear_or_set(patch.retention_text.strip())
+        if patch.privacy_policy_url is not None:
+            settings.privacy_policy_url = _clear_or_set(patch.privacy_policy_url.strip())
+        if patch.require_verified_identity is not None:
+            settings.require_verified_identity = patch.require_verified_identity
+        if patch.allow_editing_response is not None:
+            settings.allow_editing_response = patch.allow_editing_response
+        if patch.show_submission_number is not None:
+            settings.show_submission_number = patch.show_submission_number
+    await workspace_form.save()
+    return WorkspaceFormSettingsCamelModal(**settings.model_dump()).model_dump(
+        mode="json", by_alias=True
+    )
 
 
 async def persist_ops_to_form(form_document: FormDocument, form: StandardForm, ops) -> tuple:
-    """Apply ops and persist the draft when anything applied.
+    """Apply ops and persist when anything applied.
 
-    The ONE write path for AI form mutation — the chat turn and MCP's
-    update_form both go through here; never two ways to mutate a form.
+    The ONE write path for AI form mutation — the chat turn, review fixes and
+    MCP's update_form all go through here; never two ways to mutate a form.
+    Returns (new_form, results, updated_settings_or_none).
     """
     new_form, results = apply_form_ops(form, ops)
     if any(r.ok for r in results):
@@ -73,7 +126,8 @@ async def persist_ops_to_form(form_document: FormDocument, form: StandardForm, o
         form_document.welcome_page = new_form.welcome_page
         form_document.thankyou_page = new_form.thankyou_page
         await form_document.save()
-    return new_form, results
+    settings = await _persist_settings_ops(form_document.form_id, ops, results)
+    return new_form, results, settings
 
 
 class FormAIChatService:
@@ -125,7 +179,9 @@ class FormAIChatService:
         form = StandardForm(**form_document.model_dump())
         profile = await AIProfileService.get_profile_for_prompt(workspace_id)
         memory_entries = await AIMemoryService.get_entries_for_prompt(workspace_id, user.id)
-        system = build_chat_system_prompt(project_form(form), profile, memory_entries)
+        system = build_chat_system_prompt(
+            project_form(form, settings=association.settings), profile, memory_entries
+        )
 
         history = [
             {"role": m["role"], "content": m["content"]}
@@ -147,7 +203,7 @@ class FormAIChatService:
                 content="The AI returned an unusable reply — nothing was changed. Please try again.",
             )
 
-        new_form, results = await persist_ops_to_form(form_document, form, ops)
+        new_form, results, updated_settings = await persist_ops_to_form(form_document, form, ops)
 
         now = dt.datetime.now(dt.timezone.utc).isoformat()
         session.provider = request.provider or session.provider
@@ -183,4 +239,5 @@ class FormAIChatService:
             results=results,
             # Camelised — the webapp's form DTOs are camelCase.
             form=StandardFormCamelModel(**new_form.model_dump()).model_dump(mode="json", by_alias=True),
+            settings=updated_settings,
         )

--- a/backend/backend/app/services/ai/chat.py
+++ b/backend/backend/app/services/ai/chat.py
@@ -25,6 +25,7 @@ from backend.app.exceptions import HTTPException
 from backend.app.models.dtos.response_dtos import StandardFormCamelModel
 from backend.app.schemas.form_ai_session import FormAISessionDocument
 from backend.app.schemas.standard_form import FormDocument
+from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.ai.memory import AIMemoryService
 from backend.app.services.ai.ops import OpResult, apply_form_ops, parse_ops
 from backend.app.services.ai.profile import AIProfileService
@@ -98,7 +99,15 @@ class FormAIChatService:
             workspace_id=workspace_id, user=user
         )
 
-        form_document = await FormDocument.find_one({"form_id": form_id})
+        # The form must belong to THIS workspace — access to workspace A must
+        # not allow editing workspace B's forms by id (MCP has the same rule).
+        association = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.workspace_id == workspace_id,
+            WorkspaceFormDocument.form_id == form_id,
+        )
+        form_document = (
+            await FormDocument.find_one({"form_id": form_id}) if association else None
+        )
         if not form_document:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, content="Form not found")
 

--- a/backend/backend/app/services/ai/insights.py
+++ b/backend/backend/app/services/ai/insights.py
@@ -1,0 +1,331 @@
+"""Response summaries & insights (plan §2, phase P3) — strictly opt-in.
+
+Principle #2 of the AI-native plan: the AI never touches respondent data by
+default. Generation happens only on an explicit creator action (the POST),
+the result is cached so viewing it later reads the cache, not the data, and
+the projection is minimising by construction:
+
+- respondent identity (email, data-owner identifier, hidden fields) is NEVER
+  projected into the prompt;
+- email / phone answer values are redacted before the model sees them —
+  the summary reasons about their presence, not their content;
+- the prompt forbids reproducing identifying details from free text.
+"""
+
+import datetime as dt
+import json
+import re
+from http import HTTPStatus
+from typing import Any, Callable, Dict, List, Optional
+
+from beanie import PydanticObjectId
+from common.models.standard_form import StandardForm
+from common.models.user import User
+from common.services.crypto_service import crypto_service
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from backend.app.exceptions import HTTPException
+from backend.app.schemas.form_ai_insight import FormAIInsightDocument
+from backend.app.schemas.standard_form import FormDocument
+from backend.app.schemas.standard_form_response import FormResponseDocument
+from backend.app.schemas.workspace_form import WorkspaceFormDocument
+from backend.app.services.ai.prompt_builder import extract_json_object
+from backend.app.services.workspace_user_service import WorkspaceUserService
+
+MAX_RESPONSES = 200
+MAX_PROJECTION_CHARS = 60_000
+REDACTED_TYPES = {"email": "[email provided]", "phone_number": "[phone provided]"}
+
+INSIGHTS_SYSTEM_PROMPT = """\
+You are the response-insights assistant inside BetterCollected, a privacy-first form builder. \
+You will receive a form's questions and a batch of anonymised responses. Summarize what the responses say, for the form's creator.
+
+Privacy rules (hard requirements):
+- NEVER reproduce names, email addresses, phone numbers, or any other identifying detail from the responses, even partially.
+- Reason in aggregate. A short quote (8 words or fewer) is allowed only if it contains nothing identifying.
+- If the data is too sparse to support a claim, say so instead of inventing one.
+
+Respond with a single JSON object and nothing else:
+{"summary": "<3-5 sentences: what the responses collectively say>",
+ "themes": [{"title": "<short theme name>", "description": "<1-2 sentences>", "approxCount": <int or null>}],
+ "actionable": ["<concrete follow-up the creator could take>", ...],
+ "sentiment": "<one sentence on overall tone, or null if not meaningful>"}
+Order themes by how many responses support them. 3-6 themes, 1-4 actionable items."""
+
+
+class _CamelModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class FormAIInsightsRequest(_CamelModel):
+    provider: Optional[str] = None
+
+
+class InsightTheme(_CamelModel):
+    title: str
+    description: str
+    approx_count: Optional[int] = None
+
+
+class FormAIInsightsResponse(_CamelModel):
+    summary: str
+    themes: List[InsightTheme] = []
+    actionable: List[str] = []
+    sentiment: Optional[str] = None
+    response_count: int
+    total_responses: int
+    generated_at: dt.datetime
+
+
+def _question_titles(form: StandardForm) -> Dict[str, str]:
+    """fieldId -> plain question title, tolerating v2 pages and v1 flat forms."""
+    titles: Dict[str, str] = {}
+
+    def visit(fields):
+        for f in fields or []:
+            if isinstance(f.title, str) and f.title:
+                titles[f.id] = f.title
+            if f.properties and f.properties.fields:
+                visit(f.properties.fields)
+
+    visit(form.fields)
+    return titles
+
+
+def _choice_labels(form: StandardForm) -> Dict[str, str]:
+    """choiceId -> human label. Responses store choice IDs; the model should
+    see what the respondent actually picked, not a UUID."""
+    labels: Dict[str, str] = {}
+
+    def visit(fields):
+        for f in fields or []:
+            if f.properties:
+                for choice in f.properties.choices or []:
+                    if choice.id and choice.value:
+                        labels[choice.id] = choice.value
+                visit(f.properties.fields)
+
+    visit(form.fields)
+    return labels
+
+
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
+def _resolve_choice(value: str, labels: Dict[str, str]) -> str:
+    """Choice ID -> label; an unmapped UUID (older form version) projects as
+    a neutral marker instead of leaking meaningless IDs into the prompt."""
+    if value in labels:
+        return labels[value]
+    return "[selected option]" if _UUID_RE.match(value) else value
+
+
+def _answer_text(raw: Any, choice_labels: Dict[str, str]) -> Optional[str]:
+    """One answer -> plain text, with identifying value types redacted and
+    choice IDs resolved to their labels."""
+    answer = raw if isinstance(raw, dict) else raw.model_dump() if hasattr(raw, "model_dump") else None
+    if not answer:
+        return None
+    answer_type = str(answer.get("type") or "")
+    if answer_type in REDACTED_TYPES:
+        return REDACTED_TYPES[answer_type]
+    if answer.get("text"):
+        return str(answer["text"])
+    if answer.get("number") is not None:
+        return str(answer["number"])
+    if answer.get("boolean") is not None:
+        return "yes" if answer["boolean"] else "no"
+    if answer.get("date"):
+        return str(answer["date"])
+    choice = answer.get("choice")
+    if isinstance(choice, dict) and choice.get("value"):
+        return _resolve_choice(str(choice["value"]), choice_labels)
+    choices = answer.get("choices")
+    if isinstance(choices, dict) and choices.get("values"):
+        return ", ".join(_resolve_choice(str(v), choice_labels) for v in choices["values"])
+    if answer.get("file_url") or answer.get("file_metadata"):
+        return "[file uploaded]"
+    if answer.get("url"):
+        return str(answer["url"])
+    return None
+
+
+def project_responses(
+    workspace_id: PydanticObjectId,
+    form: StandardForm,
+    responses: List[FormResponseDocument],
+) -> tuple:
+    """Anonymised plain-text projection of responses, within the char budget.
+
+    Returns (projection_text, included_count).
+    """
+    titles = _question_titles(form)
+    choice_labels = _choice_labels(form)
+    blocks: List[str] = []
+    used = 0
+    included = 0
+    for index, response in enumerate(responses, start=1):
+        answers = response.answers
+        if isinstance(answers, (bytes, str)):
+            answers = json.loads(
+                crypto_service.decrypt(workspace_id=workspace_id, form_id=response.form_id, data=answers)
+            )
+        if not isinstance(answers, dict):
+            continue
+        lines = []
+        for field_id, raw in answers.items():
+            text = _answer_text(raw, choice_labels)
+            if not text:
+                continue
+            question = titles.get(field_id, "Question")
+            lines.append(f"  {question}: {text[:500]}")
+        if not lines:
+            continue
+        block = f"Response {index}:\n" + "\n".join(lines)
+        if used + len(block) > MAX_PROJECTION_CHARS:
+            break
+        blocks.append(block)
+        used += len(block)
+        included += 1
+    return "\n\n".join(blocks), included
+
+
+class FormAIInsightsService:
+    def __init__(
+        self,
+        workspace_user_service: WorkspaceUserService,
+        provider_resolver: Callable,
+    ):
+        self._workspace_user_service = workspace_user_service
+        self._provider_resolver = provider_resolver
+
+    async def _authorize(self, workspace_id: PydanticObjectId, form_id: str, user: User) -> FormDocument:
+        await self._workspace_user_service.check_user_has_access_in_workspace(
+            workspace_id=workspace_id, user=user
+        )
+        association = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.workspace_id == workspace_id,
+            WorkspaceFormDocument.form_id == form_id,
+        )
+        form_document = (
+            await FormDocument.find_one({"form_id": form_id}) if association else None
+        )
+        if not form_document:
+            raise HTTPException(status_code=HTTPStatus.NOT_FOUND, content="Form not found")
+        return form_document
+
+    async def get_cached(
+        self, workspace_id: PydanticObjectId, form_id: str, user: User
+    ) -> Optional[FormAIInsightsResponse]:
+        await self._authorize(workspace_id, form_id, user)
+        document = await FormAIInsightDocument.find_one(
+            FormAIInsightDocument.workspace_id == workspace_id,
+            FormAIInsightDocument.form_id == form_id,
+        )
+        if not document:
+            return None
+        return FormAIInsightsResponse(
+            **document.payload,
+            response_count=document.response_count,
+            total_responses=document.total_responses,
+            generated_at=document.generated_at,
+        )
+
+    async def generate(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        request: FormAIInsightsRequest,
+        user: User,
+    ) -> FormAIInsightsResponse:
+        """The explicit opt-in action — the only moment the AI reads answers."""
+        form_document = await self._authorize(workspace_id, form_id, user)
+
+        total = await FormResponseDocument.find(
+            FormResponseDocument.form_id == form_id
+        ).count()
+        if total == 0:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                content="This form has no responses to summarize yet.",
+            )
+        responses = (
+            await FormResponseDocument.find(FormResponseDocument.form_id == form_id)
+            .sort("-created_at")
+            .limit(MAX_RESPONSES)
+            .to_list()
+        )
+        form = StandardForm(**form_document.model_dump())
+        projection, included = project_responses(workspace_id, form, responses)
+        if not included:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_REQUEST,
+                content="No readable answers found in this form's responses.",
+            )
+
+        provider = self._provider_resolver(request.provider)
+        raw_reply = await provider.chat(
+            INSIGHTS_SYSTEM_PROMPT,
+            [
+                {
+                    "role": "user",
+                    "content": f"Form title: {form.title}\n\nResponses ({included} of {total} total):\n\n{projection}",
+                }
+            ],
+        )
+        try:
+            parsed = extract_json_object(raw_reply)
+            summary = str(parsed.get("summary") or "").strip()
+            if not summary:
+                raise ValueError("missing summary")
+            themes = [
+                InsightTheme(
+                    title=str(t.get("title") or "").strip(),
+                    description=str(t.get("description") or "").strip(),
+                    approx_count=t.get("approxCount") if isinstance(t.get("approxCount"), int) else None,
+                )
+                for t in (parsed.get("themes") or [])
+                if isinstance(t, dict) and t.get("title")
+            ]
+            actionable = [str(a) for a in (parsed.get("actionable") or []) if isinstance(a, str)]
+            sentiment = str(parsed["sentiment"]) if parsed.get("sentiment") else None
+        except HTTPException:
+            raise
+        except Exception:
+            raise HTTPException(
+                status_code=HTTPStatus.BAD_GATEWAY,
+                content="The AI returned an unusable summary — please try again.",
+            )
+
+        payload = {
+            "summary": summary,
+            "themes": [t.model_dump() for t in themes],
+            "actionable": actionable,
+            "sentiment": sentiment,
+        }
+        now = dt.datetime.now(dt.timezone.utc)
+        document = await FormAIInsightDocument.find_one(
+            FormAIInsightDocument.workspace_id == workspace_id,
+            FormAIInsightDocument.form_id == form_id,
+        )
+        if document:
+            document.payload = payload
+            document.response_count = included
+            document.total_responses = total
+            document.generated_by = user.id
+            document.generated_at = now
+        else:
+            document = FormAIInsightDocument(
+                workspace_id=workspace_id,
+                form_id=form_id,
+                payload=payload,
+                response_count=included,
+                total_responses=total,
+                generated_by=user.id,
+                generated_at=now,
+            )
+        await document.save()
+        return FormAIInsightsResponse(
+            **payload, response_count=included, total_responses=total, generated_at=now
+        )

--- a/backend/backend/app/services/ai/ops.py
+++ b/backend/backend/app/services/ai/ops.py
@@ -21,7 +21,10 @@ import uuid
 from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from common.models.standard_form import (
+    FieldLogic,
+    FieldLogicCondition,
     LayoutType,
+    PageJump,
     StandardChoice,
     StandardFieldProperty,
     StandardFieldValidations,
@@ -143,6 +146,70 @@ class UpdateFormInfoOp(_CamelModel):
     description: Optional[str] = None
 
 
+COMPARISONS = (
+    "IS_EMPTY", "IS_NOT_EMPTY", "IS_EQUAL", "IS_NOT_EQUAL", "CONTAINS",
+    "DOES_NOT_CONTAIN", "LESS_THAN", "LESS_THAN_EQUAL", "GREATER_THAN",
+    "GREATER_THAN_EQUAL", "STARTS_WITH", "ENDS_WITH",
+)
+VALUELESS_COMPARISONS = {"IS_EMPTY", "IS_NOT_EMPTY"}
+JUMP_TARGET_SUBMIT = "__SUBMIT__"
+
+
+class LogicConditionSpec(_CamelModel):
+    """One condition of a visibility rule / page jump. Mirrors the builder's
+    logic editor exactly: choice conditions carry the choice LABEL, yes/no
+    carries "Yes"/"No" (see webapp condition-editor-shared.tsx)."""
+
+    field_id: str
+    comparison: Literal[
+        "IS_EMPTY", "IS_NOT_EMPTY", "IS_EQUAL", "IS_NOT_EQUAL", "CONTAINS",
+        "DOES_NOT_CONTAIN", "LESS_THAN", "LESS_THAN_EQUAL", "GREATER_THAN",
+        "GREATER_THAN_EQUAL", "STARTS_WITH", "ENDS_WITH",
+    ]
+    value: Optional[Any] = None
+
+
+class FieldLogicSpec(_CamelModel):
+    action: Literal["SHOW", "HIDE"]
+    operator: Literal["AND", "OR"] = "AND"
+    conditions: List[LogicConditionSpec] = Field(..., min_length=1)
+
+
+class SetFieldLogicOp(_CamelModel):
+    """Conditional visibility on a field ("show X only when Y = ..."). The
+    rule lives on the TARGET field; conditions reference earlier answers.
+    ``logic: null`` clears the rule."""
+
+    op: Literal["set_field_logic"] = "set_field_logic"
+    field_id: str
+    logic: Optional[FieldLogicSpec] = None
+
+
+class PageJumpSpec(_CamelModel):
+    operator: Literal["AND", "OR"] = "AND"
+    conditions: List[LogicConditionSpec] = Field(..., min_length=1)
+    target: str  # a page id, or JUMP_TARGET_SUBMIT
+
+
+class SetPageJumpsOp(_CamelModel):
+    """Branching: after this page, jump to a target page (or submit) when the
+    conditions match; first matching jump wins, no match = next page.
+    ``jumps: null`` clears."""
+
+    op: Literal["set_page_jumps"] = "set_page_jumps"
+    page_id: str
+    jumps: Optional[List[PageJumpSpec]] = None
+
+
+class DuplicatePageOp(_CamelModel):
+    """Clone a page with all its fields (fresh ids everywhere). In-page logic
+    references are remapped to the cloned fields."""
+
+    op: Literal["duplicate_page"] = "duplicate_page"
+    page_id: str
+    index: Optional[int] = None  # default: right after the original
+
+
 class FormSettingsPatch(_CamelModel):
     """AI-editable form settings — the Form tab's metadata.
 
@@ -180,6 +247,9 @@ FormOp = Annotated[
         RemovePageOp,
         UpdateFormInfoOp,
         UpdateFormSettingsOp,
+        SetFieldLogicOp,
+        SetPageJumpsOp,
+        DuplicatePageOp,
         UpdateThemeOp,
     ],
     Field(discriminator="op"),
@@ -463,6 +533,108 @@ def _apply_update_form_settings(form: StandardForm, op: UpdateFormSettingsOp) ->
     return "Updated form settings: " + ", ".join(changed)
 
 
+
+CHOICE_TYPES = {StandardFormFieldType.MULTIPLE_CHOICE, StandardFormFieldType.DROPDOWN}
+
+
+def _validated_conditions(form: StandardForm, specs: List[LogicConditionSpec]) -> List[FieldLogicCondition]:
+    """Resolve and validate condition sources against the actual form.
+
+    Mirrors the builder's logic editor: fieldType is stamped from the source
+    field; choice values must be one of the source's labels; yes/no values
+    must be "Yes"/"No"; IS_EMPTY/IS_NOT_EMPTY take no value."""
+    conditions: List[FieldLogicCondition] = []
+    for spec in specs:
+        _, source, _ = _find_field(form, spec.field_id)
+        source_type = getattr(source.type, "value", source.type)
+        if spec.comparison in VALUELESS_COMPARISONS:
+            value = None
+        else:
+            if spec.value in (None, ""):
+                raise OpError(f"Comparison '{spec.comparison}' needs a value.")
+            value = spec.value
+            if source.type in CHOICE_TYPES:
+                labels = [c.value for c in ((source.properties.choices if source.properties else None) or [])]
+                if str(value) not in labels:
+                    raise OpError(
+                        f"'{value}' is not a choice of '{_title_text(source)}'. Choices: {', '.join(labels)}"
+                    )
+            if source.type == StandardFormFieldType.YES_NO and str(value) not in ("Yes", "No"):
+                raise OpError("Yes/No conditions take the value 'Yes' or 'No'.")
+        conditions.append(
+            FieldLogicCondition(field_id=spec.field_id, field_type=source_type, comparison=spec.comparison, value=value)
+        )
+    return conditions
+
+
+def _apply_set_field_logic(form: StandardForm, op: SetFieldLogicOp) -> str:
+    _, field, _ = _find_field(form, op.field_id)
+    if field.properties is None:
+        field.properties = StandardFieldProperty()
+    if op.logic is None:
+        field.properties.logic = None
+        return f"Cleared the visibility rule on '{_title_text(field)}'"
+    for spec in op.logic.conditions:
+        if spec.field_id == op.field_id:
+            raise OpError("A field's visibility cannot depend on its own answer.")
+    conditions = _validated_conditions(form, op.logic.conditions)
+    field.properties.logic = FieldLogic(action=op.logic.action, operator=op.logic.operator, conditions=conditions)
+    verb = "Show" if op.logic.action == "SHOW" else "Hide"
+    return f"{verb} '{_title_text(field)}' when {len(conditions)} condition(s) match"
+
+
+def _apply_set_page_jumps(form: StandardForm, op: SetPageJumpsOp) -> str:
+    page = _find_page(form, op.page_id)
+    if page.properties is None:
+        page.properties = StandardFieldProperty()
+    if op.jumps is None:
+        page.properties.jumps = None
+        return f"Cleared page jumps on page '{op.page_id}'"
+    jumps: List[PageJump] = []
+    for spec in op.jumps:
+        if spec.target != JUMP_TARGET_SUBMIT:
+            target_page = _find_page(form, spec.target)  # raises if unknown
+            if target_page.id == op.page_id:
+                raise OpError("A page cannot jump to itself.")
+        jumps.append(
+            PageJump(operator=spec.operator, conditions=_validated_conditions(form, spec.conditions), target=spec.target)
+        )
+    page.properties.jumps = jumps
+    return f"Set {len(jumps)} jump rule(s) on page '{op.page_id}'"
+
+
+def _apply_duplicate_page(form: StandardForm, op: DuplicatePageOp) -> str:
+    original = _find_page(form, op.page_id)
+    clone = original.model_copy(deep=True)
+    clone.id = str(uuid.uuid4())
+    id_map: Dict[str, str] = {}
+    for field in (clone.properties.fields if clone.properties else None) or []:
+        new_id = str(uuid.uuid4())
+        id_map[field.id] = new_id
+        field.id = new_id
+        if field.properties and field.properties.choices:
+            for choice in field.properties.choices:
+                choice.id = str(uuid.uuid4())
+    # Remap in-page logic references onto the cloned fields; references to
+    # fields outside the page stay as they are.
+    for field in (clone.properties.fields if clone.properties else None) or []:
+        logic = field.properties.logic if field.properties else None
+        for condition in (logic.conditions if logic else None) or []:
+            if condition.field_id in id_map:
+                condition.field_id = id_map[condition.field_id]
+    # Cloned jumps would re-branch from the copy in surprising ways — drop them.
+    if clone.properties:
+        clone.properties.jumps = None
+        clone.properties.position = None
+    pages = form.fields or []
+    original_position = next(i for i, f in enumerate(pages) if f.id == op.page_id)
+    insert_at = op.index if op.index is not None else original_position + 1
+    insert_at = max(0, min(insert_at, len(pages)))
+    pages.insert(insert_at, clone)
+    field_count = len((clone.properties.fields if clone.properties else None) or [])
+    return f"Duplicated page '{op.page_id}' ({field_count} fields) as '{clone.id}'"
+
+
 def _apply_update_theme(form: StandardForm, op: UpdateThemeOp) -> str:
     form.theme = op.theme
     return f"Applied theme '{op.theme.title}'"
@@ -477,6 +649,9 @@ _HANDLERS = {
     "remove_page": _apply_remove_page,
     "update_form_info": _apply_update_form_info,
     "update_form_settings": _apply_update_form_settings,
+    "set_field_logic": _apply_set_field_logic,
+    "set_page_jumps": _apply_set_page_jumps,
+    "duplicate_page": _apply_duplicate_page,
     "update_theme": _apply_update_theme,
 }
 

--- a/backend/backend/app/services/ai/ops.py
+++ b/backend/backend/app/services/ai/ops.py
@@ -143,6 +143,28 @@ class UpdateFormInfoOp(_CamelModel):
     description: Optional[str] = None
 
 
+class FormSettingsPatch(_CamelModel):
+    """AI-editable form settings — the Form tab's metadata.
+
+    Deliberately a SUBSET of SettingsPatchDto: trust-layer text and
+    response-behaviour toggles. Distribution/visibility (hidden, private,
+    pinned, custom URL, close date) stays human-only — an ambiguous chat
+    instruction must never unpublish or hide a form.
+    """
+
+    purpose: Optional[str] = None  # empty string clears
+    retention_text: Optional[str] = None  # empty string clears
+    privacy_policy_url: Optional[str] = None  # empty string clears
+    require_verified_identity: Optional[bool] = None
+    allow_editing_response: Optional[bool] = None
+    show_submission_number: Optional[bool] = None
+
+
+class UpdateFormSettingsOp(_CamelModel):
+    op: Literal["update_form_settings"] = "update_form_settings"
+    patch: FormSettingsPatch
+
+
 class UpdateThemeOp(_CamelModel):
     op: Literal["update_theme"] = "update_theme"
     theme: Theme
@@ -157,6 +179,7 @@ FormOp = Annotated[
         AddPageOp,
         RemovePageOp,
         UpdateFormInfoOp,
+        UpdateFormSettingsOp,
         UpdateThemeOp,
     ],
     Field(discriminator="op"),
@@ -414,6 +437,32 @@ def _apply_update_form_info(form: StandardForm, op: UpdateFormInfoOp) -> str:
     return f"Updated form {', '.join(changed)}"
 
 
+_SETTINGS_LABELS = {
+    "purpose": "purpose",
+    "retention_text": "retention",
+    "privacy_policy_url": "privacy policy link",
+    "require_verified_identity": "verified-identity requirement",
+    "allow_editing_response": "response editing",
+    "show_submission_number": "submission numbers",
+}
+
+
+def _apply_update_form_settings(form: StandardForm, op: UpdateFormSettingsOp) -> str:
+    """Settings live on the workspace-form association, not the form body —
+    the engine validates and reports; ``persist_ops_to_form`` writes them."""
+    changed = [
+        _SETTINGS_LABELS[key]
+        for key, value in op.patch.model_dump().items()
+        if value is not None
+    ]
+    if not changed:
+        raise OpError(
+            "Nothing to change — provide at least one of: purpose, retentionText, "
+            "privacyPolicyUrl, requireVerifiedIdentity, allowEditingResponse, showSubmissionNumber."
+        )
+    return "Updated form settings: " + ", ".join(changed)
+
+
 def _apply_update_theme(form: StandardForm, op: UpdateThemeOp) -> str:
     form.theme = op.theme
     return f"Applied theme '{op.theme.title}'"
@@ -427,6 +476,7 @@ _HANDLERS = {
     "add_page": _apply_add_page,
     "remove_page": _apply_remove_page,
     "update_form_info": _apply_update_form_info,
+    "update_form_settings": _apply_update_form_settings,
     "update_theme": _apply_update_theme,
 }
 

--- a/backend/backend/app/services/ai/prompt_builder.py
+++ b/backend/backend/app/services/ai/prompt_builder.py
@@ -63,6 +63,11 @@ Operations (camelCase keys, referencing the ids from the form snapshot):
 - {"op":"add_page","index":0?,"fields":[<field specs>]?}
 - {"op":"remove_page","pageId":"..."}
 - {"op":"update_form_info","title":"?","description":"?"}
+- {"op":"update_form_settings","patch":{"purpose":"?","retentionText":"?","privacyPolicyUrl":"?","requireVerifiedIdentity":true?,"allowEditingResponse":true?,"showSubmissionNumber":true?}}
+  (the Form tab's trust & privacy metadata: "purpose" tells respondents why the
+  data is collected, "retentionText" how long it is kept — e.g. "kept for 90
+  days". An empty string clears a text value. Visibility/distribution settings
+  are not editable here.)
 
 Field types you may create: short_text, long_text, email, number, url,
 phone_number, date, yes_no, multiple_choice, dropdown, rating, linear_rating,
@@ -77,11 +82,13 @@ Rules:
 - If the request is unclear or nothing needs to change, return "ops": [] and ask in "reply"."""
 
 
-def project_form(form) -> str:
+def project_form(form, settings=None) -> str:
     """Compact JSON snapshot of a form for the chat context window.
 
     Ids, types, titles and the properties the ops can touch — never TipTap
     blobs, theme values or response data. Small enough to resend every turn.
+    ``settings`` (the workspace-form association's settings) contributes the
+    trust metadata so the model can see and edit purpose/retention.
     """
     import json
 
@@ -111,6 +118,15 @@ def project_form(form) -> str:
             fields.append(entry)
         pages.append({"pageId": slide.id, "index": slide.index, "fields": fields})
     snapshot = {"title": form.title, "description": form.description, "pages": pages}
+    if settings is not None:
+        snapshot["settings"] = {
+            "purpose": getattr(settings, "purpose", None),
+            "retentionText": getattr(settings, "retention_text", None),
+            "privacyPolicyUrl": getattr(settings, "privacy_policy_url", None),
+            "requireVerifiedIdentity": getattr(settings, "require_verified_identity", None),
+            "allowEditingResponse": getattr(settings, "allow_editing_response", None),
+            "showSubmissionNumber": getattr(settings, "show_submission_number", None),
+        }
     return json.dumps(snapshot, ensure_ascii=False)
 
 

--- a/backend/backend/app/services/ai/prompt_builder.py
+++ b/backend/backend/app/services/ai/prompt_builder.py
@@ -63,6 +63,14 @@ Operations (camelCase keys, referencing the ids from the form snapshot):
 - {"op":"add_page","index":0?,"fields":[<field specs>]?}
 - {"op":"remove_page","pageId":"..."}
 - {"op":"update_form_info","title":"?","description":"?"}
+- {"op":"set_field_logic","fieldId":"...","logic":{"action":"SHOW"|"HIDE","operator":"AND"|"OR","conditions":[{"fieldId":"<earlier field>","comparison":"IS_EQUAL","value":"..."}]}}
+  (conditional visibility — "show X only when Y is ...". The rule sits on the TARGET field.
+  Comparisons: IS_EMPTY, IS_NOT_EMPTY, IS_EQUAL, IS_NOT_EQUAL, CONTAINS, DOES_NOT_CONTAIN,
+  LESS_THAN, LESS_THAN_EQUAL, GREATER_THAN, GREATER_THAN_EQUAL, STARTS_WITH, ENDS_WITH.
+  Choice conditions use the choice LABEL; yes/no uses "Yes"/"No". "logic":null clears.)
+- {"op":"set_page_jumps","pageId":"...","jumps":[{"operator":"AND","conditions":[...],"target":"<page id or __SUBMIT__>"}]}
+  (branching after a page; first matching jump wins, no match = next page. "jumps":null clears.)
+- {"op":"duplicate_page","pageId":"...","index":0?} (clones a page with all fields, fresh ids)
 - {"op":"update_form_settings","patch":{"purpose":"?","retentionText":"?","privacyPolicyUrl":"?","requireVerifiedIdentity":true?,"allowEditingResponse":true?,"showSubmissionNumber":true?}}
   (the Form tab's trust & privacy metadata: "purpose" tells respondents why the
   data is collected, "retentionText" how long it is kept — e.g. "kept for 90
@@ -115,8 +123,30 @@ def project_form(form, settings=None) -> str:
                     entry["placeholder"] = props.placeholder
                 if getattr(props, "col_span", None):
                     entry["colSpan"] = props.col_span
+                if getattr(props, "logic", None) and props.logic.conditions:
+                    entry["logic"] = {
+                        "action": props.logic.action,
+                        "operator": props.logic.operator,
+                        "conditions": [
+                            {"fieldId": c.field_id, "comparison": c.comparison, "value": c.value}
+                            for c in props.logic.conditions
+                        ],
+                    }
             fields.append(entry)
-        pages.append({"pageId": slide.id, "index": slide.index, "fields": fields})
+        page_entry = {"pageId": slide.id, "index": slide.index, "fields": fields}
+        if slide.properties and slide.properties.jumps:
+            page_entry["jumps"] = [
+                {
+                    "operator": j.operator,
+                    "target": j.target,
+                    "conditions": [
+                        {"fieldId": c.field_id, "comparison": c.comparison, "value": c.value}
+                        for c in (j.conditions or [])
+                    ],
+                }
+                for j in slide.properties.jumps
+            ]
+        pages.append(page_entry)
     snapshot = {"title": form.title, "description": form.description, "pages": pages}
     if settings is not None:
         snapshot["settings"] = {

--- a/backend/backend/app/services/ai/review.py
+++ b/backend/backend/app/services/ai/review.py
@@ -88,6 +88,8 @@ class ApplyReviewFixRequest(_CamelModel):
 class ApplyReviewFixResponse(_CamelModel):
     results: List[OpResult] = []
     form: dict
+    # Present when a fix changed form settings (purpose/retention/…).
+    settings: Optional[dict] = None
 
 
 def build_review_system_prompt(form_snapshot: str, profile) -> str:
@@ -167,7 +169,7 @@ class FormAIReviewService:
         )
         if not form_document:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, content="Form not found")
-        return form_document
+        return form_document, association
 
     async def review(
         self,
@@ -176,10 +178,14 @@ class FormAIReviewService:
         request: FormAIReviewRequest,
         user: User,
     ) -> FormAIReviewResponse:
-        form_document = await self._load_form(workspace_id, form_id, user)
+        form_document, association = await self._load_form(workspace_id, form_id, user)
         form = StandardForm(**form_document.model_dump())
         profile = await AIProfileService.get_profile_for_prompt(workspace_id)
-        system = build_review_system_prompt(project_form(form), profile)
+        # The snapshot includes trust settings — a review that can't see the
+        # stated purpose/retention would flag them as missing forever.
+        system = build_review_system_prompt(
+            project_form(form, settings=association.settings), profile
+        )
 
         provider = self._provider_resolver(request.provider)
         raw_reply = await provider.chat(
@@ -210,7 +216,7 @@ class FormAIReviewService:
         request: ApplyReviewFixRequest,
         user: User,
     ) -> ApplyReviewFixResponse:
-        form_document = await self._load_form(workspace_id, form_id, user)
+        form_document, _ = await self._load_form(workspace_id, form_id, user)
         try:
             ops = parse_ops(request.ops)
         except Exception:
@@ -218,10 +224,11 @@ class FormAIReviewService:
                 status_code=HTTPStatus.BAD_REQUEST, content="Invalid fix operations"
             )
         form = StandardForm(**form_document.model_dump())
-        new_form, results = await persist_ops_to_form(form_document, form, ops)
+        new_form, results, updated_settings = await persist_ops_to_form(form_document, form, ops)
         return ApplyReviewFixResponse(
             results=results,
             form=StandardFormCamelModel(**new_form.model_dump()).model_dump(
                 mode="json", by_alias=True
             ),
+            settings=updated_settings,
         )

--- a/backend/backend/app/services/ai/review.py
+++ b/backend/backend/app/services/ai/review.py
@@ -21,6 +21,7 @@ from pydantic.alias_generators import to_camel
 from backend.app.exceptions import HTTPException
 from backend.app.models.dtos.response_dtos import StandardFormCamelModel
 from backend.app.schemas.standard_form import FormDocument
+from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.ai.chat import persist_ops_to_form
 from backend.app.services.ai.ops import OpResult, parse_ops
 from backend.app.services.ai.profile import AIProfileService, render_prompt_block
@@ -156,7 +157,14 @@ class FormAIReviewService:
         await self._workspace_user_service.check_user_has_access_in_workspace(
             workspace_id=workspace_id, user=user
         )
-        form_document = await FormDocument.find_one({"form_id": form_id})
+        # The form must belong to THIS workspace (same rule as chat and MCP).
+        association = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.workspace_id == workspace_id,
+            WorkspaceFormDocument.form_id == form_id,
+        )
+        form_document = (
+            await FormDocument.find_one({"form_id": form_id}) if association else None
+        )
         if not form_document:
             raise HTTPException(status_code=HTTPStatus.NOT_FOUND, content="Form not found")
         return form_document

--- a/backend/backend/app/services/aws_service.py
+++ b/backend/backend/app/services/aws_service.py
@@ -1,6 +1,7 @@
 import datetime
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from fastapi import HTTPException
 
@@ -10,22 +11,31 @@ aws_settings = settings.aws_settings
 
 
 class AWSS3Service:
+    """Works against any S3-compatible store — Wasabi in production,
+    RustFS/MinIO locally. Endpoint/region/bucket come from AWS_* settings."""
+
     def __init__(self, aws_access_key_id: str, aws_secret_access_key: str):
         self._aws_access_key_id = aws_access_key_id
         self._aws_secret_access_key = aws_secret_access_key
+        # SigV4 + path-style addressing work across every S3-compatible
+        # store we target (Wasabi, RustFS, MinIO). Without the explicit
+        # signature version, presigned URLs 403 on RustFS.
+        client_config = Config(signature_version="s3v4", s3={"addressing_style": "path"})
         self._s3 = boto3.resource(
             "s3",
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
-            region_name="eu-central-1",
-            endpoint_url="https://s3.eu-central-1.wasabisys.com",
+            region_name=aws_settings.REGION,
+            endpoint_url=aws_settings.ENDPOINT_URL,
+            config=client_config,
         )
         self._s3_client = boto3.client(
             "s3",
             aws_access_key_id=self._aws_access_key_id,
             aws_secret_access_key=self._aws_secret_access_key,
-            region_name="eu-central-1",
-            endpoint_url="https://s3.eu-central-1.wasabisys.com",
+            region_name=aws_settings.REGION,
+            endpoint_url=aws_settings.ENDPOINT_URL,
+            config=client_config,
         )
 
     async def upload_file_to_s3(
@@ -33,7 +43,7 @@ class AWSS3Service:
         file=None,
         key=None,
         previous_image="",
-        bucket="bettercollected",
+        bucket=aws_settings.BUCKET,
         private=False,
         folder_name="public",
     ):
@@ -63,13 +73,12 @@ class AWSS3Service:
         except Exception as other_exception:
             print("Other Exception:", other_exception)
             raise HTTPException(550, "INFO: Failed to upload image")
-        wasabi_domain = "https://s3.eu-central-1.wasabisys.com"
         folder = f"/{bucket}/{folder_name}/{current_time}_{key}"
         if private:
             folder = f"/{bucket}/{folder_name}/{key}"
-        return f"{wasabi_domain}{folder}"
+        return f"{aws_settings.public_base_url}{folder}"
 
-    def check_if_key_exists(self, key, bucket="bettercollected"):
+    def check_if_key_exists(self, key, bucket=aws_settings.BUCKET):
         try:
             objs = list(self._s3.Bucket(bucket).objects.filter(Prefix=key))
             if len(objs) > 0:
@@ -83,20 +92,20 @@ class AWSS3Service:
         key : path to your file
     """
 
-    def delete_file_from_s3(self, key: str, bucket: str = "bettercollected"):
+    def delete_file_from_s3(self, key: str, bucket: str = aws_settings.BUCKET):
         try:
             self._s3.Object(bucket, key).delete()
         except ClientError:
             raise HTTPException(404, "INFO: Failed to delete file")
 
-    def delete_folder_from_s3(self, prefix: str, bucket: str = "bettercollected"):
+    def delete_folder_from_s3(self, prefix: str, bucket: str = aws_settings.BUCKET):
         try:
             for object_summary in self._s3.Bucket(bucket).objects.filter(Prefix=prefix):
                 object_summary.delete()
         except ClientError:
             return
 
-    def generate_presigned_url(self, key: str, bucket="bettercollected"):
+    def generate_presigned_url(self, key: str, bucket=aws_settings.BUCKET):
         try:
             presigned_url = self._s3_client.generate_presigned_url(
                 "get_object",

--- a/backend/backend/config/aws.py
+++ b/backend/backend/config/aws.py
@@ -5,5 +5,18 @@ class AWSSettings(BaseSettings):
     ACCESS_KEY_ID: str = ""
     SECRET_ACCESS_KEY: str = ""
     PRE_SIGNED_URL_EXPIRY: int = 10
+    # Any S3-compatible store works (Wasabi in production; RustFS/MinIO for
+    # local dev and self-hosting). The defaults preserve the original
+    # hardwired Wasabi setup so existing deployments need no new env.
+    ENDPOINT_URL: str = "https://s3.eu-central-1.wasabisys.com"
+    REGION: str = "eu-central-1"
+    BUCKET: str = "bettercollected"
+    # Domain used to build public object URLs. Defaults to ENDPOINT_URL;
+    # set separately when serving objects through a CDN.
+    PUBLIC_URL: str = ""
 
     model_config = SettingsConfigDict(env_prefix='AWS_')
+
+    @property
+    def public_base_url(self) -> str:
+        return self.PUBLIC_URL or self.ENDPOINT_URL

--- a/backend/scripts/setup_local_s3.py
+++ b/backend/scripts/setup_local_s3.py
@@ -1,0 +1,60 @@
+"""Bootstrap the local S3 bucket (RustFS from docker-compose.local.yml).
+
+Idempotent: creates the bucket and applies the anonymous-read policy for the
+PUBLIC prefixes only. Private uploads (``private/*`` — respondent files) stay
+unreadable without a presigned URL, exactly like production.
+
+Run:  uv run python scripts/setup_local_s3.py
+"""
+
+import json
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+ENDPOINT = os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000")
+ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID", "rustfsadmin")
+SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "rustfsadmin")
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+BUCKET = os.environ.get("AWS_BUCKET", "bettercollected")
+
+# RustFS/MinIO ignore per-object ACLs — anonymous read is granted by bucket
+# policy, scoped to the prefixes the product treats as public.
+PUBLIC_PREFIXES = ["public/*", "media_library/*"]
+
+POLICY = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"AWS": ["*"]},
+            "Action": ["s3:GetObject"],
+            "Resource": [f"arn:aws:s3:::{BUCKET}/{prefix}" for prefix in PUBLIC_PREFIXES],
+        }
+    ],
+}
+
+
+def main() -> None:
+    s3 = boto3.client(
+        "s3",
+        aws_access_key_id=ACCESS_KEY,
+        aws_secret_access_key=SECRET_KEY,
+        region_name=REGION,
+        endpoint_url=ENDPOINT,
+    )
+    try:
+        s3.create_bucket(Bucket=BUCKET)
+        print(f"created bucket '{BUCKET}'")
+    except ClientError as e:
+        code = e.response["Error"]["Code"]
+        if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+            raise
+        print(f"bucket '{BUCKET}' already exists")
+    s3.put_bucket_policy(Bucket=BUCKET, Policy=json.dumps(POLICY))
+    print(f"anonymous read enabled for: {', '.join(PUBLIC_PREFIXES)} (private/* stays private)")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/app/controllers/test_form_ai_chat.py
+++ b/backend/tests/app/controllers/test_form_ai_chat.py
@@ -122,6 +122,91 @@ class TestFormAIChat:
         system = fake_provider.calls[0]["system"]
         assert "<form_snapshot>" in system and "dark patterns" in system
 
+    async def test_settings_op_updates_purpose_and_retention(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+        fake_provider: FakeProvider,
+    ):
+        """The exact user journey that surfaced this gap: 'update the purpose
+        and retention for this form' must land in the Form tab's settings."""
+        form_doc = await FormDocument.find_one({"form_id": workspace_form.form_id})
+        await _make_v2(form_doc)
+        fake_provider.replies = [
+            json.dumps(
+                {
+                    "reply": "Set the purpose and retention.",
+                    "ops": [
+                        {
+                            "op": "update_form_settings",
+                            "patch": {"purpose": "To schedule your appointment", "retentionText": "kept for 90 days"},
+                        }
+                    ],
+                }
+            ),
+            json.dumps({"memories": []}),  # background extraction
+        ]
+
+        response = await client.post(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/chat",
+            cookies=test_user_cookies,
+            json={"message": "update the purpose and retention for this form"},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["results"][0]["ok"] is True
+        assert "purpose" in body["results"][0]["message"] and "retention" in body["results"][0]["message"]
+        # The response carries the updated settings for the Form tab.
+        assert body["settings"]["purpose"] == "To schedule your appointment"
+        assert body["settings"]["retentionText"] == "kept for 90 days"
+
+        # Persisted on the workspace-form association (where the Form tab reads).
+        from backend.app.schemas.workspace_form import WorkspaceFormDocument
+
+        workspace_form_doc = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.form_id == workspace_form.form_id
+        )
+        assert workspace_form_doc.settings.purpose == "To schedule your appointment"
+        assert workspace_form_doc.settings.retention_text == "kept for 90 days"
+
+        # …and the model could SEE the current settings in its snapshot.
+        assert '"settings"' in fake_provider.calls[0]["system"]
+
+    async def test_settings_op_clears_with_empty_string(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+        fake_provider: FakeProvider,
+    ):
+        form_doc = await FormDocument.find_one({"form_id": workspace_form.form_id})
+        await _make_v2(form_doc)
+        from backend.app.schemas.workspace_form import WorkspaceFormDocument
+
+        workspace_form_doc = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.form_id == workspace_form.form_id
+        )
+        workspace_form_doc.settings.purpose = "Old purpose"
+        await workspace_form_doc.save()
+
+        fake_provider.replies = [
+            json.dumps({"reply": "Cleared.", "ops": [{"op": "update_form_settings", "patch": {"purpose": ""}}]}),
+            json.dumps({"memories": []}),
+        ]
+        response = await client.post(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/chat",
+            cookies=test_user_cookies,
+            json={"message": "remove the purpose text"},
+        )
+        assert response.status_code == 200
+        refreshed = await WorkspaceFormDocument.find_one(
+            WorkspaceFormDocument.form_id == workspace_form.form_id
+        )
+        assert refreshed.settings.purpose is None
+
     async def test_second_turn_carries_history(
         self,
         client: AsyncClient,

--- a/backend/tests/app/controllers/test_form_ai_insights.py
+++ b/backend/tests/app/controllers/test_form_ai_insights.py
@@ -1,0 +1,236 @@
+"""Response summaries & insights — opt-in, anonymised by construction."""
+
+import json
+from typing import Any, Coroutine
+
+import pytest
+from httpx import AsyncClient
+
+from common.models.standard_form import (
+    StandardChoice,
+    StandardFieldProperty,
+    StandardFormField,
+    StandardFormFieldType,
+    StandardFormResponse,
+)
+
+from backend.app.container import container
+from backend.app.models.enum.workspace_roles import WorkspaceRoles
+from backend.app.schemas.form_ai_insight import FormAIInsightDocument
+from backend.app.schemas.standard_form import FormDocument
+from backend.app.schemas.workspace import WorkspaceDocument
+from backend.app.schemas.workspace_user import WorkspaceUserDocument
+from tests.app.controllers.data import testUser
+
+
+class FakeProvider:
+    def __init__(self):
+        self.replies = []
+        self.calls = []
+
+    async def chat(self, system: str, messages: list) -> str:
+        self.calls.append({"system": system, "messages": messages})
+        return self.replies.pop(0)
+
+
+@pytest.fixture()
+def fake_insights_provider(monkeypatch):
+    fake = FakeProvider()
+    service = container.form_ai_insights_service()
+    monkeypatch.setattr(service, "_provider_resolver", lambda name: fake)
+    return fake
+
+
+INSIGHTS_REPLY = {
+    "summary": "Respondents are broadly happy with onboarding but struggle with billing.",
+    "themes": [
+        {"title": "Billing confusion", "description": "Several responses mention unclear invoices.", "approxCount": 2},
+        {"title": "Smooth onboarding", "description": "Setup is repeatedly called easy.", "approxCount": 2},
+    ],
+    "actionable": ["Clarify the invoice layout."],
+    "sentiment": "Mostly positive with one recurring frustration.",
+}
+
+
+async def _seed_form_and_responses(workspace_id, form_id: str) -> None:
+    """Give the fixture form real questions and three answered responses."""
+    form_doc = await FormDocument.find_one({"form_id": form_id})
+    form_doc.fields = [
+        StandardFormField(
+            id="page-1",
+            index=0,
+            type=StandardFormFieldType.SLIDE,
+            properties=StandardFieldProperty(
+                fields=[
+                    StandardFormField(id="q-feedback", index=0, type=StandardFormFieldType.LONG_TEXT, title="Any feedback?", properties=StandardFieldProperty(fields=[])),
+                    StandardFormField(id="q-email", index=1, type=StandardFormFieldType.EMAIL, title="Your email?", properties=StandardFieldProperty(fields=[])),
+                    StandardFormField(id="q-score", index=2, type=StandardFormFieldType.NUMBER, title="Score 1-10?", properties=StandardFieldProperty(fields=[])),
+                    StandardFormField(
+                        id="q-plan",
+                        index=3,
+                        type=StandardFormFieldType.DROPDOWN,
+                        title="Which plan are you on?",
+                        properties=StandardFieldProperty(fields=[], choices=[StandardChoice(id="choice-free", value="Free"), StandardChoice(id="choice-pro", value="Pro")]),
+                    ),
+                ]
+            ),
+        )
+    ]
+    await form_doc.save()
+
+    answer_sets = [
+        {
+            "q-feedback": {"type": "text", "text": "Onboarding was easy but the invoice is confusing."},
+            "q-email": {"type": "email", "email": "alice@example.com"},
+            "q-score": {"type": "number", "number": 8},
+            # Responses store choice IDs — the projection must resolve labels.
+            "q-plan": {"type": "choice", "choice": {"value": "choice-pro"}},
+        },
+        {
+            "q-feedback": {"type": "text", "text": "Billing page needs work, rest is great."},
+            "q-email": {"type": "email", "email": "bob@example.com"},
+            "q-score": {"type": "number", "number": 7},
+        },
+        {
+            "q-feedback": {"type": "text", "text": "Setup took five minutes. Loved it."},
+            "q-email": {"type": "email", "email": "carol@example.com"},
+            "q-score": {"type": "number", "number": 10},
+        },
+    ]
+    for answers in answer_sets:
+        await container.form_response_service().submit_form_response(
+            form_id, StandardFormResponse(answers=answers), workspace_id
+        )
+
+
+class TestFormAIInsights:
+    async def test_generate_is_grounded_anonymised_and_cached(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+        fake_insights_provider: FakeProvider,
+    ):
+        await _seed_form_and_responses(workspace.id, workspace_form.form_id)
+        fake_insights_provider.replies = [json.dumps(INSIGHTS_REPLY)]
+
+        response = await client.post(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/insights",
+            cookies=test_user_cookies,
+            json={},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["summary"].startswith("Respondents are broadly happy")
+        assert body["themes"][0]["title"] == "Billing confusion"
+        assert body["responseCount"] == 3
+        assert body["totalResponses"] == 3
+
+        # The prompt saw questions and answer text…
+        prompt = fake_insights_provider.calls[0]["messages"][0]["content"]
+        assert "Any feedback?" in prompt
+        assert "invoice is confusing" in prompt
+        # …but NEVER the email addresses — redacted at projection time, the
+        # model cannot leak what it never received.
+        assert "alice@example.com" not in prompt
+        assert "bob@example.com" not in prompt
+        assert "[email provided]" in prompt
+        assert "alice@example.com" not in fake_insights_provider.calls[0]["system"]
+        # Choice answers arrive as IDs; the model must see the human label.
+        assert "Pro" in prompt
+        assert "choice-pro" not in prompt
+
+        # Cached: GET returns it without another model call.
+        cached = await client.get(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/insights",
+            cookies=test_user_cookies,
+        )
+        assert cached.status_code == 200
+        assert cached.json()["summary"] == body["summary"]
+        assert len(fake_insights_provider.calls) == 1
+
+        document = await FormAIInsightDocument.find_one(
+            FormAIInsightDocument.form_id == workspace_form.form_id
+        )
+        assert document is not None and document.response_count == 3
+
+    async def test_get_without_generation_returns_empty(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+    ):
+        response = await client.get(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/insights",
+            cookies=test_user_cookies,
+        )
+        assert response.status_code == 200
+        assert response.json() is None
+
+    async def test_no_responses_is_a_clear_400(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+    ):
+        response = await client.post(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/insights",
+            cookies=test_user_cookies,
+            json={},
+        )
+        assert response.status_code == 400
+        assert "no responses" in response.text.lower()
+
+    async def test_unusable_model_reply_is_a_502_and_nothing_cached(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+        fake_insights_provider: FakeProvider,
+    ):
+        await _seed_form_and_responses(workspace.id, workspace_form.form_id)
+        fake_insights_provider.replies = ["The responses look nice overall!"]
+
+        response = await client.post(
+            f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/insights",
+            cookies=test_user_cookies,
+            json={},
+        )
+        assert response.status_code == 502
+        assert await FormAIInsightDocument.find_one(FormAIInsightDocument.form_id == workspace_form.form_id) is None
+
+
+class TestAIFormAccessIsWorkspaceScoped:
+    """REGRESSION: access to workspace B must not unlock workspace A's forms
+    by id — every AI surface 404s on a foreign form."""
+
+    async def test_all_ai_endpoints_404_on_foreign_form(
+        self,
+        client: AsyncClient,
+        workspace_1: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+        test_user_cookies: dict[str, str],
+    ):
+        # Make the caller a member of workspace_1 so plain workspace access
+        # passes — the form-belongs-to-workspace check must be what stops it.
+        await WorkspaceUserDocument(
+            workspace_id=workspace_1.id, user_id=testUser.id, roles=[WorkspaceRoles.COLLABORATOR]
+        ).save()
+        foreign = workspace_form.form_id
+        calls = [
+            ("post", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/chat", {"message": "hi"}),
+            ("post", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/review", {}),
+            ("post", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/review/apply", {"ops": [{"op": "remove_field", "fieldId": "x"}]}),
+            ("post", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/insights", {}),
+            ("get", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/insights", None),
+        ]
+        for method, url, body in calls:
+            if method == "get":
+                response = await client.get(url, cookies=test_user_cookies)
+            else:
+                response = await client.post(url, cookies=test_user_cookies, json=body)
+            assert response.status_code == 404, f"{method.upper()} {url} -> {response.status_code}: {response.text}"

--- a/backend/tests/app/controllers/test_mcp_server.py
+++ b/backend/tests/app/controllers/test_mcp_server.py
@@ -167,6 +167,76 @@ class TestMCPServer:
         ).to_list()
         assert any(log.tool == "update_form" and log.ok for log in logs)
 
+    async def test_create_form_blank_then_build_with_ops(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+    ):
+        token = await _make_key(workspace.id, ["forms:read", "forms:write"])
+        created = _tool_text(
+            await _call_tool(client, token, "create_form", {"title": "Import target", "description": "Built by ops"})
+        )
+        assert created["title"] == "Import target" and created["published"] is False
+
+        # The blank form has exactly one empty page, ready for precise ops.
+        form = _tool_text(await _call_tool(client, token, "get_form", {"form_id": created["formId"]}))
+        assert len(form["fields"]) == 1
+        page_id = form["fields"][0]["id"]
+        assert (form["fields"][0].get("properties", {}) or {}).get("fields", []) in ([], None)
+
+        result = _tool_text(
+            await _call_tool(
+                client, token, "update_form",
+                {"form_id": created["formId"],
+                 "ops": [
+                     {"op": "add_field", "pageId": page_id, "field": {"title": "Branch", "type": "short_text"}},
+                     {"op": "add_field", "pageId": page_id, "field": {"title": "Rented house?", "type": "yes_no"}},
+                 ]},
+            )
+        )
+        assert all(r["ok"] for r in result["results"])
+
+    async def test_logic_ops_work_over_mcp(
+        self,
+        client: AsyncClient,
+        workspace: Coroutine[Any, Any, WorkspaceDocument],
+        workspace_form: Coroutine[Any, Any, FormDocument],
+    ):
+        form_doc = await FormDocument.find_one({"form_id": workspace_form.form_id})
+        page_id = await _make_v2(form_doc)
+        token = await _make_key(workspace.id, ["forms:read", "forms:write"])
+
+        result = _tool_text(
+            await _call_tool(
+                client, token, "update_form",
+                {"form_id": workspace_form.form_id,
+                 "ops": [
+                     {"op": "add_field", "pageId": page_id, "field": {"title": "Rented?", "type": "yes_no"}},
+                     {"op": "add_field", "pageId": page_id, "field": {"title": "Landlord name", "type": "short_text"}},
+                 ]},
+            )
+        )
+        assert all(r["ok"] for r in result["results"])
+        form = _tool_text(await _call_tool(client, token, "get_form", {"form_id": workspace_form.form_id}))
+        fields = form["fields"][0]["properties"]["fields"]
+        rented = next(f for f in fields if f["title"] == "Rented?")
+        landlord = next(f for f in fields if f["title"] == "Landlord name")
+
+        result = _tool_text(
+            await _call_tool(
+                client, token, "update_form",
+                {"form_id": workspace_form.form_id,
+                 "ops": [{"op": "set_field_logic", "fieldId": landlord["id"],
+                          "logic": {"action": "SHOW", "conditions": [{"fieldId": rented["id"], "comparison": "IS_EQUAL", "value": "Yes"}]}}]},
+            )
+        )
+        assert result["results"][0]["ok"], result
+
+        # Persisted and visible in the snapshot external clients read.
+        form = _tool_text(await _call_tool(client, token, "get_form", {"form_id": workspace_form.form_id}))
+        landlord_after = next(f for f in form["fields"][0]["properties"]["fields"] if f["title"] == "Landlord name")
+        assert landlord_after["properties"]["logic"]["action"] == "SHOW"
+
     async def test_scope_is_enforced_per_tool(
         self,
         client: AsyncClient,

--- a/backend/tests/app/services/test_ai_form_ops.py
+++ b/backend/tests/app/services/test_ai_form_ops.py
@@ -253,3 +253,101 @@ class TestEngineSemantics:
         fid = _page_fields(form, "page-1")[0].id
         _, results = apply_form_ops(form, [UpdateFieldOp(field_id=fid, patch=FieldPatch(required=True))])
         assert "Your name" in results[0].message
+
+
+class TestConditionalLogicOps:
+    def _ids(self, form):
+        page1, page2 = form.fields
+        name, yesno = page1.properties.fields
+        colour = page2.properties.fields[0]
+        return name, yesno, colour
+
+    def test_set_show_logic_stamps_field_type_and_persists(self, form):
+        name, yesno, _ = self._ids(form)
+        ops = parse_ops([
+            {"op": "set_field_logic", "fieldId": name.id,
+             "logic": {"action": "SHOW", "conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "Yes"}]}}
+        ])
+        new_form, results = apply_form_ops(form, ops)
+        assert results[0].ok, results[0].message
+        logic = new_form.fields[0].properties.fields[0].properties.logic
+        assert logic.action == "SHOW" and logic.operator == "AND"
+        assert logic.conditions[0].field_id == yesno.id
+        # fieldType is stamped from the SOURCE field, like the builder does.
+        assert logic.conditions[0].field_type == "yes_no"
+
+    def test_logic_validation_catches_real_mistakes(self, form):
+        name, yesno, colour = self._ids(form)
+        cases = [
+            # unknown source field
+            ({"fieldId": "ghost", "comparison": "IS_EQUAL", "value": "Yes"}, "not found"),
+            # choice label that doesn't exist (the model guessing labels)
+            ({"fieldId": colour.id, "comparison": "IS_EQUAL", "value": "Green"}, "not a choice"),
+            # yes/no with a non-Yes/No value
+            ({"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "true"}, "'Yes' or 'No'"),
+            # value-comparison without a value
+            ({"fieldId": yesno.id, "comparison": "IS_EQUAL"}, "needs a value"),
+        ]
+        for condition, expected in cases:
+            ops = parse_ops([{"op": "set_field_logic", "fieldId": name.id,
+                              "logic": {"action": "SHOW", "conditions": [condition]}}])
+            _, results = apply_form_ops(form, ops)
+            assert results[0].ok is False
+            assert expected in results[0].message
+
+    def test_self_referencing_logic_is_rejected(self, form):
+        _, yesno, _ = self._ids(form)
+        ops = parse_ops([{"op": "set_field_logic", "fieldId": yesno.id,
+                          "logic": {"action": "HIDE", "conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "Yes"}]}}])
+        _, results = apply_form_ops(form, ops)
+        assert results[0].ok is False and "own answer" in results[0].message
+
+    def test_logic_null_clears(self, form):
+        name, yesno, _ = self._ids(form)
+        ops = parse_ops([
+            {"op": "set_field_logic", "fieldId": name.id,
+             "logic": {"action": "SHOW", "conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "Yes"}]}},
+            {"op": "set_field_logic", "fieldId": name.id, "logic": None},
+        ])
+        new_form, results = apply_form_ops(form, ops)
+        assert all(r.ok for r in results)
+        assert new_form.fields[0].properties.fields[0].properties.logic is None
+
+    def test_page_jumps_validate_targets(self, form):
+        _, yesno, _ = self._ids(form)
+        good = parse_ops([{"op": "set_page_jumps", "pageId": "page-1",
+                           "jumps": [{"conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "No"}], "target": "__SUBMIT__"}]}])
+        new_form, results = apply_form_ops(form, good)
+        assert results[0].ok
+        assert new_form.fields[0].properties.jumps[0].target == "__SUBMIT__"
+
+        bad = parse_ops([{"op": "set_page_jumps", "pageId": "page-1",
+                          "jumps": [{"conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "No"}], "target": "page-404"}]}])
+        _, results = apply_form_ops(form, bad)
+        assert results[0].ok is False and "not found" in results[0].message
+
+        selfjump = parse_ops([{"op": "set_page_jumps", "pageId": "page-1",
+                               "jumps": [{"conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "No"}], "target": "page-1"}]}])
+        _, results = apply_form_ops(form, selfjump)
+        assert results[0].ok is False and "itself" in results[0].message
+
+    def test_duplicate_page_fresh_ids_and_remapped_logic(self, form):
+        name, yesno, _ = self._ids(form)
+        ops = parse_ops([
+            {"op": "set_field_logic", "fieldId": name.id,
+             "logic": {"action": "SHOW", "conditions": [{"fieldId": yesno.id, "comparison": "IS_EQUAL", "value": "Yes"}]}},
+            {"op": "duplicate_page", "pageId": "page-1"},
+        ])
+        new_form, results = apply_form_ops(form, ops)
+        assert all(r.ok for r in results), [r.message for r in results]
+        pages = new_form.fields
+        assert len(pages) == 3  # copy inserted right after the original
+        original, clone = pages[0], pages[1]
+        assert clone.id != original.id
+        original_ids = {f.id for f in original.properties.fields}
+        clone_ids = {f.id for f in clone.properties.fields}
+        assert not (original_ids & clone_ids)  # every field id is fresh
+        # In-page logic reference remapped onto the cloned yes/no field.
+        clone_name = clone.properties.fields[0]
+        cloned_yesno_id = clone.properties.fields[1].id
+        assert clone_name.properties.logic.conditions[0].field_id == cloned_yesno_id

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -66,11 +66,14 @@ services:
         image: rustfs/rustfs:latest
         restart: unless-stopped
         ports:
-            - '9000:9000'
+            - '9000:9000' # S3 API
+            - '9001:9001' # web console — http://localhost:9001/rustfs/console/ (rustfsadmin/rustfsadmin)
         environment:
             RUSTFS_ACCESS_KEY: rustfsadmin
             RUSTFS_SECRET_KEY: rustfsadmin
             RUSTFS_VOLUMES: /data
+            RUSTFS_CONSOLE_ENABLE: 'true'
+            RUSTFS_CONSOLE_ADDRESS: ':9001'
         volumes:
             - rustfs-data:/data
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,6 +3,7 @@ version: '3.7'
 volumes:
     mongo-data:
     umami-db-data:
+    rustfs-data:
 
 services:
     mongodb:
@@ -54,6 +55,24 @@ services:
         environment:
             MP_SMTP_AUTH_ACCEPT_ANY: 'true'
             MP_SMTP_AUTH_ALLOW_INSECURE: 'true'
+
+    # S3-compatible object storage (file uploads, media library, workspace
+    # images). The backend's AWSS3Service points here via AWS_* env vars:
+    #   AWS_ENDPOINT_URL=http://localhost:9000  AWS_REGION=us-east-1
+    #   AWS_ACCESS_KEY_ID=rustfsadmin           AWS_SECRET_ACCESS_KEY=rustfsadmin
+    #   AWS_BUCKET=bettercollected
+    # Local-only credentials — deployments must override with real secrets.
+    rustfs:
+        image: rustfs/rustfs:latest
+        restart: unless-stopped
+        ports:
+            - '9000:9000'
+        environment:
+            RUSTFS_ACCESS_KEY: rustfsadmin
+            RUSTFS_SECRET_KEY: rustfsadmin
+            RUSTFS_VOLUMES: /data
+        volumes:
+            - rustfs-data:/data
 
     # Self-hosted product analytics (see plans/umami-self-hosted-form-analytics.md).
     # Admin UI: http://localhost:3003 — default login admin/umami, change it, then

--- a/webapp/.env.example
+++ b/webapp/.env.example
@@ -26,5 +26,6 @@ GOOGLE_PICKER_API_KEY=
 
 UNSPLASH_ACCESS_KEY=
 
-FORM_DOMAIN=localhost:3001
+# Locally one Next app serves both dashboard and forms — point FORM_DOMAIN at it.
+FORM_DOMAIN=localhost:3000
 DASHBOARD_DOMAIN=localhost:3000

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/_components/form-dashboard-layout-client.tsx
@@ -122,7 +122,7 @@ export default function FormDashboardLayoutClient({
     }
 
     return (
-        <TopNavLayout isCustomDomain={false} isClientDomain={false} showNavbar={true} workspaceIdentity hideMenu={false} showAuthAccount={true} className="flex w-full flex-col !bg-white !p-0">
+        <TopNavLayout isCustomDomain={false} isClientDomain={false} showNavbar={true} workspaceIdentity hideMenu={false} showAuthAccount={true} className="flex w-full flex-col !bg-white !p-0" navContainerClassName="px-4 md:px-10 lg:px-28">
             <div className="my-2 w-full">
                 <div className="mt-6 flex flex-col gap-1 sm:mt-12">
                     <FormPageLayer className="px-4 md:px-10 lg:px-28">

--- a/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/responses/page.tsx
+++ b/webapp/src/app/(admin-portal)/(form-page-layout)/[workspace_name]/dashboard/forms/[form_id]/responses/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import AIInsightsCard from '@app/components/form/ai-insights-card';
 import FormResponses from '@app/components/form/responses';
 import ResponseSegments from '@app/components/form/response-segments';
 
@@ -7,6 +8,7 @@ export default function Page() {
     return (
         <div className="mt-4 px-4 md:px-10 lg:px-28">
             <ResponseSegments />
+            <AIInsightsCard />
             <FormResponses />
         </div>
     );

--- a/webapp/src/components/auth/auth-navbar.tsx
+++ b/webapp/src/components/auth/auth-navbar.tsx
@@ -28,6 +28,9 @@ interface IAuthNavbarProps {
     showAuthAccount?: boolean;
     handleDrawerToggle?: () => void;
     workspaceIdentity?: boolean;
+    /** Constrain the navbar CONTENT to the same container as the page body
+     *  (pass the body's padding classes) so their left edges align. */
+    containerClassName?: string;
 }
 
 AuthNavbar.defaultProps = {
@@ -69,12 +72,12 @@ function WorkspaceIdentity() {
     );
 }
 
-function AuthNavbar({ showHamburgerIcon, showPlans, mobileOpen, handleDrawerToggle, isCustomDomain = false, isFooter = false, isClientDomain = false, hideMenu = false, showAuthAccount, workspaceIdentity = false }: IAuthNavbarProps) {
+function AuthNavbar({ showHamburgerIcon, showPlans, mobileOpen, handleDrawerToggle, isCustomDomain = false, isFooter = false, isClientDomain = false, hideMenu = false, showAuthAccount, workspaceIdentity = false, containerClassName }: IAuthNavbarProps) {
     const { t } = useTranslation();
     const inMobile = useIsMobile();
     return (
-        <Header className="!z-[1300]">
-            <div className="flex flex-row w-full h-full py-2 md:py-0 justify-between items-center">
+        <Header className={`!z-[1300] ${containerClassName ? '!px-0' : ''}`}>
+            <div className={`flex flex-row w-full h-full py-2 md:py-0 justify-between items-center ${containerClassName ?? ''}`}>
                 <div className="flex gap-4">
                     {inMobile && showHamburgerIcon && <Hamburger isOpen={mobileOpen} className="!shadow-none mr-2 !bg-white hover:!bg-white !text-black-900 !flex !justify-start" onClick={handleDrawerToggle} />}
                     {/* Admin surfaces lead with the WORKSPACE identity, not the

--- a/webapp/src/components/form/ai-insights-card.test.tsx
+++ b/webapp/src/components/form/ai-insights-card.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cachedQueryMock: { data: any } = { data: undefined };
+const generateMock = vi.fn();
+vi.mock('@app/store/redux/form-api', async (importOriginal) => {
+    const actual: any = await importOriginal();
+    return {
+        ...actual,
+        useGetAIInsightsQuery: () => cachedQueryMock,
+        useGenerateAIInsightsMutation: () => [generateMock, { isLoading: false }]
+    };
+});
+
+import { store } from '@app/store/store';
+import AIInsightsCard from './ai-insights-card';
+
+const INSIGHT = {
+    summary: 'Respondents love onboarding but find billing confusing.',
+    themes: [{ title: 'Billing confusion', description: 'Invoices are unclear.', approxCount: 2 }],
+    actionable: ['Clarify the invoice layout.'],
+    sentiment: 'Mostly positive.',
+    responseCount: 3,
+    totalResponses: 3,
+    generatedAt: '2026-07-09T12:00:00Z'
+};
+
+const renderCard = () =>
+    render(
+        <ReduxProvider store={store}>
+            <AIInsightsCard />
+        </ReduxProvider>
+    );
+
+describe('AIInsightsCard', () => {
+    beforeEach(() => {
+        generateMock.mockReset();
+        cachedQueryMock.data = undefined;
+    });
+
+    it('empty state states the opt-in contract and offers one explicit action', () => {
+        renderCard();
+        expect(screen.getByText(/only when you click/)).toBeDefined();
+        expect(screen.getByRole('button', { name: /Summarize responses/ })).toBeDefined();
+    });
+
+    it('generating renders summary, themes with counts, and provenance', async () => {
+        generateMock.mockResolvedValue({ data: INSIGHT });
+        renderCard();
+
+        fireEvent.click(screen.getByRole('button', { name: /Summarize responses/ }));
+        await waitFor(() => expect(screen.getByText(/love onboarding/)).toBeDefined());
+        expect(screen.getByText('Billing confusion')).toBeDefined();
+        expect(screen.getByText('~2')).toBeDefined();
+        expect(screen.getByText(/Clarify the invoice layout/)).toBeDefined();
+        expect(screen.getByText(/all 3 responses/)).toBeDefined();
+        expect(screen.getByText(/never shared with the AI/)).toBeDefined();
+    });
+
+    it('a cached insight renders without any generate call', () => {
+        cachedQueryMock.data = INSIGHT;
+        renderCard();
+        expect(screen.getByText(/love onboarding/)).toBeDefined();
+        expect(generateMock).not.toHaveBeenCalled();
+        // Regeneration stays available.
+        expect(screen.getByRole('button', { name: /Refresh/ })).toBeDefined();
+    });
+
+    it('errors are stated honestly in place', async () => {
+        generateMock.mockResolvedValue({ error: { status: 400, data: 'This form has no responses to summarize yet.' } });
+        renderCard();
+
+        fireEvent.click(screen.getByRole('button', { name: /Summarize responses/ }));
+        await waitFor(() => expect(screen.getByText(/no responses to summarize/)).toBeDefined());
+    });
+});

--- a/webapp/src/components/form/ai-insights-card.tsx
+++ b/webapp/src/components/form/ai-insights-card.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+
+import { RefreshCw, Sparkles } from 'lucide-react';
+
+import { Button } from '@app/shadcn/components/ui/button';
+import { selectForm } from '@app/store/forms/slice';
+import { useAppSelector } from '@app/store/hooks';
+import { useGenerateAIInsightsMutation, useGetAIInsightsQuery } from '@app/store/redux/form-api';
+import { selectWorkspace } from '@app/store/workspaces/slice';
+
+interface InsightTheme {
+    title: string;
+    description: string;
+    approxCount?: number | null;
+}
+
+interface Insight {
+    summary: string;
+    themes: InsightTheme[];
+    actionable: string[];
+    sentiment?: string | null;
+    responseCount: number;
+    totalResponses: number;
+    generatedAt: string;
+}
+
+/**
+ * AI summary of a form's responses (plan §2 'response summaries', P3).
+ * Opt-in by construction: the AI reads answer content ONLY when the creator
+ * clicks Summarize — viewing later reads the cached result. Identities and
+ * email/phone values are never sent to the model at all.
+ */
+export default function AIInsightsCard() {
+    const workspace = useAppSelector(selectWorkspace);
+    const form = useAppSelector(selectForm);
+    const { data: cached } = useGetAIInsightsQuery({ workspaceId: workspace?.id, formId: form?.formId }, { skip: !workspace?.id || !form?.formId });
+    const [generate, { isLoading: isGenerating }] = useGenerateAIInsightsMutation();
+    const [fresh, setFresh] = useState<Insight | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const insight: Insight | null = fresh ?? cached ?? null;
+
+    const handleGenerate = async () => {
+        setError(null);
+        const response: any = await generate({ workspaceId: workspace.id, formId: form.formId });
+        if (response.data) {
+            setFresh(response.data);
+        } else {
+            setError(typeof response.error?.data === 'string' ? response.error.data : 'Could not generate the summary — please try again.');
+        }
+    };
+
+    return (
+        <div className="border-black-200 mb-6 flex flex-col gap-3 rounded-lg border bg-white p-5">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                    <Sparkles className="text-brand-500 h-4 w-4" />
+                    <h2 className="text-black-900 text-sm font-semibold">AI summary</h2>
+                </div>
+                {insight && (
+                    <button type="button" disabled={isGenerating} onClick={handleGenerate} className="text-black-500 hover:text-black-800 flex items-center gap-1 text-xs transition-colors disabled:opacity-60">
+                        <RefreshCw className={`h-3 w-3 ${isGenerating ? 'animate-spin' : ''}`} />
+                        {isGenerating ? 'Summarizing…' : 'Refresh'}
+                    </button>
+                )}
+            </div>
+
+            {!insight ? (
+                <div className="flex flex-col items-start gap-2.5">
+                    <p className="text-black-600 max-w-[68ch] text-[13px] leading-relaxed">
+                        Get a plain-language summary of what your responses say — recurring themes, overall tone, and what to act on. The AI reads answer content <span className="font-medium">only when you click</span>; respondent identities, emails and phone
+                        numbers are never shared with it.
+                    </p>
+                    {error && <p className="text-xs text-[#7A2E2E]">{error}</p>}
+                    <Button size="sm" variant="v2Button" isLoading={isGenerating} onClick={handleGenerate}>
+                        Summarize responses
+                    </Button>
+                </div>
+            ) : (
+                <div className="flex flex-col gap-3">
+                    <p className="text-black-800 max-w-[75ch] text-[13px] leading-relaxed">{insight.summary}</p>
+                    {!!insight.themes?.length && (
+                        <ul className="flex flex-col gap-1.5">
+                            {insight.themes.map((theme) => (
+                                <li key={theme.title} className="flex items-baseline gap-2 text-[13px]">
+                                    <span className="text-black-900 shrink-0 font-medium">{theme.title}</span>
+                                    {typeof theme.approxCount === 'number' && <span className="bg-black-100 text-black-600 shrink-0 rounded px-1.5 py-0.5 text-[10.5px] tabular-nums">~{theme.approxCount}</span>}
+                                    <span className="text-black-600">{theme.description}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                    {!!insight.actionable?.length && (
+                        <div className="text-[13px]">
+                            <span className="text-black-900 font-medium">Worth acting on: </span>
+                            <span className="text-black-700">{insight.actionable.join(' · ')}</span>
+                        </div>
+                    )}
+                    {insight.sentiment && <p className="text-black-500 text-xs">{insight.sentiment}</p>}
+                    {error && <p className="text-xs text-[#7A2E2E]">{error}</p>}
+                    <p className="text-black-400 text-[10.5px]">
+                        Based on {insight.responseCount === insight.totalResponses ? `all ${insight.totalResponses}` : `the latest ${insight.responseCount} of ${insight.totalResponses}`} responses · generated {new Date(insight.generatedAt).toLocaleString()} · identities
+                        and contact details are never shared with the AI
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/webapp/src/components/hocs/auth-status-dispatcher.tsx
+++ b/webapp/src/components/hocs/auth-status-dispatcher.tsx
@@ -1,11 +1,11 @@
 import { UserStatus } from '@app/models/dtos/user-status';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
-import { useGetStatusQuery } from '@app/store/auth/api';
+import { useGetStatusQuery, useRefreshTokenMutation } from '@app/store/auth/api';
 import { initialAuthState, setAuth } from '@app/store/auth/slice';
 import { useAppDispatch } from '@app/store/hooks';
 import { isAdminDomain } from '@app/utils/domain-utils';
 import { useRouter } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 interface IAuthStatusDispatcherProps {
     workspace: WorkspaceDto | null | undefined;
@@ -30,6 +30,25 @@ export default function AuthStatusDispatcher({ workspace, children }: IAuthStatu
         },
         skip: is401
     });
+
+    // The plan claim lives inside the (httpOnly) access token, so an upgrade
+    // that happens outside this tab — another session, an admin action, the
+    // API — leaves the cookie stale: /auth/status says PRO while every
+    // authorized endpoint still sees FREE and 403s. Re-mint the token once
+    // per app load and again whenever the server-truth plan changes.
+    const [refreshToken] = useRefreshTokenMutation();
+    const refreshedOnMountRef = useRef(false);
+    const lastPlanRef = useRef<string | undefined>(undefined);
+    useEffect(() => {
+        if (!data?.id) return;
+        const planChanged = lastPlanRef.current !== undefined && lastPlanRef.current !== data.plan;
+        lastPlanRef.current = data.plan;
+        if (!refreshedOnMountRef.current || planChanged) {
+            refreshedOnMountRef.current = true;
+            refreshToken();
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [data?.id, data?.plan]);
 
     useEffect(() => {
         const currentPath = window.location.pathname;

--- a/webapp/src/components/onboarding/workspace-name-input-handler.tsx
+++ b/webapp/src/components/onboarding/workspace-name-input-handler.tsx
@@ -75,21 +75,19 @@ const WorkspaceNameInputHandler = ({ formData, setFormData, handleOnChange, crea
             getAvailabilityStatusOfWorkspaceName(workspaceName).then((availability) => {
                 if (!availability) {
                     fetchSuggestionsForWorkspaceHandle(formData.title).then((suggestion) => {
-                        setFormData({
-                            ...formData,
-                            workspaceName: suggestion
-                        });
+                        // No suggestion (empty title / failed fetch) must not
+                        // write undefined — that flips the input to
+                        // uncontrolled and React logs an error.
+                        if (suggestion) setFormData({ ...formData, workspaceName: suggestion });
                     });
                 }
             });
         } else {
             fetchSuggestionsForWorkspaceHandle(formData.title.toLowerCase()).then((suggestion) => {
-                setFormData({
-                    ...formData,
-                    workspaceName: suggestion
-                });
+                if (suggestion) setFormData({ ...formData, workspaceName: suggestion });
             });
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {
@@ -117,8 +115,9 @@ const WorkspaceNameInputHandler = ({ formData, setFormData, handleOnChange, crea
                 if (data.includes(text)) {
                     return text;
                 } else {
-                    const suggestion = data[Math.floor(Math.random() * 4) + 1];
-                    setWorkspaceNameSuggestion(suggestion);
+                    // Fewer than 5 suggestions made this index out of range.
+                    const suggestion = data[Math.floor(Math.random() * 4) + 1] ?? data[0];
+                    if (suggestion) setWorkspaceNameSuggestion(suggestion);
                     return suggestion;
                 }
             }
@@ -134,7 +133,7 @@ const WorkspaceNameInputHandler = ({ formData, setFormData, handleOnChange, crea
                 required
                 id="workspaceName"
                 placeholder="Enter workspace handle name"
-                value={formData.workspaceName?.toLowerCase()}
+                value={formData.workspaceName?.toLowerCase() ?? ''}
                 onChange={handleOnChange}
                 className={errorMessage && formData.workspaceName ? 'border-red-500 focus-visible:ring-red-500 w-full' : 'w-full'}
             />

--- a/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
@@ -77,6 +77,11 @@ export default function WorkspaceFormCard({ form, hasCustomDomain, group, worksp
 
     const isFormOpen = validateFormOpen(form?.settings?.formCloseDate);
 
+    // Provider only carries signal for IMPORTED forms — every native form
+    // showing the bettercollected logo was noise on the creator's own list.
+    const providerForIcon = form.settings?.provider === 'self' && form.importedFormId && form.settings.showOriginalForm ? 'google' : form?.settings?.provider;
+    const showProviderChip = !!providerForIcon && providerForIcon !== 'self';
+
     return (
         <div className={`hover:border-brand-200 shadow-formCardDefault hover:shadow-formCard flex h-full cursor-pointer flex-col  items-start justify-between rounded-lg border-[1px] border-transparent bg-white transition ${className}`}>
             <div className="group flex w-full items-center justify-between rounded px-5 py-4">
@@ -128,11 +133,11 @@ export default function WorkspaceFormCard({ form, hasCustomDomain, group, worksp
                         </div>
                     )}
                     <div className={`flex max-w-full flex-wrap items-center gap-2 ${isResponderPortal ? 'hidden' : ''}`}>
-                        <FormProviderIcon provider={form.settings?.provider === 'self' && form.importedFormId && form.settings.showOriginalForm ? 'google' : form?.settings?.provider} />
+                        {showProviderChip && <FormProviderIcon provider={providerForIcon} />}
                         {showVisibility && (
                             <Tooltip label={form?.settings?.private ? t(toolTipConstant.hideForm) : ''}>
                                 <div className="fap-2 flex items-center">
-                                    <DotIcon />
+                                    {showProviderChip && <DotIcon />}
                                     {form?.isPublished || isResponderPortal ? (
                                         <div className="text-black-600 flex items-center">
                                             {visibility().icon}

--- a/webapp/src/containers/upgrade-to-pro.tsx
+++ b/webapp/src/containers/upgrade-to-pro.tsx
@@ -144,8 +144,11 @@ export default function UpgradeToProContainer({ featureText, isModal = true, cal
                                     toast({ description: 'Congratulations! You have been upgraded to PRO' });
                                 }
                                 if (response.error) {
+                                    // Say what actually failed — a 503 "Service is
+                                    // not enabled" is actionable; "Something went
+                                    // wrong" is not.
                                     toast({
-                                        description: 'Something went wrong',
+                                        description: typeof response.error?.data === 'string' ? response.error.data : 'Could not activate PRO — please try again.',
                                         variant: 'destructive'
                                     });
                                 }

--- a/webapp/src/layouts/top-navbar-layout.tsx
+++ b/webapp/src/layouts/top-navbar-layout.tsx
@@ -16,6 +16,8 @@ interface LayoutProps {
     showNavbar?: boolean;
     workspaceIdentity?: boolean;
     isFooter?: boolean;
+    /** Align the navbar content with the page body's container (padding classes). */
+    navContainerClassName?: string;
 }
 
 export default function TopNavLayout({
@@ -29,11 +31,24 @@ export default function TopNavLayout({
     showNavbar = false,
     workspaceIdentity = false,
     isFooter = false,
-    showAuthAccount
+    showAuthAccount,
+    navContainerClassName
 }: React.PropsWithChildren<LayoutProps>) {
     return (
         <div className="!bg-black-200 dark:bg-dark z-20 !min-h-screen !min-w-full">
-            {showNavbar && <AuthNavbar isFooter={isFooter} isCustomDomain={isCustomDomain} isClientDomain={isClientDomain} showHamburgerIcon={showHamburgerIcon} hideMenu={hideMenu} showPlans={false} showAuthAccount={showAuthAccount} workspaceIdentity={workspaceIdentity} />}
+            {showNavbar && (
+                <AuthNavbar
+                    isFooter={isFooter}
+                    isCustomDomain={isCustomDomain}
+                    isClientDomain={isClientDomain}
+                    showHamburgerIcon={showHamburgerIcon}
+                    hideMenu={hideMenu}
+                    showPlans={false}
+                    showAuthAccount={showAuthAccount}
+                    workspaceIdentity={workspaceIdentity}
+                    containerClassName={navContainerClassName}
+                />
+            )}
             <main
                 className={cn(
                     "bg-black-100 float-none flex w-full px-5 lg:float-right lg:px-10",

--- a/webapp/src/store/redux/form-api.ts
+++ b/webapp/src/store/redux/form-api.ts
@@ -94,8 +94,21 @@ export const formsApi = createApi({
                 method: 'POST',
                 body: request.body
             })
+        }),
+        getAIInsights: builder.query<any, any>({
+            query: (request) => ({
+                url: `/workspaces/${request.workspaceId}/forms/${request.formId}/ai/insights`,
+                method: 'GET'
+            })
+        }),
+        generateAIInsights: builder.mutation<any, any>({
+            query: (request) => ({
+                url: `/workspaces/${request.workspaceId}/forms/${request.formId}/ai/insights`,
+                method: 'POST',
+                body: {}
+            })
         })
     })
 });
 
-export const { useCreateV2FormMutation, usePatchV2FormMutation, usePublishV2FormMutation, useGetFormResponseQuery, useSubmitResponseMutation, useSendFlowEventMutation, useGetFlowAnalyticsQuery, useLazyLogOutQuery, useCreateFormWithAIMutation, useChatEditFormWithAIMutation, useReviewFormWithAIMutation, useApplyAIReviewFixMutation } = formsApi;
+export const { useCreateV2FormMutation, usePatchV2FormMutation, usePublishV2FormMutation, useGetFormResponseQuery, useSubmitResponseMutation, useSendFlowEventMutation, useGetFlowAnalyticsQuery, useLazyLogOutQuery, useCreateFormWithAIMutation, useChatEditFormWithAIMutation, useReviewFormWithAIMutation, useApplyAIReviewFixMutation, useGetAIInsightsQuery, useGenerateAIInsightsMutation } = formsApi;

--- a/webapp/src/views/molecules/form-builder/navbar.tsx
+++ b/webapp/src/views/molecules/form-builder/navbar.tsx
@@ -3,7 +3,6 @@
 import { useRouter } from 'next/navigation';
 
 import { SheetClose } from '@app/shadcn/components/ui/sheet';
-import { NewBetterCollectedSmallLogo } from '@Components/icons/bettercollected-small-logo';
 
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
@@ -12,16 +11,26 @@ import BackButton from './back-button';
 const NavBar = ({ isModal = false }: { isModal?: boolean }) => {
     const workspace = useAppSelector(selectWorkspace);
     const router = useRouter();
+    const workspaceTitle = workspace?.title || workspace?.workspaceName;
     return (
         <div className="border-b-black-300 flex h-16 w-full items-center justify-start border-b-[1px] !bg-white p-4">
-            <div
-                className={'bg-brand-500 active:bg-brand-600 cursor-pointer rounded-[5px] p-[6px] text-white shadow mr-1'}
+            {/* Workspace identity, not the product logo (de-brand decision —
+                same rule as the top navbar). Still the "back to forms" target. */}
+            <button
+                type="button"
+                aria-label={`Back to ${workspaceTitle || 'workspace'} forms`}
+                className="mr-1 cursor-pointer"
                 onClick={() => {
                     router.push('/' + workspace.workspaceName + '/dashboard/forms');
                 }}
             >
-                <NewBetterCollectedSmallLogo width={17} height={19} />
-            </div>
+                {workspace?.profileImage ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={workspace.profileImage} alt="" className="h-8 w-8 shrink-0 rounded-md object-cover shadow" />
+                ) : (
+                    <span className="bg-brand-100 text-brand-600 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-xs font-bold shadow">{(workspaceTitle?.[0] || 'W').toUpperCase()}</span>
+                )}
+            </button>
             {isModal ? (
                 <SheetClose asChild>
                     <div>

--- a/webapp/src/views/organism/form-builder/ai-chat-tab.test.tsx
+++ b/webapp/src/views/organism/form-builder/ai-chat-tab.test.tsx
@@ -315,6 +315,26 @@ describe('AIChatTab', () => {
         expect(chatEditMock.mock.calls[1][0].body.sessionId).toBe('session-1');
     });
 
+    it('a settings turn (purpose/retention) lands in the form slice for the Form tab', async () => {
+        chatEditMock.mockResolvedValue(
+            success({
+                reply: 'Set the purpose and retention.',
+                results: [{ index: 0, op: 'update_form_settings', ok: true, message: 'Updated form settings: purpose, retention' }],
+                settings: { purpose: 'To schedule your appointment', retentionText: 'kept for 90 days' }
+            })
+        );
+        renderPanel();
+
+        await sendMessage('update the purpose and retention for this form');
+        await waitFor(() => expect(screen.getByText('Set the purpose and retention.')).toBeDefined());
+
+        // The Form tab reads settings from the form slice — the turn must
+        // have dispatched them (this exact journey silently no-oped before).
+        const settings = (store.getState() as any).form.settings;
+        expect(settings.purpose).toBe('To schedule your appointment');
+        expect(settings.retentionText).toBe('kept for 90 days');
+    });
+
     it('REGRESSION: the conversation survives a tab switch (unmount/remount)', async () => {
         chatEditMock.mockResolvedValue(success());
         const { setForm } = await import('@app/store/forms/slice');

--- a/webapp/src/views/organism/form-builder/ai-chat-tab.tsx
+++ b/webapp/src/views/organism/form-builder/ai-chat-tab.tsx
@@ -6,7 +6,7 @@ import { BookOpen, Check, Plus, Send, ShieldCheck, X } from 'lucide-react';
 
 import { StandardFormDto } from '@app/models/dtos/form';
 import { deepCopy } from '@app/utils/object-utils';
-import { selectForm, setForm } from '@app/store/forms/slice';
+import { selectForm, setForm, setFormSettings } from '@app/store/forms/slice';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
 import useFormFieldsAtom from '@app/store/jotai/field-selectors';
 import { useFormState } from '@app/store/jotai/form';
@@ -165,10 +165,13 @@ export default function AIChatTab({ memoryPollDelaysMs = [4000, 10000] }: { memo
 
     // One canvas-apply path for chat turns and review fixes. deepCopy per
     // store is LOAD-BEARING — see the note in send().
-    const applyFormToCanvas = (form: any) => {
+    const applyFormToCanvas = (form: any, settings?: any) => {
         setFormFields(deepCopy(form.fields ?? []));
         setFormState({ ...formState, title: form.title ?? formState.title });
         dispatch(setForm({ ...standardForm, title: form.title, description: form.description, fields: deepCopy(form.fields ?? []) }));
+        // Settings (purpose/retention/… — the Form tab) live on the
+        // workspace-form association; the backend returns them separately.
+        if (settings) dispatch(setFormSettings(settings));
     };
 
     // Compliance copilot (plan §2, P2): read-only review; each finding's fix
@@ -197,7 +200,7 @@ export default function AIChatTab({ memoryPollDelaysMs = [4000, 10000] }: { memo
         const applied = !!response.data?.results?.some((r: TurnResult) => r.ok);
         if (applied) {
             patchFinding(turnIndex, findingIndex, { applying: false, applied: true });
-            applyFormToCanvas(response.data.form);
+            applyFormToCanvas(response.data.form, response.data.settings);
         } else {
             const failure = response.data?.results?.find((r: TurnResult) => !r.ok)?.message;
             patchFinding(turnIndex, findingIndex, { applying: false, applyError: failure ?? 'The fix could not be applied — please try again.' });
@@ -239,7 +242,7 @@ export default function AIChatTab({ memoryPollDelaysMs = [4000, 10000] }: { memo
         });
 
         if (response.data) {
-            const { reply, results, form, sessionId: sid } = response.data;
+            const { reply, results, form, settings, sessionId: sid } = response.data;
             setSessionId(sid);
             // Apply the AI's edit to the canvas — ONE setFormFields call = one
             // undo snapshot, so a whole turn reverts with a single Ctrl+Z.
@@ -252,7 +255,7 @@ export default function AIChatTab({ memoryPollDelaysMs = [4000, 10000] }: { memo
             // property". Each store gets its own copy (mirrors how the edit
             // page hydrates with deepCopy at mount).
             if (results?.some((r: TurnResult) => r.ok)) {
-                applyFormToCanvas(form);
+                applyFormToCanvas(form, settings);
             }
             setTurns((t) => [...t, { role: 'assistant', content: reply, results }]);
             surfaceNewMemories(memoryIdsBeforeTurn);

--- a/webapp/src/views/organism/form/thankyou-page.test.tsx
+++ b/webapp/src/views/organism/form/thankyou-page.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'jotai';
+import { Provider as ReduxProvider } from 'react-redux';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { setForm } from '@app/store/forms/slice';
+import { store } from '@app/store/store';
+import ThankyouPage from './thankyou-page';
+
+const renderPage = () =>
+    render(
+        <ReduxProvider store={store}>
+            <Provider>
+                <ThankyouPage isPreviewMode />
+            </Provider>
+        </ReduxProvider>
+    );
+
+describe('ThankyouPage', () => {
+    beforeEach(() => {
+        window.PUBLIC_CONFIG = { HTTP_SCHEME: 'http://', FORM_DOMAIN: 'localhost:3000' } as any;
+    });
+
+    it('REGRESSION: survives a form with NO thank-you page (API/MCP-born forms)', () => {
+        // create_form over MCP used to produce thankyouPage: null — the
+        // non-null assertion + [0] here crashed the post-submit screen.
+        store.dispatch(setForm({ formId: 'form-no-typ', title: 'No thankyou', thankyouPage: null, fields: [] }));
+        renderPage();
+        expect(screen.getByText('Thank You! 🎉')).toBeDefined();
+        expect(screen.getByText(/successfully submitted/)).toBeDefined();
+    });
+
+    it('renders the custom title, message and button when set', () => {
+        store.dispatch(
+            setForm({
+                formId: 'form-typ',
+                title: 'With thankyou',
+                fields: [],
+                thankyouPage: [{ title: 'Cheers!', message: 'We got it.', buttonText: 'Visit us', buttonLink: 'https://example.com' }]
+            })
+        );
+        renderPage();
+        expect(screen.getByText('Cheers!')).toBeDefined();
+        expect(screen.getByText('We got it.')).toBeDefined();
+        expect(screen.getByText('Visit us')).toBeDefined();
+    });
+});

--- a/webapp/src/views/organism/form/thankyou-page.tsx
+++ b/webapp/src/views/organism/form/thankyou-page.tsx
@@ -48,18 +48,22 @@ export default function ThankyouPage({ isPreviewMode }: { isPreviewMode: boolean
             description: 'Copied'
         });
     };
+    // Forms created outside the builder (API/MCP) may have no thank-you page
+    // at all — every read below must survive null/[] (the `!` + index here
+    // crashed the post-submit screen with "Cannot read properties of null").
+    const thankyouPage = standardForm?.thankyouPage?.[0];
     return (
-        <div className={cn('flex h-full w-full flex-col justify-center bg-inherit', standardForm?.thankyouPage![0]?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'items-start' : 'items-center')}>
+        <div className={cn('flex h-full w-full flex-col justify-center bg-inherit', thankyouPage?.layout === FormSlideLayout.SINGLE_COLUMN_NO_BACKGROUND_LEFT_ALIGN ? 'items-start' : 'items-center')}>
             <UserAvatarDropDown disabled />
             <div className=" flex h-full w-full max-w-[800px] flex-col justify-between">
                 <div className="flex">
                     <span className="text-[40px] font-bold leading-[48px]">{getThankYouTitle()}</span>
                 </div>
                 <div className="p2-new text-black-700 mt-4">{getThankYouMessage()}</div>
-                {standardForm?.thankyouPage && standardForm?.thankyouPage[0].buttonText && (
+                {thankyouPage?.buttonText && (
                     <Button style={{ background: standardForm.theme?.secondary }} className="mt-14">
-                        <Link href={isPreviewMode ? '' : standardForm?.thankyouPage[0].buttonLink || 'https://bettercollected.com'} target="_blank" referrerPolicy="no-referrer">
-                            {standardForm?.thankyouPage[0].buttonText}
+                        <Link href={isPreviewMode ? '' : thankyouPage.buttonLink || 'https://bettercollected.com'} target="_blank" referrerPolicy="no-referrer">
+                            {thankyouPage.buttonText}
                         </Link>
                     </Button>
                 )}

--- a/webapp/src/views/organism/navbar.tsx
+++ b/webapp/src/views/organism/navbar.tsx
@@ -25,7 +25,6 @@ import { AppInput } from '@app/shadcn/components/ui/input';
 import { selectForm } from '@app/store/forms/slice';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
-import { NewBetterCollectedSmallLogo } from '@Components/icons/bettercollected-small-logo';
 import { LogicOutlinedIcon } from '@Components/icons/logic-outlined-icon';
 import { PlusOutlined } from '@Components/icons/plus-outlined';
 import { TextOutlinedIcon } from '@Components/icons/text-outlined';
@@ -156,14 +155,23 @@ const Navbar = () => {
     return (
         <div id="navbar" className="border-b-black-300 flex h-16 w-full justify-between border-b-[1px] p-4">
             <div className={'flex flex-1 items-center gap-[2px]'}>
-                <div
-                    className={'bg-brand-500 active:bg-brand-600 cursor-pointer rounded-[5px] p-[6px] text-white shadow'}
+                {/* Workspace identity, not the product logo (de-brand decision —
+                    same rule as the top navbar). Still the "back to forms" target. */}
+                <button
+                    type="button"
+                    aria-label={`Back to ${workspace?.title || workspace?.workspaceName || 'workspace'} forms`}
+                    className="mr-1 cursor-pointer"
                     onClick={() => {
                         router.push('/' + workspace.workspaceName + '/dashboard/forms');
                     }}
                 >
-                    <NewBetterCollectedSmallLogo width={17} height={19} />
-                </div>
+                    {workspace?.profileImage ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={workspace.profileImage} alt="" className="h-8 w-8 shrink-0 rounded-md object-cover shadow" />
+                    ) : (
+                        <span className="bg-brand-100 text-brand-600 flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-xs font-bold shadow">{((workspace?.title || workspace?.workspaceName)?.[0] || 'W').toUpperCase()}</span>
+                    )}
+                </button>
                 <AppInput
                     placeholder="Form title"
                     value={formState.title}


### PR DESCRIPTION
## AI P3 kickoff + real-world hardening

Two threads in this branch: the first P3 features of the AI-native plan, and a series of fixes that fell out of dogfooding the MCP surface against real bank KYC documents.

### Response summaries & insights (opt-in AI over answers)
Plan principle #2: the AI never touches respondent data by default. Generation happens only on an explicit creator click; the result is cached (`FormAIInsightDocument`) so viewing later reads the cache, never the data. The projection is minimising **by construction**:
- respondent identity (email, data-owner id, hidden fields) is never projected into the prompt
- email/phone answer *values* are redacted before the model sees them (test-pinned: the addresses never reach the provider)
- choice IDs resolve to labels; orphaned UUIDs from older form versions project as `[selected option]`
- capped at the latest 200 responses / 60k chars, coverage always stated
- **"AI summary" card** on the responses page with themes, actionable items, and provenance

### AI can edit form settings (purpose/retention)
"Update the purpose and retention for this form" silently no-oped — trust metadata lives on the workspace-form association, which the ops engine couldn't touch. New `update_form_settings` op (purpose, retentionText, privacyPolicyUrl, requireVerifiedIdentity, allowEditingResponse, showSubmissionNumber). Deliberately a **subset**: visibility/distribution (hidden, private, pinned, custom URL, close date) stays human-only so an ambiguous chat instruction can never unpublish a form. Settings return separately in chat/review/MCP responses and land in the Form tab immediately.

### Conditional logic through the ops engine (from the KYC exercise)
Rebuilt two real Global IME Bank KYC forms (individual: 10 pages/96 fields; corporate: 12 pages/86 fields/40 rules) purely over MCP. The gaps that exercise exposed, closed:
- `set_field_logic` — show/hide rules validated against the real form (source must exist, choice values must be actual labels, yes/no takes "Yes"/"No", no self-reference); stamps fieldType exactly like the builder's logic editor
- `set_page_jumps` — branching with validated targets (`__SUBMIT__` sentinel)
- `duplicate_page` — fresh ids everywhere, in-page logic remapped onto clones
- MCP `create_form` — blank one-page draft for deterministic imports (now with the builder's default welcome/thank-you pages)
- form snapshots carry logic + jumps so models can see existing rules

### S3-compatible storage + RustFS for local dev
`AWSS3Service` had Wasabi hardwired — no local or self-hosted file uploads were possible. Now `AWS_ENDPOINT_URL/REGION/BUCKET/PUBLIC_URL` settings (defaults preserve Wasabi exactly), SigV4 + path-style on the clients (presigned URLs 403 on RustFS without it), a `rustfs` service in `docker-compose.local.yml` (S3 API :9000, console :9001), and `scripts/setup_local_s3.py` which grants anonymous read **only** on public prefixes — `private/*` (respondent files) stays presigned-only. Verified end-to-end: media upload, byte-identical public fetch, 403 on anonymous private access, 200 via presigned, and a real respondent PDF upload through a published form.

### Security
- **Cross-workspace authz gap**: chat and review loaded forms by id without verifying workspace membership of the *form* — access to workspace B allowed AI edits on workspace A's forms. Fixed (MCP already checked); regression test sweeps every AI endpoint with a foreign form.
- MCP `list_responses` counted ciphertext chars as answerCount; `get_response` now decrypts on read like the dashboard.

### UX / correctness fixes
- Post-submit crash ("Cannot read properties of null") on API-born forms without a thank-you page — component null-safe + MCP forms get builder defaults (regression-tested)
- Stale plan claim in the httpOnly token: `/auth/refresh` re-mints on app load and on plan change — upgraded users no longer 403 as FREE
- PRO activation surfaces the real error (was a generic toast hiding a 503 feature-flag message)
- Workspace-name input no longer flips controlled→uncontrolled on the create flow
- Form cards drop the bettercollected logo for native forms (provider chip only for imports); builder navbar leads with workspace identity instead of the product logo
- Form-page navbar content aligns with the body container
- `.env.example` FORM_DOMAIN points at the single local app (3001 was dead)

### Tests
Backend **227 passed** (insights + authz sweep, settings ops incl. the exact reported user journey, 6 logic-engine, MCP round-trips for create_form + logic). Webapp **206 passed** (settings-to-Form-tab dispatch, thank-you regression, insights card, memory/chat suites). Everything live-smoked against the running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
