### PR TITLE
feat(auth): implement PKCE verifier for Google OAuth flow and add integration tests

### DIFF
--- a/auth/auth/app/services/google_auth_provider.py
+++ b/auth/auth/app/services/google_auth_provider.py
@@ -1,4 +1,5 @@
 import json
+import secrets
 
 import loguru
 
@@ -52,19 +53,31 @@ GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/userinfo.profile",
 ]
+PKCE_VERIFIER_STATE_KEY = "pkce_code_verifier"
 
 
 class GoogleAuthProvider(BaseAuthProvider):
     async def get_basic_auth_url(self, client_referer_url: str, *args, **kwargs):
         creator = kwargs.get("creator", False)
         prospective_pro_user = kwargs.get("prospective_pro_user", False)
+        # google-auth-oauthlib 1.4 generates a PKCE challenge by default. Keep
+        # its matching verifier in the encrypted state so the callback can use
+        # the same value when exchanging the authorization code.
+        code_verifier = secrets.token_urlsafe(64)
         state_json = json.dumps(
-            {"client_referer_url": client_referer_url, "creator": creator, "prospective_pro_user": prospective_pro_user}
+            {
+                "client_referer_url": client_referer_url,
+                "creator": creator,
+                "prospective_pro_user": prospective_pro_user,
+                PKCE_VERIFIER_STATE_KEY: code_verifier,
+            }
         )
         state = crypto.encrypt(state_json)
         flow = google_auth_oauthlib.flow.Flow.from_client_config(
             client_config=client_config,
             scopes=GOOGLE_SCOPES,
+            code_verifier=code_verifier,
+            autogenerate_code_verifier=False,
         )
         flow.redirect_uri = settings.google_settings.basic_auth_redirect
 
@@ -79,14 +92,17 @@ class GoogleAuthProvider(BaseAuthProvider):
         authorization_response = (
             tmp if tmp[0:5] == "https" else tmp.replace(tmp[0:4], "https", 1)
         )
-        state_decrypted = ""
         try:
-            state_decrypted = crypto.decrypt(state)
-        except (InvalidToken, ValueError):
+            state_json = json.loads(crypto.decrypt(state))
+            code_verifier = state_json.pop(PKCE_VERIFIER_STATE_KEY)
+            if not isinstance(code_verifier, str):
+                raise ValueError("Invalid PKCE code verifier")
+        except (InvalidToken, KeyError, TypeError, ValueError):
             raise HTTPException(400, "Bad request")
-        state_json = json.loads(state_decrypted)
         credentials = self.fetch_basic_token(
-            auth_code=authorization_response, state=state
+            auth_code=authorization_response,
+            state=state,
+            code_verifier=code_verifier,
         )
         if credentials is None:
             # Token exchange failed (fetch_basic_token logged the cause). Fail
@@ -114,12 +130,13 @@ class GoogleAuthProvider(BaseAuthProvider):
         state_json["user"] = user.dict()
         return state_json
 
-
-    def fetch_basic_token(self, auth_code: str, state):
+    def fetch_basic_token(self, auth_code: str, state: str, code_verifier: str):
         flow = google_auth_oauthlib.flow.Flow.from_client_config(
             client_config=client_config,
             scopes=GOOGLE_SCOPES,
             state=state,
+            code_verifier=code_verifier,
+            autogenerate_code_verifier=False,
         )
         flow.redirect_uri = settings.google_settings.basic_auth_redirect
         try:

--- a/auth/tests/integration/app/test_google_auth_provider.py
+++ b/auth/tests/integration/app/test_google_auth_provider.py
@@ -1,0 +1,71 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock
+
+from auth.app.services import google_auth_provider
+from auth.app.services.google_auth_provider import (
+    GoogleAuthProvider,
+    PKCE_VERIFIER_STATE_KEY,
+)
+from starlette.requests import Request
+
+
+class FakeFlow:
+    calls = []
+    authorization_calls = []
+
+    @classmethod
+    def from_client_config(cls, **kwargs):
+        cls.calls.append(kwargs)
+        return cls()
+
+    def authorization_url(self, **kwargs):
+        self.authorization_calls.append(kwargs)
+        return "https://accounts.google.com/o/oauth2/auth", kwargs["state"]
+
+    def fetch_token(self, authorization_response):
+        self.authorization_response = authorization_response
+
+    @property
+    def credentials(self):
+        return object()
+
+
+def test_google_basic_auth_reuses_the_pkce_verifier(monkeypatch):
+    FakeFlow.calls = []
+    FakeFlow.authorization_calls = []
+    monkeypatch.setattr(
+        google_auth_provider.google_auth_oauthlib.flow, "Flow", FakeFlow
+    )
+
+    provider = GoogleAuthProvider()
+    provider.get_google_user = AsyncMock(return_value=None)
+
+    asyncio.run(
+        provider.get_basic_auth_url(
+            "https://admin.bettercollected.com/login", creator=True
+        )
+    )
+    state = FakeFlow.authorization_calls[0]["state"]
+    state_data = json.loads(google_auth_provider.crypto.decrypt(state))
+    code_verifier = state_data[PKCE_VERIFIER_STATE_KEY]
+
+    request = Request(
+        {
+            "type": "http",
+            "scheme": "https",
+            "server": ("bettercollected.com", 443),
+            "path": "/api/v1/auth/google/basic/callback",
+            "query_string": f"code=authorization-code&state={state}".encode(),
+            "headers": [],
+        }
+    )
+    response = asyncio.run(
+        provider.basic_auth_callback("authorization-code", state, request=request)
+    )
+
+    assert FakeFlow.calls[0]["code_verifier"] == code_verifier
+    assert FakeFlow.calls[0]["autogenerate_code_verifier"] is False
+    assert FakeFlow.calls[1]["code_verifier"] == code_verifier
+    assert FakeFlow.calls[1]["autogenerate_code_verifier"] is False
+    assert PKCE_VERIFIER_STATE_KEY not in response


### PR DESCRIPTION
## Summary
 This adds support for PKCE verifier for Updated Google OAuth flow.
Closes #<!-- issue number, if any -->

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactor / chore
- [ ] 📝 Documentation
- [ ] ⚙️ CI / build / dependencies

## Affected services

- [ ] webapp
- [ ] backend
- [x] auth
- [ ] integrations (google / typeform)
- [ ] temporal (workers)
- [ ] infra / docs

## How was this tested?

This was tested with pytests.

## Checklist

- [x] I branched from and target `develop`
- [x] Tests pass (`uv run pytest` for Python, `yarn build` / `yarn test` for webapp)
- [x] Lint/format pass (`black`/`flake8`, `yarn lint`)
- [x] I updated docs (`README`, `docs/`, relevant `AGENTS.md`) where needed
- [x] **No secrets committed** — `.env.example` files contain placeholders only
- [x] I read the [Contributing guide](../blob/develop/CONTRIBUTING.md)
