### PR TITLE
fix(backend): require workspace membership for form all-submissions

### DIFF
--- a/backend/backend/app/controllers/workspace_responses.py
+++ b/backend/backend/app/controllers/workspace_responses.py
@@ -70,11 +70,14 @@ class WorkspaceResponsesRouter(CustomRoutable):
         response_model=List[StandardFormResponseCamelModel],
     )
     async def get_workspace_form_all_submissions(
-        self, workspace_id: PydanticObjectId, form_id: str
+        self,
+        workspace_id: PydanticObjectId,
+        form_id: str,
+        user: User = Depends(get_logged_user),
     ):
         responses = (
             await self._form_response_service.get_workspace_form_all_submissions(
-                form_id, workspace_id
+                form_id, workspace_id, user
             )
         )
         return responses

--- a/backend/backend/app/services/form_response_service.py
+++ b/backend/backend/app/services/form_response_service.py
@@ -147,8 +147,25 @@ class FormResponseService:
         return form_responses
 
     async def get_workspace_form_all_submissions(
-        self, form_id: str, workspace_id: PydanticObjectId
+        self, form_id: str, workspace_id: PydanticObjectId, user: User
     ):
+        if not await self._workspace_user_repo.has_user_access_in_workspace(
+            workspace_id, user
+        ):
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN, content=MESSAGE_FORBIDDEN
+            )
+        # Scope the form to the workspace as well: without this the caller could
+        # name any workspace they belong to and read another workspace's form.
+        workspace_form = (
+            await self._workspace_form_repo.get_workspace_form_in_workspace(
+                workspace_id, form_id
+            )
+        )
+        if not workspace_form:
+            raise HTTPException(
+                HTTPStatus.NOT_FOUND, "Form not found in the workspace."
+            )
         form_responses = await FormResponseDocument.find({"form_id": form_id}).to_list()
         return self.decrypt_form_responses(
             workspace_id=workspace_id, responses=form_responses

--- a/backend/tests/app/controllers/test_workspace_form_submissions.py
+++ b/backend/tests/app/controllers/test_workspace_form_submissions.py
@@ -41,6 +41,13 @@ def get_get_form_responses_url(
 
 
 @pytest.fixture()
+def get_form_all_submissions_url(
+    common_url: str, workspace_form: Coroutine[Any, Any, FormDocument]
+):
+    return f"{common_url}/forms/{workspace_form.form_id}/all-submissions"
+
+
+@pytest.fixture()
 def get_all_workspace_responses_url(common_url: str):
     return f"{common_url}/all-submissions"
 
@@ -409,3 +416,79 @@ class TestWorkspaceFormSubmission:
         expected_response_message = "Form not found in this workspace"
         actual_response_message = single_form_response.json()
         assert actual_response_message == expected_response_message
+
+    async def test_anonymous_get_form_all_submissions_fails(
+        self,
+        client: AsyncClient,
+        published_form: Coroutine[Any, Any, FormDocument],
+        workspace_form_response: Coroutine[Any, Any, dict],
+        get_form_all_submissions_url: str,
+    ):
+        """Regression for GHSA-fxj7-cmmh-8c38: the route must never serve an
+        unauthenticated caller."""
+        form_responses = await client.get(get_form_all_submissions_url)
+
+        assert form_responses.status_code == 401
+
+    async def test_unauthorized_get_form_all_submissions_fails(
+        self,
+        client: AsyncClient,
+        test_user_cookies_1: dict[str, str],
+        published_form: Coroutine[Any, Any, FormDocument],
+        workspace_form_response: Coroutine[Any, Any, dict],
+        get_form_all_submissions_url: str,
+    ):
+        form_responses = await client.get(
+            get_form_all_submissions_url,
+            cookies=test_user_cookies_1,
+        )
+
+        expected_response = MESSAGE_FORBIDDEN
+        actual_response = form_responses.json()
+        assert form_responses.status_code == 403
+        assert actual_response == expected_response
+
+    async def test_get_form_all_submissions(
+        self,
+        client: AsyncClient,
+        test_user_cookies: dict[str, str],
+        published_form: Coroutine[Any, Any, FormDocument],
+        workspace_form_response: Coroutine[Any, Any, dict],
+        workspace_form_response_1: Coroutine[Any, Any, dict],
+        get_form_all_submissions_url: str,
+    ):
+        """A workspace member still gets the responses: the builder's Insights
+        overlay and the CSV export both read this endpoint."""
+        form_responses = await client.get(
+            get_form_all_submissions_url,
+            cookies=test_user_cookies,
+        )
+
+        expected_response_ids = {
+            workspace_form_response["response_id"],
+            workspace_form_response_1["response_id"],
+        }
+        actual_response_ids = {item["responseId"] for item in form_responses.json()}
+        assert form_responses.status_code == 200
+        assert actual_response_ids == expected_response_ids
+
+    async def test_non_workspace_form_fails_on_get_form_all_submissions(
+        self,
+        client: AsyncClient,
+        common_url: str,
+        test_user_cookies: dict[str, str],
+        workspace_form_1: Coroutine[Any, Any, FormDocument],
+    ):
+        get_non_workspace_form_url = (
+            f"{common_url}/forms/{workspace_form_1.form_id}/all-submissions"
+        )
+
+        form_responses = await client.get(
+            get_non_workspace_form_url,
+            cookies=test_user_cookies,
+        )
+
+        expected_response = "Form not found in the workspace."
+        actual_response = form_responses.json()
+        assert form_responses.status_code == 404
+        assert actual_response == expected_response


### PR DESCRIPTION
## What

`GET /workspaces/{workspace_id}/forms/{form_id}/all-submissions` was missing its authorization guard. It was the only route in `WorkspaceResponsesRouter` without `get_logged_user`, and `FormResponseService.get_workspace_form_all_submissions` performed no membership check of its own — unlike every sibling submissions endpoint in the same router.

## Change

- **Route** ([`workspace_responses.py`](backend/backend/app/controllers/workspace_responses.py)): added `user: User = Depends(get_logged_user)`.
- **Service** ([`form_response_service.py`](backend/backend/app/services/form_response_service.py)): added `has_user_access_in_workspace` (403), then a `get_workspace_form_in_workspace` lookup (404) — mirroring the guarded sibling `get_workspace_form_submissions`.

The scoping check earns its place independently of the auth check: without it, an authenticated member of any workspace could pass their own `workspace_id` together with another workspace's `form_id`.

## Compatibility

Both frontend consumers already run behind login, so no UI change is needed:

- the builder's Insights overlay — `views/organism/form-builder/flow-view.tsx`
- the CSV export — `components/datatable/form-responses.tsx`

## Tests

Four regression tests added to `tests/app/controllers/test_workspace_form_submissions.py`:

| Caller | Expected |
|---|---|
| unauthenticated | 401 |
| authenticated non-member | 403 |
| workspace member | 200, responses returned |
| member, form from another workspace | 404 |

Confirmed they fail against the unpatched service, so they genuinely regress. Full backend suite passes (231 tests).

Refs GHSA-fxj7-cmmh-8c38.
