### PR TITLE
fix(webapp): translations broke after i18next major — remove next-i18next, single react-i18next instance

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -76,7 +76,6 @@
         "minimatch": "^10.2.1",
         "moment": "^2.29.4",
         "next": "16.2.10",
-        "next-i18next": "^12.1.0",
         "next-nprogress-bar": "^2.3.11",
         "next-qrcode": "^2.5.1",
         "next-seo": "^5.5.0",
@@ -164,7 +163,6 @@
         "@types/react-dom": "19.2.3",
         "tar-fs": "^3.1.3",
         "minimatch": "^10.2.3",
-        "i18next-fs-backend": "^2.6.6",
         "postcss": "^8.5.10"
     },
     "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"

--- a/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/account-settings/_components/account-settings-client.tsx
+++ b/webapp/src/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/account-settings/_components/account-settings-client.tsx
@@ -2,7 +2,7 @@
 
 
 import AIMemorySection from '@app/components/account-settings/ai-memory-section';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 

--- a/webapp/src/app/(admin-portal)/(top-nav-layout)/[workspace_name]/onboarding/_components/onbaording-client.tsx
+++ b/webapp/src/app/(admin-portal)/(top-nav-layout)/[workspace_name]/onboarding/_components/onbaording-client.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 
 import { Button } from '@app/shadcn/components/ui/button';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import AuthAccountProfileImage from '@app/components/auth/account-profile-image';
 import Logo from '@app/components/ui/logo';

--- a/webapp/src/app/(admin-portal)/(top-nav-layout)/invitation/[id]/page.tsx
+++ b/webapp/src/app/(admin-portal)/(top-nav-layout)/invitation/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useParams, useRouter } from 'next/navigation';
 
 import LoginView from '@app/app/(auth)/_components/login-view';

--- a/webapp/src/components/auth/account-menu-dropdown.tsx
+++ b/webapp/src/components/auth/account-menu-dropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash';
 

--- a/webapp/src/components/auth/auth-navbar.tsx
+++ b/webapp/src/components/auth/auth-navbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 

--- a/webapp/src/components/badge/status-badge.tsx
+++ b/webapp/src/components/badge/status-badge.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash';
 

--- a/webapp/src/components/cards/regex-card.tsx
+++ b/webapp/src/components/cards/regex-card.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Plus } from 'lucide-react';
 

--- a/webapp/src/components/cards/setting-card.tsx
+++ b/webapp/src/components/cards/setting-card.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 
 import AnchorLink from '@app/components/ui/links/anchor-link';

--- a/webapp/src/components/common/generic-half-modal.tsx
+++ b/webapp/src/components/common/generic-half-modal.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import HeaderModalWrapper from '@Components/modals/modal-wrapper/header-modal-wrapper';
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/common/search-input.tsx
+++ b/webapp/src/components/common/search-input.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { debounce } from 'lodash';
 

--- a/webapp/src/components/common/upload-logo.tsx
+++ b/webapp/src/components/common/upload-logo.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import Image from "next/legacy/image";
 
 import Camera from "@app/components/icons/camera";

--- a/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
+++ b/webapp/src/components/custom-domain/add-workspace-domain-form.tsx
@@ -6,7 +6,7 @@ import { cn } from '@app/shadcn/util/lib';
 import { useAppDispatch, useAppSelector } from '@app/store/hooks';
 import { usePatchExistingWorkspaceMutation } from '@app/store/workspaces/api';
 import { selectWorkspace, setWorkspace } from '@app/store/workspaces/slice';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/dashboard/banner-image.tsx
+++ b/webapp/src/components/dashboard/banner-image.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import cn from 'classnames';

--- a/webapp/src/components/dashboard/empty-group.tsx
+++ b/webapp/src/components/dashboard/empty-group.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import Tooltip from '@app/shadcn/components/ui/tooltip';

--- a/webapp/src/components/dashboard/form-settings.tsx
+++ b/webapp/src/components/dashboard/form-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/dashboard/profile-image.tsx
+++ b/webapp/src/components/dashboard/profile-image.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { buttonConstant } from '@app/constants/locales/button';
 import { toastMessage } from '@app/constants/locales/toast-message';

--- a/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-forms-tab-content.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { escapeRegExp } from 'lodash';
 

--- a/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
+++ b/webapp/src/components/dashboard/workspace-responses-tab-content.tsx
@@ -1,6 +1,6 @@
 
 "use client";
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { usePathname, useRouter } from 'next/navigation';
 
 import ZeroElement from '@Components/common/zero-elament';

--- a/webapp/src/components/datatable/form-options-dropdown.tsx
+++ b/webapp/src/components/datatable/form-options-dropdown.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import Tooltip from '@app/shadcn/components/ui/tooltip';
 import { Copy, Eye, MoreVertical, Pencil, Pin, QrCode, Trash2 } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { LinkIcon } from '@app/components/icons/link-icon';
 import { useModal } from '@app/components/modal-views/context';

--- a/webapp/src/components/datatable/member-options.tsx
+++ b/webapp/src/components/datatable/member-options.tsx
@@ -7,7 +7,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useToast } from '@app/shadcn/components/ui/use-toast';
 import { useResendWorkspaceInvitationMutation } from '@app/store/workspaces/members-n-invitations-api';
 import { Loader2, MoreHorizontal, RefreshCw, Trash2 } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 
 interface IMemberOptionProps {

--- a/webapp/src/components/datatable/responses-table.tsx
+++ b/webapp/src/components/datatable/responses-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import StyledPagination from '@Components/common/pagination';
 import { cn } from '@app/shadcn/util/lib';

--- a/webapp/src/components/form/delete-form-modal.tsx
+++ b/webapp/src/components/form/delete-form-modal.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';

--- a/webapp/src/components/form/form-slug.tsx
+++ b/webapp/src/components/form/form-slug.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 

--- a/webapp/src/components/form/links.tsx
+++ b/webapp/src/components/form/links.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import FormSettingsTab from '@app/components/dashboard/form-settings';
 import { formConstant } from '@app/constants/locales/form';

--- a/webapp/src/components/form/responses.tsx
+++ b/webapp/src/components/form/responses.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 

--- a/webapp/src/components/form/settings.tsx
+++ b/webapp/src/components/form/settings.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import FormSettingsTab from '@app/components/dashboard/form-settings';
 import FormIntegrations from '@app/components/form/integrations';

--- a/webapp/src/components/form/tabular-responses.tsx
+++ b/webapp/src/components/form/tabular-responses.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import StyledPagination from '@Components/common/pagination';
 import cn from 'classnames';

--- a/webapp/src/components/form/visibility.tsx
+++ b/webapp/src/components/form/visibility.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import FormSettingsTab from '@app/components/dashboard/form-settings';
 import { formPage } from '@app/constants/locales/form-page';

--- a/webapp/src/components/forms-and-submisions-tabs/forms-and-submisisons-tab-container.tsx
+++ b/webapp/src/components/forms-and-submisions-tabs/forms-and-submisisons-tab-container.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 

--- a/webapp/src/components/group-preview/forms.tsx
+++ b/webapp/src/components/group-preview/forms.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import { Plus } from '@app/components/icons/plus';

--- a/webapp/src/components/group-preview/group-details.tsx
+++ b/webapp/src/components/group-preview/group-details.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 

--- a/webapp/src/components/group-preview/member.tsx
+++ b/webapp/src/components/group-preview/member.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useToast } from '@app/shadcn/components/ui/use-toast';
 

--- a/webapp/src/components/group/group-info.tsx
+++ b/webapp/src/components/group/group-info.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 
 import { localesCommon } from '@app/constants/locales/common';

--- a/webapp/src/components/group/group-member.tsx
+++ b/webapp/src/components/group/group-member.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import SearchInput from '@Components/common/search-input';

--- a/webapp/src/components/group/select-group.tsx
+++ b/webapp/src/components/group/select-group.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/invitation/expired.tsx
+++ b/webapp/src/components/invitation/expired.tsx
@@ -1,7 +1,7 @@
 import AuthNavbar from '@app/components/auth/auth-navbar';
 import { useAppSelector } from '@app/store/hooks';
 import { selectWorkspace } from '@app/store/workspaces/slice';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import React from 'react';
 

--- a/webapp/src/components/invitation/main-valid-user.tsx
+++ b/webapp/src/components/invitation/main-valid-user.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
 

--- a/webapp/src/components/layout/workspace-footer.tsx
+++ b/webapp/src/components/layout/workspace-footer.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import ActiveLink from '@app/components/ui/links/active-link';
 import PoweredBy from '@app/components/ui/powered-by';

--- a/webapp/src/components/member/collaborators.tsx
+++ b/webapp/src/components/member/collaborators.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { Plus } from 'lucide-react';

--- a/webapp/src/components/member/invitations.tsx
+++ b/webapp/src/components/member/invitations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import InvitationsTable from '@app/components/settings/invitations-table';
 import Loader from '@app/components/ui/loader';

--- a/webapp/src/components/modal-views/full-screen-modals/v2-preview-modal.tsx
+++ b/webapp/src/components/modal-views/full-screen-modals/v2-preview-modal.tsx
@@ -11,7 +11,7 @@ import BackButton from '@app/views/molecules/form-builder/back-button';
 import PublishButton from '@app/views/molecules/form-builder/publish-button';
 import Form from '@app/views/organism/form/form';
 import ShareIcon from '@Components/icons/share-icon';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useModal } from '../context';
 import { useFullScreenModal } from '../full-screen-modal-context';
 

--- a/webapp/src/components/modal-views/modals/add-form-group-modal.tsx
+++ b/webapp/src/components/modal-views/modals/add-form-group-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@app/shadcn/components/ui/command";

--- a/webapp/src/components/modal-views/modals/add-group-form-modal.tsx
+++ b/webapp/src/components/modal-views/modals/add-group-form-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@app/shadcn/components/ui/command";

--- a/webapp/src/components/modal-views/modals/add-members-modal.tsx
+++ b/webapp/src/components/modal-views/modals/add-members-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Close } from '@app/components/icons/close';
 import { useModal } from '@app/components/modal-views/context';

--- a/webapp/src/components/modal-views/modals/add-regex-modal.tsx
+++ b/webapp/src/components/modal-views/modals/add-regex-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import HeaderModalWrapper from '@Components/modals/modal-wrapper/header-modal-wrapper';
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/modal-views/modals/delete-confirmation-modal.tsx
+++ b/webapp/src/components/modal-views/modals/delete-confirmation-modal.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
 

--- a/webapp/src/components/modal-views/modals/delete-custom-domain-modal.tsx
+++ b/webapp/src/components/modal-views/modals/delete-custom-domain-modal.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/modal-views/modals/delete-invitation-modal.tsx
+++ b/webapp/src/components/modal-views/modals/delete-invitation-modal.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/modal-views/modals/delete-member-modal.tsx
+++ b/webapp/src/components/modal-views/modals/delete-member-modal.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/modal-views/modals/delete-template-modal-view.tsx
+++ b/webapp/src/components/modal-views/modals/delete-template-modal-view.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';

--- a/webapp/src/components/modal-views/modals/edit-workspace-modal.tsx
+++ b/webapp/src/components/modal-views/modals/edit-workspace-modal.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Close } from '@app/components/icons/close';
 import editWorkspace from '@app/constants/locales/edit-workpsace';

--- a/webapp/src/components/modal-views/modals/generate-qr-modal-view.tsx
+++ b/webapp/src/components/modal-views/modals/generate-qr-modal-view.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Divider from '@Components/common/divider';
 

--- a/webapp/src/components/modal-views/modals/invite-member-modal.tsx
+++ b/webapp/src/components/modal-views/modals/invite-member-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/modal-views/modals/sign-in-modal.tsx
+++ b/webapp/src/components/modal-views/modals/sign-in-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import Image from "next/legacy/image";
 
 import OtpCodeForm from '@app/app/(auth)/_components/otp-code-form';

--- a/webapp/src/components/modal-views/modals/visibility-confirmation-modal-view.tsx
+++ b/webapp/src/components/modal-views/modals/visibility-confirmation-modal-view.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import Divider from '@Components/common/divider';

--- a/webapp/src/components/modals/bottom-sheet-modals/create-group-modal.tsx
+++ b/webapp/src/components/modals/bottom-sheet-modals/create-group-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import BottomSheetModalWrapper from '@Components/modals/modal-wrapper/bottom-sheet-modal-wrapper';

--- a/webapp/src/components/modals/bottom-sheet-modals/delete-account-modal.tsx
+++ b/webapp/src/components/modals/bottom-sheet-modals/delete-account-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import BottomSheetModalWrapper from '@Components/modals/modal-wrapper/bottom-sheet-modal-wrapper';

--- a/webapp/src/components/modals/dialog-modals/update-custom-domain-modal.tsx
+++ b/webapp/src/components/modals/dialog-modals/update-custom-domain-modal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import HeaderModalWrapper from '@Components/modals/modal-wrapper/header-modal-wrapper';
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/modals/dialog-modals/update-workspace-handle-modal.tsx
+++ b/webapp/src/components/modals/dialog-modals/update-workspace-handle-modal.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import HeaderModalWrapper from '@Components/modals/modal-wrapper/header-modal-wrapper';

--- a/webapp/src/components/onboarding/workspace-name-input-handler.tsx
+++ b/webapp/src/components/onboarding/workspace-name-input-handler.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useCallback, useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash';
 

--- a/webapp/src/components/responder-portal/workspace-details-card.tsx
+++ b/webapp/src/components/responder-portal/workspace-details-card.tsx
@@ -2,7 +2,7 @@ import AuthAccountProfileImage from '@app/components/auth/account-profile-image'
 import ActiveLink from '@app/components/ui/links/active-link';
 import { localesCommon } from '@app/constants/locales/common';
 import { WorkspaceDto } from '@app/models/dtos/workspace-dto';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import Image from 'next/image';
 
 interface IWorkspaceDetailsCardProps {

--- a/webapp/src/components/settings/invitations-table.tsx
+++ b/webapp/src/components/settings/invitations-table.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Info } from 'lucide-react';
 import DataTable from 'react-data-table-component';

--- a/webapp/src/components/settings/members-table.tsx
+++ b/webapp/src/components/settings/members-table.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import _ from 'lodash';
 

--- a/webapp/src/components/settings/workspace-info.tsx
+++ b/webapp/src/components/settings/workspace-info.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Button } from '@app/shadcn/components/ui/button';
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/components/submission-request-for-deletion/submission-request-for-deletion.tsx
+++ b/webapp/src/components/submission-request-for-deletion/submission-request-for-deletion.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import GenericHalfModal from '@Components/common/generic-half-modal';
 

--- a/webapp/src/components/template/template-card.tsx
+++ b/webapp/src/components/template/template-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import Image from 'next/legacy/image';
 
 

--- a/webapp/src/components/template/template-section.tsx
+++ b/webapp/src/components/template/template-section.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Empty from '@Components/icons/empty';
 

--- a/webapp/src/components/template/template-settings.tsx
+++ b/webapp/src/components/template/template-settings.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Divider from '@Components/common/divider';
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/ui/customize-url-ui.tsx
+++ b/webapp/src/components/ui/customize-url-ui.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 
 import { buttonConstant } from '@app/constants/locales/button';

--- a/webapp/src/components/ui/delete-dropdown.tsx
+++ b/webapp/src/components/ui/delete-dropdown.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { MoreHorizontal, Trash2 } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@app/shadcn/components/ui/popover';
 

--- a/webapp/src/components/ui/empty-response.tsx
+++ b/webapp/src/components/ui/empty-response.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Inbox from '@app/components/icons/inbox';
 

--- a/webapp/src/components/ui/form-link-update-view.tsx
+++ b/webapp/src/components/ui/form-link-update-view.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import PrivateFormButtonWrapper from '@Components/common/private-form-button-wrapper';
 import useCopyToClipboard from 'react-use/lib/useCopyToClipboard';

--- a/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
+++ b/webapp/src/components/workspace-client/workspace-form-response-deletion-card.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { Shield as ShieldIcon } from 'lucide-react';
 

--- a/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
+++ b/webapp/src/components/workspace-dashboard/workspace-form-card.tsx
@@ -1,5 +1,5 @@
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import { DotIcon } from '@Components/icons/dot-icon';

--- a/webapp/src/components/workspace-responders/workspace-groups.tsx
+++ b/webapp/src/components/workspace-responders/workspace-groups.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import { Button } from '@app/shadcn/components/ui/button';

--- a/webapp/src/components/workspace-responders/workspace-responders.tsx
+++ b/webapp/src/components/workspace-responders/workspace-responders.tsx
@@ -2,7 +2,7 @@
 import { useState } from 'react';
 
 import { Check, Plus } from 'lucide-react';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Tooltip from '@app/shadcn/components/ui/tooltip';
 import StyledPagination from '@Components/common/pagination';

--- a/webapp/src/components/workspace/manage-urls.tsx
+++ b/webapp/src/components/workspace/manage-urls.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { CustomDomainCard } from '@app/app/(admin-portal)/(side-top-nav-layout)/[workspace_name]/dashboard/custom-domain/_components/custom-domain-client';
 import { useModal } from '@app/components/modal-views/context';

--- a/webapp/src/components/workspace/workspace-menu-dropdown.tsx
+++ b/webapp/src/components/workspace/workspace-menu-dropdown.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useRouter } from 'next/navigation';
 
 import Tooltip from '@app/shadcn/components/ui/tooltip';

--- a/webapp/src/components/workspace/workspace-settings-content.tsx
+++ b/webapp/src/components/workspace/workspace-settings-content.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 
 import ManageURLs from '@Components/workspace/manage-urls';

--- a/webapp/src/containers/upgrade-to-pro.tsx
+++ b/webapp/src/containers/upgrade-to-pro.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useFullScreenModal } from '@app/components/modal-views/full-screen-modal-context';
 import Logo, { ProLogo } from '@app/components/ui/logo';

--- a/webapp/src/lib/hooks/use-builder-translation.ts
+++ b/webapp/src/lib/hooks/use-builder-translation.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 export default function useBuilderTranslation() {
     return useTranslation('builder');

--- a/webapp/src/lib/hooks/use-group-form.ts
+++ b/webapp/src/lib/hooks/use-group-form.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useToast } from '@app/shadcn/components/ui/use-toast';

--- a/webapp/src/lib/hooks/use-group-members.ts
+++ b/webapp/src/lib/hooks/use-group-members.ts
@@ -1,4 +1,4 @@
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 
 import { useToast } from '@app/shadcn/components/ui/use-toast';
 

--- a/webapp/src/shared/hocs/i18n-provider.test.tsx
+++ b/webapp/src/shared/hocs/i18n-provider.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useTranslation } from 'react-i18next';
+import I18nProvider from '@app/shared/hocs/i18n-provider';
+
+function Probe() {
+    const { t } = useTranslation();
+    return <span>{t('MEMBERS.DEFAULT')} / {t('FORM.RESPONSES')}</span>;
+}
+
+describe('i18n after next-i18next removal', () => {
+    it('t() resolves translations through the app provider (no raw keys)', () => {
+        render(<I18nProvider><Probe /></I18nProvider>);
+        expect(screen.getByText(/Members/)).toBeDefined();
+        expect(screen.queryByText(/MEMBERS\.DEFAULT/)).toBeNull();
+    });
+});

--- a/webapp/src/views/molecules/form-builder/preview-wrapper.tsx
+++ b/webapp/src/views/molecules/form-builder/preview-wrapper.tsx
@@ -20,7 +20,7 @@ import ShareIcon from '@Components/icons/share-icon';
 import FloatingPopOverButton from '@Components/sidebar/floating-pop-over-button';
 import HelpMenuComponent from '@Components/sidebar/help-menu-component';
 import HelpMenuItem from '@Components/sidebar/help-menu-item';
-import { useTranslation } from 'next-i18next';
+import { useTranslation } from 'react-i18next';
 import PublishButton from './publish-button';
 
 const PreviewWrapper = ({ children, handleResetResponderState }: { children: React.ReactNode; handleResetResponderState: () => void }) => {

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -241,7 +241,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.29.7"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.6", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.6", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.2", "@babel/runtime@^7.18.3", "@babel/runtime@^7.20.13", "@babel/runtime@^7.20.6", "@babel/runtime@^7.9.2":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
   integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
@@ -3681,11 +3681,6 @@ copy-to-clipboard@^3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
-core-js@^3:
-  version "3.49.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.49.0.tgz#8b4d520ac034311fa21aa616f017ada0e0dbbddd"
-  integrity sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==
-
 core-util-is@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
@@ -5402,18 +5397,6 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
   integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
 
-i18next-fs-backend@^1.1.5, i18next-fs-backend@^2.6.6:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz#d7a0b4595cc3d504c9d0b267e527d2b4926d9418"
-  integrity sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==
-
-i18next@^21.9.1:
-  version "21.10.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-21.10.0.tgz#85429af55fdca4858345d0e16b584ec29520197d"
-  integrity sha512-YeuIBmFsGjUfO3qBmMOc0rQaun4mIpGKET5WDwvu8lU7gvwpcariZLNtL0Fzj+zazcHUrlXHiptcFhBMFaxzfg==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-
 i18next@^26.3.6:
   version "26.3.6"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.3.6.tgz#599db275c50b66d28a69d8f6c5162c245ce9296b"
@@ -6759,19 +6742,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next-i18next@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/next-i18next/-/next-i18next-12.1.0.tgz#70926fbe966bc4750d2f68573307bfe36eadba46"
-  integrity sha512-rhos/PVULmZPdC0jpec2MDBQMXdGZ3+Mbh/tZfrDtjgnVN3ucdq7k8BlwsJNww6FnqC8AC31n6dSYuqVzYsGsw==
-  dependencies:
-    "@babel/runtime" "^7.18.9"
-    "@types/hoist-non-react-statics" "^3.3.1"
-    core-js "^3"
-    hoist-non-react-statics "^3.3.2"
-    i18next "^21.9.1"
-    i18next-fs-backend "^1.1.5"
-    react-i18next "^11.18.4"
-
 next-line@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-line/-/next-line-1.1.0.tgz#fcae57853052b6a9bae8208e40dd7d3c2d304603"
@@ -7659,14 +7629,6 @@ react-hotkeys-hook@^4.4.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.6.2.tgz#26dd20f59d23204814f223d5c5f3979a3fe83c88"
   integrity sha512-FmP+ZriY3EG59Ug/lxNfrObCnW9xQShgk7Nb83+CkpfkcCpfS95ydv+E9JuXA5cp8KtskU7LGlIARpkc92X22Q==
-
-react-i18next@^11.18.4:
-  version "11.18.6"
-  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.6.tgz#e159c2960c718c1314f1e8fcaa282d1c8b167887"
-  integrity sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==
-  dependencies:
-    "@babel/runtime" "^7.14.5"
-    html-parse-stringify "^3.0.1"
 
 react-i18next@^12.3.1:
   version "12.3.1"


### PR DESCRIPTION
Follow-up to #601 (these two commits landed on that branch minutes after it merged).

## The breakage
After the i18next 21→26 / react-i18next 11→12 upgrade, the dashboard rendered raw translation keys (`FORM.DRAFT`, …) with the console warning *"You will need to pass in an i18next instance by using initReactI18next"*.

## Root cause
A pre-existing split-brain that the major bump exposed: `next-i18next@12` bundles its **own nested `react-i18next@11`**, and 84 files imported `useTranslation` from `next-i18next` — an instance-less copy — while the app's `I18nProvider` initialized the top-level v12.

## Fix: remove the redundant library
`next-i18next` did nothing here — app-router app, custom `I18nProvider`, no `appWithTranslation`/`serverSideTranslations`; it existed purely as an import alias. Removed it (plus the now-dead `i18next-fs-backend` resolutions pin); all 84 imports now point at `react-i18next`, the single copy the provider initializes. One library, one instance — no version-pairing trap on future upgrades.

## Verification
- New regression test renders `t()` through the real `I18nProvider` and asserts a translated string (and no raw key) comes out
- tsc clean, 207 vitest tests pass (24 files)
- Dev server restarted: forms dashboard renders translated labels, zero i18next warnings in browser telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)