### PR TITLE
feat(infra): add the application Postgres with per-service schemas and roles

### DIFF
--- a/.env.deployment
+++ b/.env.deployment
@@ -9,6 +9,10 @@ AUTH_JWT_SECRET=qZ86c1g6Mm4J9cVSzx6zGeppUyqDpS31
 # Mongo
 MONGO_URI=mongodb://root:root@mongodb:27017
 
+# Postgres (app database) — no key needed here: docker-compose.deployment.yml
+# injects DATABASE_URL per service from the passwords deploy.sh generates into
+# the root .env on first run (see plans/postgres-consolidation.md).
+
 # Stripe
 STRIPE_PRODUCT_ID=
 STRIPE_SECRET=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,19 @@ jobs:
                     --health-interval 10s
                     --health-timeout 5s
                     --health-retries 10
+            postgres:
+                image: postgres:16-alpine
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: bettercollected_test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U postgres -d bettercollected_test"
+                    --health-interval 5s
+                    --health-timeout 5s
+                    --health-retries 10
         defaults:
             run:
                 working-directory: backend
@@ -82,6 +95,7 @@ jobs:
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
+                  DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/bettercollected_test
                   AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
                   AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
                   SCHEDULAR_ENABLED: "False"
@@ -94,8 +108,23 @@ jobs:
         name: Auth tests (pytest)
         needs: select-runner
         runs-on: ${{ needs.select-runner.outputs.runner }}
-        # The auth suite uses an in-memory Mongo mock (mongomock-motor), so no
-        # database service is needed — only the settings the config requires.
+        # The auth suite uses an in-memory Mongo mock (mongomock-motor), so no Mongo
+        # service is needed. Postgres is provided for the repository layer that is
+        # replacing Mongo (plans/postgres-consolidation.md).
+        services:
+            postgres:
+                image: postgres:16-alpine
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: bettercollected_test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U postgres -d bettercollected_test"
+                    --health-interval 5s
+                    --health-timeout 5s
+                    --health-retries 10
         defaults:
             run:
                 working-directory: auth
@@ -117,6 +146,7 @@ jobs:
               env:
                   VIRTUAL_ENV: ""
                   DOTENV_PATH: /nonexistent.env
+                  DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/bettercollected_test
                   AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
                   AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
                   ELASTIC_APM_DISABLE_SEND: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,19 @@ jobs:
                     --health-interval 10s
                     --health-timeout 5s
                     --health-retries 10
+            postgres:
+                image: postgres:16-alpine
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: bettercollected_test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd "pg_isready -U postgres -d bettercollected_test"
+                    --health-interval 5s
+                    --health-timeout 5s
+                    --health-retries 10
         defaults:
             run:
                 working-directory: backend
@@ -46,6 +59,7 @@ jobs:
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
+                  DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/bettercollected_test
                   AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
                   AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
                   SCHEDULAR_ENABLED: "False"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ Public site: https://bettercollected.com · License: see [LICENSE](LICENSE).
 | [common/](common/) | Python package (Beanie/JWT/crypto) | — | Shared models/enums/services for all Python services |
 
 **Infra** (via `docker-compose.local.yml` / `docker-compose.deployment.yml`): **MongoDB** (app data),
+**PostgreSQL `app-postgres`** (the application database replacing MongoDB and Temporal — one schema per
+service, `app`/`auth`/`google`/`jobs`, one least-privilege role each; plan in `plans/postgres-consolidation.md`),
 **PostgreSQL + Temporal server** (workflow engine), **Redis**, **nginx** (routes the admin / client / custom-domain
 hosts), **Umami + its own PostgreSQL** (self-hosted product analytics, admin UI on `:3003` — see
 `backend/AGENTS.md` "Analytics (Umami)" and `plans/umami-self-hosted-form-analytics.md`).

--- a/auth/.env.example
+++ b/auth/.env.example
@@ -5,6 +5,10 @@ API_ROOT_PATH=/api/v1
 # Mongo
 MONGO_DB=bettercollected_auth
 MONGO_URI=mongodb://<USER>:<PASSWORD>@localhost:27017
+# Postgres — the application database replacing MongoDB and Temporal
+# (plans/postgres-consolidation.md). One role per service; the local compose
+# stack (docker-compose.local.yml, service app-postgres) creates these on first start.
+DATABASE_URL=postgresql+asyncpg://bc_auth:bc_auth@localhost:5432/bettercollected
 # Mail
 MAIL_USER=EMAIL_ADDRESS
 MAIL_PASSWORD=APP_PASSWORD or EMAIL ADDRESS PASSWORD

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,10 @@ AUTH_CALLBACK_URI=http://localhost:8001/api/v1/auth/callback
 # Mongo
 MONGO_DB=bettercollected_backend
 MONGO_URI=mongodb://<USER>:<PASSWORD>@localhost:27017
+# Postgres — the application database replacing MongoDB and Temporal
+# (plans/postgres-consolidation.md). One role per service; the local compose
+# stack (docker-compose.local.yml, service app-postgres) creates these on first start.
+DATABASE_URL=postgresql+asyncpg://bc_app:bc_app@localhost:5432/bettercollected
 # Schedular
 SCHEDULAR_INTERVAL_MINUTES=10
 # Export csv

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,6 +30,17 @@ if [ ! -f .env ] || ! grep -q "^UMAMI_APP_SECRET=" .env 2>/dev/null; then
   echo "Generated a new UMAMI_APP_SECRET in .env (first run)."
 fi
 
+# Same mechanism for the application Postgres (plans/postgres-consolidation.md):
+# docker-compose.deployment.yml substitutes the superuser password and the four
+# per-service role passwords, and postgres/init/01-roles-schemas.sh reads them on
+# the volume's first start. Hex only, so they are safe inside DATABASE_URL.
+for var in APP_POSTGRES_PASSWORD BC_APP_PASSWORD BC_AUTH_PASSWORD BC_GOOGLE_PASSWORD BC_JOBS_EXEC_PASSWORD; do
+  if ! grep -q "^${var}=" .env 2>/dev/null; then
+    echo "${var}=$(openssl rand -hex 24)" >> .env
+    echo "Generated a new ${var} in .env (first run)."
+  fi
+done
+
 # Common docker function
 function dockerup() {
   typeform_flag=false

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -1,6 +1,7 @@
 version: '3.7'
 volumes:
   mongo-data:
+  app-postgres-data:
   umami-db-data:
   temporal-postgres-data:
 services:
@@ -103,6 +104,36 @@ services:
       retries: 20
       start_period: 30s
 
+  # Application database — the consolidation target for MongoDB and Temporal
+  # (plans/postgres-consolidation.md). One schema per service (app / auth /
+  # google / jobs), one least-privilege role each, created on the volume's first
+  # start by postgres/init/01-roles-schemas.sh from the passwords below.
+  # `deploy.sh` generates APP_POSTGRES_PASSWORD and the BC_*_PASSWORD values into
+  # the root `.env` on first run (compose's var-substitution file, exactly like
+  # UMAMI_APP_SECRET). Running the compose file directly? Set them yourself —
+  # the `:?` markers make compose refuse to start with them missing rather than
+  # bring up a database with empty passwords. Major version pinned for the same
+  # reason as the Temporal postgres above.
+  app-postgres:
+    image: postgres:16-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: bettercollected
+      POSTGRES_USER: bettercollected
+      POSTGRES_PASSWORD: ${APP_POSTGRES_PASSWORD:?set by deploy.sh in the root .env}
+      BC_APP_PASSWORD: ${BC_APP_PASSWORD:?set by deploy.sh in the root .env}
+      BC_AUTH_PASSWORD: ${BC_AUTH_PASSWORD:?set by deploy.sh in the root .env}
+      BC_GOOGLE_PASSWORD: ${BC_GOOGLE_PASSWORD:?set by deploy.sh in the root .env}
+      BC_JOBS_EXEC_PASSWORD: ${BC_JOBS_EXEC_PASSWORD:?set by deploy.sh in the root .env}
+    volumes:
+      - app-postgres-data:/var/lib/postgresql/data
+      - ./postgres/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U bettercollected -d bettercollected']
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   worker:
     image: bettercollected/temporal-worker:nightly
     environment:
@@ -133,12 +164,15 @@ services:
       # Backend reaches Umami over the compose network; only UMAMI_USERNAME/
       # UMAMI_PASSWORD/UMAMI_WEBSITE_ID need to come from .env.deployment.
       UMAMI_URL: http://umami:3000
+      DATABASE_URL: postgresql+asyncpg://bc_app:${BC_APP_PASSWORD}@app-postgres:5432/bettercollected
     env_file:
       - .env.deployment
     ports:
       - '8000:8000'
     depends_on:
       temporal:
+        condition: service_healthy
+      app-postgres:
         condition: service_healthy
       mongodb:
         condition: service_healthy
@@ -161,8 +195,11 @@ services:
       STRIPE_SUCCESS_URL: ${STRIPE_REDIRECT_URL}
       STRIPE_CANCEL_URL: ${STRIPE_REDIRECT_URL}
       STRIPE_RETURN_URL: ${STRIPE_REDIRECT_URL}
+      DATABASE_URL: postgresql+asyncpg://bc_auth:${BC_AUTH_PASSWORD}@app-postgres:5432/bettercollected
     depends_on:
       mongodb:
+        condition: service_healthy
+      app-postgres:
         condition: service_healthy
     healthcheck:
       # No curl/wget in this image — use python3 (present) against /ready.
@@ -182,8 +219,13 @@ services:
 
   integrations-googleform:
     image: bettercollected/integrations-google:nightly
+    environment:
+      DATABASE_URL: postgresql+asyncpg://bc_google:${BC_GOOGLE_PASSWORD}@app-postgres:5432/bettercollected
     env_file:
       - .env.deployment
+    depends_on:
+      app-postgres:
+        condition: service_healthy
 
   # Self-hosted product analytics (see plans/umami-self-hosted-form-analytics.md).
   # First-pass exposure: plain host port 3003, no TLS/reverse-proxy — put it

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
     mongo-data:
+    app-postgres-data:
     umami-db-data:
     rustfs-data:
 
@@ -26,6 +27,32 @@ services:
             - mongodb
         restart: on-failure
         
+
+    # Application database — the consolidation target for MongoDB and Temporal
+    # (plans/postgres-consolidation.md). One database, one schema per service
+    # (app / auth / google / jobs) and one least-privilege role each, created on
+    # first start by postgres/init/01-roles-schemas.sh. Local-only credentials —
+    # deploy.sh generates real ones for deployments. Pinned major version on
+    # purpose: an unpinned tag drifts to a new major that refuses the old
+    # on-disk format (see the note on the Temporal postgres in
+    # docker-compose.deployment.yml).
+    app-postgres:
+        image: postgres:16-alpine
+        restart: unless-stopped
+        ports:
+            - '5432:5432'
+        environment:
+            POSTGRES_DB: bettercollected
+            POSTGRES_USER: bettercollected
+            POSTGRES_PASSWORD: bettercollected
+        volumes:
+            - app-postgres-data:/var/lib/postgresql/data
+            - ./postgres/init:/docker-entrypoint-initdb.d:ro
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U bettercollected -d bettercollected']
+            interval: 5s
+            timeout: 5s
+            retries: 10
 
     nginx:
         image: nginx

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,7 +120,12 @@ The backend can migrate legacy **APScheduler** jobs into Temporal Schedules on s
 - **MongoDB** — all application data via Beanie Documents. Backend collections are registered in
   [backend/app/handlers/database.py](../backend/backend/app/handlers/database.py) `init_db`; core models come from
   `common/`. A separate `apscheduler` DB holds `APSchedulerDocument`.
-- **PostgreSQL** — used only by the Temporal server (auto-setup image), not by application code.
+- **PostgreSQL (`app-postgres`)** — the application database that is replacing MongoDB and Temporal
+  (plan: [plans/postgres-consolidation.md](../plans/postgres-consolidation.md)). One database, one schema per
+  service (`app`, `auth`, `google`, `jobs`), one least-privilege role each — the actions-executor's role can reach
+  `jobs` only, because it runs user-authored code. Introduced empty; populated by dual-write and backfill.
+- **PostgreSQL (Temporal)** — used only by the Temporal server (auto-setup image), not by application code;
+  goes away with Temporal.
 - **Redis** — caching (notably in `integrations/google`).
 - **S3 (AWS/Wasabi)** — media/file uploads (`aws_service.py`); public assets on Wasabi.
 

--- a/integrations/google/.env.example
+++ b/integrations/google/.env.example
@@ -11,6 +11,10 @@ API_ROOT_PATH=/api/v1
 # Mongo
 MONGO_DB=bettercollected_googleform
 MONGO_URI=mongodb://<USER>:<PASSWORD>@localhost:27017
+# Postgres — the application database replacing MongoDB and Temporal
+# (plans/postgres-consolidation.md). One role per service; the local compose
+# stack (docker-compose.local.yml, service app-postgres) creates these on first start.
+DATABASE_URL=postgresql+asyncpg://bc_google:bc_google@localhost:5432/bettercollected
 # Google
 GOOGLE_CLIENT_TYPE=web
 GOOGLE_CLIENT_ID=

--- a/postgres/init/01-roles-schemas.sh
+++ b/postgres/init/01-roles-schemas.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Creates the application database's schemas and least-privilege roles.
+#
+# One schema per service, one role per service that owns its schema:
+#   app    <- bc_app        (backend; also owns `jobs`, the queue's tables)
+#   auth   <- bc_auth       (auth service)
+#   google <- bc_google     (integrations/google)
+#   jobs   <- bc_app        (procrastinate; the actions-executor connects as
+#                            bc_jobs_exec and can reach this schema and nothing
+#                            else — it runs user-authored code)
+#
+# Runs once, on the first start of an empty volume (docker-entrypoint-initdb.d).
+# Passwords come from the environment; the local compose stack leaves them at
+# their role-name defaults, deploy.sh generates real ones on first run.
+# See plans/postgres-consolidation.md, decision D3.
+set -euo pipefail
+
+: "${BC_APP_PASSWORD:=bc_app}"
+: "${BC_AUTH_PASSWORD:=bc_auth}"
+: "${BC_GOOGLE_PASSWORD:=bc_google}"
+: "${BC_JOBS_EXEC_PASSWORD:=bc_jobs_exec}"
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+    -v app_pw="$BC_APP_PASSWORD" \
+    -v auth_pw="$BC_AUTH_PASSWORD" \
+    -v google_pw="$BC_GOOGLE_PASSWORD" \
+    -v jobs_pw="$BC_JOBS_EXEC_PASSWORD" <<'SQL'
+CREATE ROLE bc_app       LOGIN PASSWORD :'app_pw';
+CREATE ROLE bc_auth      LOGIN PASSWORD :'auth_pw';
+CREATE ROLE bc_google    LOGIN PASSWORD :'google_pw';
+CREATE ROLE bc_jobs_exec LOGIN PASSWORD :'jobs_pw';
+
+CREATE SCHEMA app    AUTHORIZATION bc_app;
+CREATE SCHEMA auth   AUTHORIZATION bc_auth;
+CREATE SCHEMA google AUTHORIZATION bc_google;
+CREATE SCHEMA jobs   AUTHORIZATION bc_app;
+
+-- Nothing lands in `public` by accident, and only our roles may connect.
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+REVOKE CONNECT ON DATABASE :"DBNAME" FROM PUBLIC;
+GRANT  CONNECT ON DATABASE :"DBNAME" TO bc_app, bc_auth, bc_google, bc_jobs_exec;
+
+-- Each service sees its own schema first. The backend also sees `jobs`
+-- (it enqueues); the executor sees only `jobs`.
+ALTER ROLE bc_app       SET search_path = app, jobs, public;
+ALTER ROLE bc_auth      SET search_path = auth, public;
+ALTER ROLE bc_google    SET search_path = google, public;
+ALTER ROLE bc_jobs_exec SET search_path = jobs;
+
+-- The executor may use the queue's tables, sequences and functions that the
+-- backend creates in `jobs` (now and in the future) — and nothing in `app`.
+GRANT USAGE ON SCHEMA jobs TO bc_jobs_exec;
+ALTER DEFAULT PRIVILEGES FOR ROLE bc_app IN SCHEMA jobs
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO bc_jobs_exec;
+ALTER DEFAULT PRIVILEGES FOR ROLE bc_app IN SCHEMA jobs
+    GRANT USAGE, SELECT ON SEQUENCES TO bc_jobs_exec;
+ALTER DEFAULT PRIVILEGES FOR ROLE bc_app IN SCHEMA jobs
+    GRANT EXECUTE ON FUNCTIONS TO bc_jobs_exec;
+SQL


### PR DESCRIPTION
First PR of the Postgres consolidation — **phase 0, PR 1 of ~10** in `plans/postgres-consolidation.md` (D1–D6 confirmed 2026-09-06). It provisions the application database everywhere the stack is defined. **Nothing reads `DATABASE_URL` yet — no behaviour change.**

## What

| where | change |
|---|---|
| `postgres/init/01-roles-schemas.sh` | schemas `app` / `auth` / `google` / `jobs`; roles `bc_app`, `bc_auth`, `bc_google`, `bc_jobs_exec`; per-role `search_path`; `CREATE` on `public` revoked; `CONNECT` limited to our roles; default privileges so the executor can use whatever the backend creates in `jobs` — and nothing else |
| `docker-compose.local.yml` | `app-postgres` (postgres:16-alpine, pinned) on `:5432`, local-only credentials, init script mounted |
| `docker-compose.deployment.yml` | same service; `DATABASE_URL` injected into backend, auth, integrations-googleform; `depends_on: service_healthy`. Passwords via compose substitution marked `:?` — a missing value refuses to start rather than bring up a DB with empty passwords |
| `deploy.sh` | generates `APP_POSTGRES_PASSWORD` + four `BC_*_PASSWORD` into the root `.env` on first run (the `UMAMI_APP_SECRET` mechanism) |
| `ci.yml`, `test.yml` | `postgres:16` service next to mongo for backend + auth jobs; `DATABASE_URL` exported to the test steps |
| `.env.example` ×3, `AGENTS.md`, `docs/ARCHITECTURE.md`, `.env.deployment` | document the new store |

## Why the role split matters

The actions-executor runs user-authored code. Today it holds Temporal + backend credentials; after the migration it will hold a Postgres connection. `bc_jobs_exec` can reach `jobs.*` only — verified below, not assumed.

## Verified locally (fresh volume)

```
schemas: app, auth, google, jobs
roles:   bc_app(search_path=app, jobs, public)  bc_auth(auth, public)  bc_google(google, public)  bc_jobs_exec(jobs)
bc_app        creates app.probe + jobs.queue_probe                 OK
bc_jobs_exec  reads jobs.queue_probe                               OK (default privileges)
bc_jobs_exec  reads app.probe                                      permission denied for schema app
bc_jobs_exec  CREATE TABLE jobs.rogue                              permission denied for schema jobs
bc_auth       reads app.probe                                      permission denied for schema app
bc_auth       unqualified CREATE TABLE                             lands in schema auth
bc_app        CREATE TABLE public.oops                             permission denied for schema public
```
Both compose files validate; the deployment file without passwords fails with `required variable BC_JOBS_EXEC_PASSWORD is missing a value: set by deploy.sh in the root .env`.

## Notes for deploy

- **The Swarm stack (outside this repo) needs the same `app-postgres` service, volume and the five password variables** before R1 ships. Until then this is inert.
- CI service containers can't mount the init script, so CI connects as the superuser; the Alembic revisions in the next PRs `CREATE SCHEMA IF NOT EXISTS` so both paths converge.
- `plans/postgres-consolidation.md` is referenced from AGENTS.md/ARCHITECTURE.md but, like the other `plans/` docs, is not committed. Say if you'd rather have it in the repo.

Next: PR 2 — `common/db` (engine/session factory, `BaseRow`, canonical-JSON checksum, flags, outbox models) with its own tests.
