### PR TITLE
feat(db): initial Postgres schema for backend, auth and google, with Alembic

### DIFF
--- a/auth/alembic.ini
+++ b/auth/alembic.ini
@@ -1,0 +1,43 @@
+# Alembic for the auth service's schema (`auth`). Run from anywhere:
+#   uv run alembic upgrade head            (local; DATABASE_URL from the environment)
+#   /api/auth/.venv/bin/alembic -c /api/auth/alembic.ini upgrade head   (in the image; deploy.sh does this)
+[alembic]
+script_location = %(here)s/auth/migrations
+prepend_sys_path = %(here)s
+file_template = %%(rev)s_%%(slug)s
+# sqlalchemy.url is intentionally empty: env.py reads DATABASE_URL.
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/auth/auth/db/__init__.py
+++ b/auth/auth/db/__init__.py
@@ -1,0 +1,6 @@
+"""Postgres rows for the auth service (schema ``auth``) — plans/postgres-consolidation.md.
+
+This package deliberately lives beside ``app``, not inside it: importing anything
+under ``app`` runs ``app/__init__`` and boots the whole application (settings, APM,
+database clients), which Alembic and the tests must never do.
+"""

--- a/auth/auth/db/base.py
+++ b/auth/auth/db/base.py
@@ -1,0 +1,5 @@
+from common.db import SpineColumns, make_base
+
+SCHEMA = "auth"
+Base = make_base(SCHEMA)
+S = SpineColumns(SCHEMA)

--- a/auth/auth/db/models.py
+++ b/auth/auth/db/models.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from sqlalchemy import Index, UniqueConstraint
+
+from auth.db.base import S, Base
+from common.db import BaseRow, MirrorWriteFailureMixin
+
+
+class UserRow(Base, BaseRow):
+    __tablename__ = "users"
+    email = S.text("email")
+    stripe_customer_id = S.text("stripe_customer_id")
+    stripe_payment_id = S.text("stripe_payment_id")
+    otp_code_for = S.text("otp_code_for")
+    plan = S.text("plan")
+    __table_args__ = (
+        UniqueConstraint("email"),
+        Index(None, "stripe_customer_id"),
+        Index(None, "stripe_payment_id"),
+    )
+
+
+class ProviderRow(Base, BaseRow):
+    __tablename__ = "providers"
+    __mongo_collection__ = "Provider"  # no Settings.name on the Beanie document
+    provider_name = S.text("provider_name")
+    __table_args__ = (Index(None, "provider_name"),)
+
+
+class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
+    __tablename__ = "mirror_write_failures"

--- a/auth/auth/migrations/env.py
+++ b/auth/auth/migrations/env.py
@@ -1,0 +1,7 @@
+from alembic import context
+
+import auth.db.models  # noqa: F401  registers every table on Base.metadata
+from auth.db.base import SCHEMA, Base
+from common.db.alembic_support import run_migrations
+
+run_migrations(context, Base.metadata, SCHEMA)

--- a/auth/auth/migrations/script.py.mako
+++ b/auth/auth/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/auth/auth/migrations/versions/0001_initial_auth_schema.py
+++ b/auth/auth/migrations/versions/0001_initial_auth_schema.py
@@ -1,0 +1,164 @@
+"""initial auth schema
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-09-06 13:14:27.697770
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from common.db.alembic_support import (
+    create_helper_functions,
+    drop_helper_functions,
+    ensure_schema,
+)
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SCHEMA = "auth"
+
+
+def upgrade() -> None:
+    # The schema exists in deployments (postgres/init); CI and scratch databases get it here.
+    ensure_schema(op, SCHEMA)
+    # Spine columns are GENERATED from doc through these IMMUTABLE helpers, so they come first.
+    create_helper_functions(op, SCHEMA)
+    op.create_table(
+        "mirror_write_failures",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("table_name", sa.Text(), nullable=False),
+        sa.Column("row_id", sa.Text(), nullable=False),
+        sa.Column("op", sa.Text(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=False),
+        sa.Column(
+            "attempts", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("resolved_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mirror_write_failures")),
+        schema="auth",
+    )
+    op.create_table(
+        "providers",
+        sa.Column(
+            "provider_name",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'provider_name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_providers_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_providers_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_providers")),
+        schema="auth",
+    )
+    op.create_index(
+        op.f("ix_auth_providers_provider_name"),
+        "providers",
+        ["provider_name"],
+        unique=False,
+        schema="auth",
+    )
+    op.create_table(
+        "users",
+        sa.Column(
+            "email",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'email')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "stripe_customer_id",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'stripe_customer_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "stripe_payment_id",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'stripe_payment_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "otp_code_for",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'otp_code_for')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "plan",
+            sa.Text(),
+            sa.Computed("auth.bc_text(doc -> 'plan')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_users_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_users_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_users")),
+        sa.UniqueConstraint("email", name=op.f("uq_users_email")),
+        schema="auth",
+    )
+    op.create_index(
+        op.f("ix_auth_users_stripe_customer_id"),
+        "users",
+        ["stripe_customer_id"],
+        unique=False,
+        schema="auth",
+    )
+    op.create_index(
+        op.f("ix_auth_users_stripe_payment_id"),
+        "users",
+        ["stripe_payment_id"],
+        unique=False,
+        schema="auth",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_auth_users_stripe_payment_id"), table_name="users", schema="auth"
+    )
+    op.drop_index(
+        op.f("ix_auth_users_stripe_customer_id"), table_name="users", schema="auth"
+    )
+    op.drop_table("users", schema="auth")
+    op.drop_index(
+        op.f("ix_auth_providers_provider_name"), table_name="providers", schema="auth"
+    )
+    op.drop_table("providers", schema="auth")
+    op.drop_table("mirror_write_failures", schema="auth")
+    drop_helper_functions(op, SCHEMA)

--- a/auth/pyproject.toml
+++ b/auth/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 managed = true
 
 [tool.uv.sources]
-common = { path = "../common" }
+common = { path = "../common", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/auth/tests/db/test_migrations.py
+++ b/auth/tests/db/test_migrations.py
@@ -1,0 +1,111 @@
+"""The Alembic revisions must create exactly the tables the models declare, and roll back clean.
+
+Runs against a throw-away database created for the test (so the local
+app-postgres roles and the CI service database are never touched), skipped
+when DATABASE_URL is unset. Synchronous on purpose: Alembic's env.py drives its
+own event loop.
+"""
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+import auth.db.models  # noqa: F401
+from auth.db.base import SCHEMA, Base
+from common.db.alembic_support import metadata_diff
+from common.db.engine import normalise_url
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set (start app-postgres from docker-compose.local.yml)",
+)
+SERVICE_DIR = Path(__file__).resolve().parents[2]  # .../auth
+
+
+def _with_database(url: str, database: str) -> str:
+    base, _, _ = url.rpartition("/")
+    return f"{base}/{database}"
+
+
+async def _admin(url: str, statement: str) -> None:
+    engine = create_async_engine(
+        _with_database(url, "postgres"),
+        poolclass=NullPool,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text(statement))
+    finally:
+        await engine.dispose()
+
+
+async def _diff(url: str) -> list:
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            return await conn.run_sync(metadata_diff, Base.metadata, SCHEMA)
+    finally:
+        await engine.dispose()
+
+
+async def _tables(url: str) -> list[str]:
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            rows = await conn.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = :s ORDER BY 1"
+                ),
+                {"s": SCHEMA},
+            )
+            return [r[0] for r in rows]
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def scratch_url():
+    base_url = normalise_url(os.environ["DATABASE_URL"])
+    name = f"bc_migtest_{uuid.uuid4().hex[:10]}"
+    asyncio.run(_admin(base_url, f'CREATE DATABASE "{name}"'))
+    try:
+        yield _with_database(base_url, name)
+    finally:
+        asyncio.run(_admin(base_url, f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)'))
+
+
+def _config(url: str) -> Config:
+    config = Config(str(SERVICE_DIR / "alembic.ini"))
+    config.set_main_option("script_location", str(SERVICE_DIR / "auth" / "migrations"))
+    config.set_main_option("sqlalchemy.url", url)
+    return config
+
+
+def test_upgrade_head_matches_the_models_and_downgrade_base_is_clean(scratch_url):
+    config = _config(scratch_url)
+
+    command.upgrade(config, "head")
+    diffs = asyncio.run(_diff(scratch_url))
+    assert diffs == [], f"models and migrations have drifted: {diffs}"
+    created = asyncio.run(_tables(scratch_url))
+    expected = sorted(t.name for t in Base.metadata.sorted_tables) + ["alembic_version"]
+    assert created == sorted(expected)
+
+    command.downgrade(config, "base")
+    assert asyncio.run(_tables(scratch_url)) == ["alembic_version"]
+
+
+def test_upgrade_is_idempotent(scratch_url):
+    config = _config(scratch_url)
+    command.upgrade(config, "head")
+    command.upgrade(config, "head")  # nothing to do, must not fail
+    assert asyncio.run(_diff(scratch_url)) == []

--- a/auth/uv.lock
+++ b/auth/uv.lock
@@ -26,6 +26,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -211,7 +226,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "classy-fastapi", specifier = ">=0.6.0" },
-    { name = "common", directory = "../common" },
+    { name = "common", editable = "../common" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "dependency-injector", specifier = ">=4.49.1" },
     { name = "elastic-apm", specifier = ">=6.26.2" },
@@ -622,8 +637,9 @@ wheels = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = { directory = "../common" }
+source = { editable = "../common" }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "beanie" },
     { name = "cryptography" },
@@ -633,6 +649,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.19.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "beanie", specifier = ">=2.1.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
@@ -1348,6 +1365,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/cf/6780ab8bc3b84a1cce3e4400aed3d64b6db7d5e227a2f75b6ded5674701a/makefun-1.16.0.tar.gz", hash = "sha256:e14601831570bff1f6d7e68828bcd30d2f5856f24bad5de0ccb22921ceebc947", size = 73565, upload-time = "2025-05-09T15:00:42.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/c0/4bc973defd1270b89ccaae04cef0d5fa3ea85b59b108ad2c08aeea9afb76/makefun-1.16.0-py2.py3-none-any.whl", hash = "sha256:43baa4c3e7ae2b17de9ceac20b669e9a67ceeadff31581007cca20a07bbe42c4", size = 22923, upload-time = "2025-05-09T15:00:41.042Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
 ]
 
 [[package]]

--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,43 @@
+# Alembic for the backend's schema (`app`). Run from anywhere:
+#   uv run alembic upgrade head            (local; DATABASE_URL from the environment)
+#   /api/backend/.venv/bin/alembic -c /api/backend/alembic.ini upgrade head   (in the image; deploy.sh does this)
+[alembic]
+script_location = %(here)s/backend/migrations
+prepend_sys_path = %(here)s
+file_template = %%(rev)s_%%(slug)s
+# sqlalchemy.url is intentionally empty: env.py reads DATABASE_URL.
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/backend/db/__init__.py
+++ b/backend/backend/db/__init__.py
@@ -1,0 +1,9 @@
+"""Postgres rows for the backend (schema ``app``) — plans/postgres-consolidation.md.
+
+Nothing in the application reads or writes these yet; the repository layer
+lands in the following PRs. Alembic (``backend/alembic.ini``) owns the schema.
+
+This package deliberately lives beside ``app``, not inside it: importing anything
+under ``app`` runs ``app/__init__`` and boots the whole application (settings, APM,
+database clients), which Alembic and the tests must never do.
+"""

--- a/backend/backend/db/base.py
+++ b/backend/backend/db/base.py
@@ -1,0 +1,5 @@
+from common.db import SpineColumns, make_base
+
+SCHEMA = "app"
+Base = make_base(SCHEMA)
+S = SpineColumns(SCHEMA)

--- a/backend/backend/db/models.py
+++ b/backend/backend/db/models.py
@@ -1,0 +1,367 @@
+"""One table per Mongo collection: typed spine columns + the ``doc`` body.
+
+Spine columns are what the code filters, joins, sorts or requires unique on
+(measured from the repositories); everything else stays inside ``doc``.
+Indexes mirror the Mongo ``IndexModel``s plus the join keys. Two constraints
+Mongo does not enforce today (``workspace_forms`` per workspace+form,
+``workspace_users`` per workspace+user) are plain indexes here until the
+migration preflight has proven the data is duplicate-free.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import Index, UniqueConstraint, text
+
+from backend.db.base import S, Base
+from common.db import BaseRow, MirrorWriteFailureMixin
+
+
+class WorkspaceRow(Base, BaseRow):
+    __tablename__ = "workspaces"
+    workspace_name = S.text("workspace_name")
+    custom_domain = S.text("custom_domain")
+    owner_id = S.text("owner_id")
+    is_default = S.bool("default", name="is_default")
+    disabled = S.bool("disabled")
+    custom_domain_verified = S.bool("custom_domain_verified")
+    __table_args__ = (
+        UniqueConstraint("workspace_name"),
+        Index(
+            "uq_workspaces_custom_domain",
+            "custom_domain",
+            unique=True,
+            postgresql_where=text("custom_domain IS NOT NULL"),
+        ),
+        Index(None, "owner_id"),
+    )
+
+
+class WorkspaceUserRow(Base, BaseRow):
+    __tablename__ = "workspace_users"
+    workspace_id = S.text("workspace_id")
+    user_id = S.text("user_id")
+    disabled = S.bool("disabled")
+    __table_args__ = (
+        Index("ix_workspace_users_workspace_user", "workspace_id", "user_id"),
+        Index(None, "user_id"),
+    )
+
+
+class WorkspaceInviteRow(Base, BaseRow):
+    __tablename__ = "workspace_invites"
+    workspace_id = S.text("workspace_id")
+    email = S.text("email")
+    invitation_token = S.text("invitation_token")
+    invitation_status = S.text("invitation_status")
+    role = S.text("role")
+    expiry = S.int("expiry")
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "email"),
+        Index(None, "invitation_token"),
+    )
+
+
+class WorkspaceApiKeyRow(Base, BaseRow):
+    __tablename__ = "workspace_api_keys"
+    workspace_id = S.text("workspace_id")
+    key_hash = S.text("key_hash")
+    prefix = S.text("prefix")
+    created_by = S.text("created_by")
+    revoked = S.bool("revoked")
+    __table_args__ = (UniqueConstraint("key_hash"), Index(None, "workspace_id"))
+
+
+class BlacklistedRefreshTokenRow(Base, BaseRow):
+    __tablename__ = "blacklisted_refresh_tokens"
+    token = S.text("token")
+    expiry = S.ts("expiry")
+    __table_args__ = (Index(None, "token"), Index(None, "expiry"))
+
+
+class UserTagsRow(Base, BaseRow):
+    __tablename__ = "user_tags"
+    user_id = S.text("user_id")
+    __table_args__ = (Index(None, "user_id"),)
+
+
+class FormRow(Base, BaseRow):
+    __tablename__ = "forms"
+    form_id = S.text("form_id")
+    imported_form_id = S.text("imported_form_id")
+    title = S.text("title")
+    type = S.text("type")
+    builder_version = S.text("builder_version")
+    provider = S.text("settings", "provider")
+    custom_url = S.text("settings", "custom_url")
+    published_at = S.ts("published_at")
+    __table_args__ = (
+        UniqueConstraint("form_id"),
+        Index(None, "imported_form_id"),
+        Index(None, "custom_url"),
+    )
+
+
+class FormVersionRow(Base, BaseRow):
+    __tablename__ = "form_versions"
+    form_id = S.text("form_id")
+    version = S.int("version")
+    imported_form_id = S.text("imported_form_id")
+    __table_args__ = (UniqueConstraint("form_id", "version"),)
+
+
+class FormTemplateRow(Base, BaseRow):
+    __tablename__ = "form_templates"
+    workspace_id = S.text("workspace_id")
+    category = S.text("category")
+    created_by = S.text("created_by")
+    imported_from = S.text("imported_from")
+    type = S.text("type")
+    __table_args__ = (Index(None, "workspace_id"), Index(None, "category"))
+
+
+class WorkspaceFormRow(Base, BaseRow):
+    __tablename__ = "workspace_forms"
+    workspace_id = S.text("workspace_id")
+    form_id = S.text("form_id")
+    user_id = S.text("user_id")
+    custom_url = S.text("settings", "custom_url")
+    private = S.bool("settings", "private")
+    hidden = S.bool("settings", "hidden")
+    pinned = S.bool("settings", "pinned")
+    __table_args__ = (
+        Index("ix_workspace_forms_workspace_form", "workspace_id", "form_id"),
+        Index(None, "form_id"),
+        Index("ix_workspace_forms_workspace_custom_url", "workspace_id", "custom_url"),
+    )
+
+
+class MediaLibraryRow(Base, BaseRow):
+    __tablename__ = "media_libraries"
+    workspace_id = S.text("workspace_id")
+    media_name = S.text("media_name")
+    media_type = S.text("media_type")
+    s3_key = S.text("s3_key")
+    __table_args__ = (Index(None, "workspace_id"),)
+
+
+class WorkspaceConsentRow(Base, BaseRow):
+    __tablename__ = "workspace_consent"
+    workspace_id = S.text("workspace_id")
+    __table_args__ = (Index(None, "workspace_id"),)
+
+
+class SchedulerFormConfigRow(Base, BaseRow):
+    __tablename__ = "scheduler_form_configs"
+    form_id = S.text("form_id")
+    workspace_id = S.text("workspace_id")
+    provider = S.text("provider")
+    imported_at = S.ts("imported_at")
+    __table_args__ = (Index(None, "form_id"), Index(None, "workspace_id"))
+
+
+class FormResponseRow(Base, BaseRow):
+    __tablename__ = "form_responses"
+    form_id = S.text("form_id")
+    response_id = S.text("response_id")
+    submission_uuid = S.text("submission_uuid")
+    provider = S.text("provider")
+    data_owner_identifier = S.text("dataOwnerIdentifier", name="data_owner_identifier")
+    anonymous_identity = S.text("anonymous_identity")
+    form_version = S.int("form_version")
+    expiration = S.text("expiration")
+    expiration_type = S.text("expiration_type")
+    state = S.text("state")
+    __table_args__ = (
+        UniqueConstraint("response_id"),
+        Index("ix_form_responses_form_created", "form_id", "created_at"),
+        Index(None, "submission_uuid"),
+        Index(None, "data_owner_identifier"),
+        Index(None, "anonymous_identity"),
+        Index(None, "expiration"),
+    )
+
+
+class ResponseDeletionRequestRow(Base, BaseRow):
+    __tablename__ = "responses_deletion_requests"
+    form_id = S.text("form_id")
+    response_id = S.text("response_id")
+    provider = S.text("provider")
+    status = S.text("status")
+    data_owner_identifier = S.text("dataOwnerIdentifier", name="data_owner_identifier")
+    anonymous_identity = S.text("anonymous_identity")
+    __table_args__ = (
+        # Mongo's unique index treats a missing provider as one value; NULLS NOT DISTINCT keeps that.
+        UniqueConstraint(
+            "form_id", "response_id", "provider", postgresql_nulls_not_distinct=True
+        ),
+        Index(None, "status"),
+    )
+
+
+class WorkspaceResponderRow(Base, BaseRow):
+    __tablename__ = "workspace_responder"
+    workspace_id = S.text("workspace_id")
+    user_id = S.text("user_id")
+    email = S.text("email")
+    __table_args__ = (
+        Index("ix_workspace_responder_workspace_email", "workspace_id", "email"),
+    )
+
+
+class WorkspaceTagRow(Base, BaseRow):
+    __tablename__ = "workspace_tags"
+    workspace_id = S.text("workspace_id")
+    title = S.text("title")
+    __table_args__ = (Index(None, "workspace_id"),)
+
+
+class ResponderGroupRow(Base, BaseRow):
+    __tablename__ = "responder_group"
+    workspace_id = S.text("workspace_id")
+    name = S.text("name")
+    __table_args__ = (Index(None, "workspace_id"),)
+
+
+class ResponderGroupFormRow(Base, BaseRow):
+    __tablename__ = "responder_group_form"
+    group_id = S.text("group_id")
+    form_id = S.text("form_id")
+    role = S.text("role")
+    __table_args__ = (Index(None, "group_id"), Index(None, "form_id"))
+
+
+class ResponderGroupMemberRow(Base, BaseRow):
+    __tablename__ = "responder_group_member"
+    group_id = S.text("group_id")
+    identifier = S.text("identifier")
+    identifier_type = S.text("identifierType", name="identifier_type")
+    __table_args__ = (
+        Index("ix_responder_group_member_group_identifier", "group_id", "identifier"),
+    )
+
+
+class ActionRow(Base, BaseRow):
+    __tablename__ = "actions"
+    name = S.text("name")
+    created_by = S.text("created_by")
+    type = S.text("type")
+    predefined = S.bool("predefined")
+    __table_args__ = (Index(None, "created_by"), Index(None, "name"))
+
+
+class WorkspaceActionRow(Base, BaseRow):
+    __tablename__ = "workspace_actions"
+    workspace_id = S.text("workspace_id")
+    action_id = S.text("action_id")
+    __table_args__ = (
+        Index("ix_workspace_actions_workspace_action", "workspace_id", "action_id"),
+    )
+
+
+class AiPreferenceMemoryRow(Base, BaseRow):
+    __tablename__ = "ai_preference_memories"
+    workspace_id = S.text("workspace_id")
+    user_id = S.text("user_id")
+    __table_args__ = (
+        Index("ix_ai_preference_memories_workspace_user", "workspace_id", "user_id"),
+    )
+
+
+class FormAiSessionRow(Base, BaseRow):
+    __tablename__ = "form_ai_sessions"
+    workspace_id = S.text("workspace_id")
+    form_id = S.text("form_id")
+    user_id = S.text("user_id")
+    provider = S.text("provider")
+    __table_args__ = (
+        Index(
+            "ix_form_ai_sessions_workspace_form_user",
+            "workspace_id",
+            "form_id",
+            "user_id",
+        ),
+    )
+
+
+class FormAiInsightRow(Base, BaseRow):
+    __tablename__ = "form_ai_insights"
+    workspace_id = S.text("workspace_id")
+    form_id = S.text("form_id")
+    generated_at = S.ts("generated_at")
+    __table_args__ = (
+        Index("ix_form_ai_insights_workspace_form", "workspace_id", "form_id"),
+    )
+
+
+class WorkspaceAiProfileRow(Base, BaseRow):
+    __tablename__ = "workspace_ai_profiles"
+    workspace_id = S.text("workspace_id")
+    __table_args__ = (UniqueConstraint("workspace_id"),)
+
+
+class McpAuditLogRow(Base, BaseRow):
+    __tablename__ = "mcp_audit_logs"
+    workspace_id = S.text("workspace_id")
+    key_id = S.text("key_id")
+    tool = S.text("tool")
+    ok = S.bool("ok")
+    at = S.ts("at")
+    __table_args__ = (Index("ix_mcp_audit_logs_workspace_at", "workspace_id", "at"),)
+
+
+class CreateFormPromptRow(Base, BaseRow):
+    __tablename__ = "create_form_prompts"
+    form_id = S.text("form_id")
+    __table_args__ = (Index(None, "form_id"),)
+
+
+class FormFlowEventRow(Base, BaseRow):
+    __tablename__ = "form_flow_events"
+    form_id = S.text("form_id")
+    session_id = S.text("session_id")
+    from_page = S.text("from_page")
+    to_page = S.text("to_page")
+    __table_args__ = (
+        Index(None, "form_id"),
+        Index(None, "session_id"),
+        Index(None, "created_at"),
+    )
+
+
+class AllowedOriginRow(Base, BaseRow):
+    __tablename__ = "allowed_origins"
+    origin = S.text("origin")
+    __table_args__ = (Index(None, "origin"),)
+
+
+class FormPluginConfigRow(Base, BaseRow):
+    __tablename__ = "forms_plugin_configs"
+    provider_name = S.text("provider_name")
+    enabled = S.bool("enabled")
+    __table_args__ = (Index(None, "provider_name"),)
+
+
+class CouponCodeRow(Base, BaseRow):
+    __tablename__ = "coupon_codes"
+    code = S.text("code")
+    status = S.text("status")
+    used_by = S.text("used_by")
+    __table_args__ = (UniqueConstraint("code"),)
+
+
+class PriceSuggestionRow(Base, BaseRow):
+    __tablename__ = "price_suggestion"
+    user_id = S.text("user_id")
+    email = S.text("email")
+    __table_args__ = (Index(None, "user_id"),)
+
+
+class UserFeedbackRow(Base, BaseRow):
+    __tablename__ = "user_feedback"
+
+
+class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
+    __tablename__ = "mirror_write_failures"
+
+
+ROW_MODELS = [cls for cls in Base.__subclasses__() if issubclass(cls, BaseRow)]

--- a/backend/backend/migrations/env.py
+++ b/backend/backend/migrations/env.py
@@ -1,0 +1,7 @@
+from alembic import context
+
+import backend.db.models  # noqa: F401  registers every table on Base.metadata
+from backend.db.base import SCHEMA, Base
+from common.db.alembic_support import run_migrations
+
+run_migrations(context, Base.metadata, SCHEMA)

--- a/backend/backend/migrations/script.py.mako
+++ b/backend/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/backend/migrations/versions/0001_initial_app_schema.py
+++ b/backend/backend/migrations/versions/0001_initial_app_schema.py
@@ -1,0 +1,2032 @@
+"""initial app schema
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-09-06 13:13:40.199412
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from common.db.alembic_support import (
+    create_helper_functions,
+    drop_helper_functions,
+    ensure_schema,
+)
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    # The schema exists in deployments (postgres/init); CI and scratch databases get it here.
+    ensure_schema(op, SCHEMA)
+    # Spine columns are GENERATED from doc through these IMMUTABLE helpers, so they come first.
+    create_helper_functions(op, SCHEMA)
+    op.create_table(
+        "actions",
+        sa.Column(
+            "name",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_by",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'created_by')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'type')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "predefined",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'predefined')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_actions_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_actions_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_actions")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_actions_created_by"),
+        "actions",
+        ["created_by"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_actions_name"), "actions", ["name"], unique=False, schema="app"
+    )
+    op.create_table(
+        "ai_preference_memories",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_ai_preference_memories_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_ai_preference_memories_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ai_preference_memories")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_ai_preference_memories_workspace_user",
+        "ai_preference_memories",
+        ["workspace_id", "user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "allowed_origins",
+        sa.Column(
+            "origin",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'origin')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_allowed_origins_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_allowed_origins_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_allowed_origins")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_allowed_origins_origin"),
+        "allowed_origins",
+        ["origin"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "blacklisted_refresh_tokens",
+        sa.Column(
+            "token",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'token')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "expiry",
+            postgresql.TIMESTAMP(timezone=True),
+            sa.Computed("app.bc_ts(doc -> 'expiry')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_blacklisted_refresh_tokens_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_blacklisted_refresh_tokens_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_blacklisted_refresh_tokens")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_blacklisted_refresh_tokens_expiry"),
+        "blacklisted_refresh_tokens",
+        ["expiry"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_blacklisted_refresh_tokens_token"),
+        "blacklisted_refresh_tokens",
+        ["token"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "coupon_codes",
+        sa.Column(
+            "code",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'code')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'status')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "used_by",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'used_by')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_coupon_codes_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_coupon_codes_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_coupon_codes")),
+        sa.UniqueConstraint("code", name=op.f("uq_coupon_codes_code")),
+        schema="app",
+    )
+    op.create_table(
+        "create_form_prompts",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_create_form_prompts_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_create_form_prompts_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_create_form_prompts")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_create_form_prompts_form_id"),
+        "create_form_prompts",
+        ["form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_ai_insights",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "generated_at",
+            postgresql.TIMESTAMP(timezone=True),
+            sa.Computed("app.bc_ts(doc -> 'generated_at')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_ai_insights_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_ai_insights_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_ai_insights")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_form_ai_insights_workspace_form",
+        "form_ai_insights",
+        ["workspace_id", "form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_ai_sessions",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_ai_sessions_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_ai_sessions_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_ai_sessions")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_form_ai_sessions_workspace_form_user",
+        "form_ai_sessions",
+        ["workspace_id", "form_id", "user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_flow_events",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "session_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'session_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "from_page",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'from_page')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "to_page",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'to_page')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_flow_events_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_flow_events_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_flow_events")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_flow_events_created_at"),
+        "form_flow_events",
+        ["created_at"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_flow_events_form_id"),
+        "form_flow_events",
+        ["form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_flow_events_session_id"),
+        "form_flow_events",
+        ["session_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_responses",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "response_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'response_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "submission_uuid",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'submission_uuid')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "data_owner_identifier",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'dataOwnerIdentifier')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "anonymous_identity",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'anonymous_identity')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "form_version",
+            sa.BigInteger(),
+            sa.Computed("app.bc_int(doc -> 'form_version')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "expiration",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'expiration')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "expiration_type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'expiration_type')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "state",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'state')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_responses_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_responses_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_responses")),
+        sa.UniqueConstraint("response_id", name=op.f("uq_form_responses_response_id")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_responses_anonymous_identity"),
+        "form_responses",
+        ["anonymous_identity"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_responses_data_owner_identifier"),
+        "form_responses",
+        ["data_owner_identifier"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_responses_expiration"),
+        "form_responses",
+        ["expiration"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_responses_submission_uuid"),
+        "form_responses",
+        ["submission_uuid"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        "ix_form_responses_form_created",
+        "form_responses",
+        ["form_id", "created_at"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_templates",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "category",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'category')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_by",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'created_by')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "imported_from",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'imported_from')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'type')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_templates_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_templates_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_templates")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_templates_category"),
+        "form_templates",
+        ["category"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_form_templates_workspace_id"),
+        "form_templates",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "form_versions",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "version",
+            sa.BigInteger(),
+            sa.Computed("app.bc_int(doc -> 'version')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "imported_form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'imported_form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_form_versions_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_form_versions_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_form_versions")),
+        sa.UniqueConstraint(
+            "form_id", "version", name=op.f("uq_form_versions_form_id_version")
+        ),
+        schema="app",
+    )
+    op.create_table(
+        "forms",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "imported_form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'imported_form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "title",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'title')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'type')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "builder_version",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'builder_version')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc #> '{settings,provider}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "custom_url",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc #> '{settings,custom_url}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "published_at",
+            postgresql.TIMESTAMP(timezone=True),
+            sa.Computed("app.bc_ts(doc -> 'published_at')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_forms_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_forms_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_forms")),
+        sa.UniqueConstraint("form_id", name=op.f("uq_forms_form_id")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_forms_custom_url"),
+        "forms",
+        ["custom_url"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_forms_imported_form_id"),
+        "forms",
+        ["imported_form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "forms_plugin_configs",
+        sa.Column(
+            "provider_name",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'provider_name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'enabled')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_forms_plugin_configs_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_forms_plugin_configs_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_forms_plugin_configs")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_forms_plugin_configs_provider_name"),
+        "forms_plugin_configs",
+        ["provider_name"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "mcp_audit_logs",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "key_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'key_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "tool",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'tool')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "ok",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'ok')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "at",
+            postgresql.TIMESTAMP(timezone=True),
+            sa.Computed("app.bc_ts(doc -> 'at')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_mcp_audit_logs_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_mcp_audit_logs_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mcp_audit_logs")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_mcp_audit_logs_workspace_at",
+        "mcp_audit_logs",
+        ["workspace_id", "at"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "media_libraries",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "media_name",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'media_name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "media_type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'media_type')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "s3_key",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 's3_key')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_media_libraries_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_media_libraries_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_media_libraries")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_media_libraries_workspace_id"),
+        "media_libraries",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "mirror_write_failures",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("table_name", sa.Text(), nullable=False),
+        sa.Column("row_id", sa.Text(), nullable=False),
+        sa.Column("op", sa.Text(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=False),
+        sa.Column(
+            "attempts", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("resolved_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mirror_write_failures")),
+        schema="app",
+    )
+    op.create_table(
+        "price_suggestion",
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "email",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'email')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_price_suggestion_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_price_suggestion_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_price_suggestion")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_price_suggestion_user_id"),
+        "price_suggestion",
+        ["user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "responder_group",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "name",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_responder_group_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_responder_group_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_responder_group")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_responder_group_workspace_id"),
+        "responder_group",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "responder_group_form",
+        sa.Column(
+            "group_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'group_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "role",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'role')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_responder_group_form_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_responder_group_form_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_responder_group_form")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_responder_group_form_form_id"),
+        "responder_group_form",
+        ["form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_responder_group_form_group_id"),
+        "responder_group_form",
+        ["group_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "responder_group_member",
+        sa.Column(
+            "group_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'group_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "identifier",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'identifier')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "identifier_type",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'identifierType')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_responder_group_member_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_responder_group_member_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_responder_group_member")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_responder_group_member_group_identifier",
+        "responder_group_member",
+        ["group_id", "identifier"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "responses_deletion_requests",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "response_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'response_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'status')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "data_owner_identifier",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'dataOwnerIdentifier')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "anonymous_identity",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'anonymous_identity')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_responses_deletion_requests_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_responses_deletion_requests_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_responses_deletion_requests")),
+        sa.UniqueConstraint(
+            "form_id",
+            "response_id",
+            "provider",
+            name=op.f("uq_responses_deletion_requests_form_id_response_id_provider"),
+            postgresql_nulls_not_distinct=True,
+        ),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_responses_deletion_requests_status"),
+        "responses_deletion_requests",
+        ["status"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "scheduler_form_configs",
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "imported_at",
+            postgresql.TIMESTAMP(timezone=True),
+            sa.Computed("app.bc_ts(doc -> 'imported_at')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_scheduler_form_configs_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_scheduler_form_configs_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_scheduler_form_configs")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_scheduler_form_configs_form_id"),
+        "scheduler_form_configs",
+        ["form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_scheduler_form_configs_workspace_id"),
+        "scheduler_form_configs",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "user_feedback",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_user_feedback_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_user_feedback_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_feedback")),
+        schema="app",
+    )
+    op.create_table(
+        "user_tags",
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_user_tags_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_user_tags_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_user_tags")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_user_tags_user_id"),
+        "user_tags",
+        ["user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_actions",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "action_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'action_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_actions_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_actions_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_actions")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_workspace_actions_workspace_action",
+        "workspace_actions",
+        ["workspace_id", "action_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_ai_profiles",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_ai_profiles_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_workspace_ai_profiles_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_ai_profiles")),
+        sa.UniqueConstraint(
+            "workspace_id", name=op.f("uq_workspace_ai_profiles_workspace_id")
+        ),
+        schema="app",
+    )
+    op.create_table(
+        "workspace_api_keys",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "key_hash",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'key_hash')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "prefix",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'prefix')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_by",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'created_by')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "revoked",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'revoked')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_api_keys_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_api_keys_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_api_keys")),
+        sa.UniqueConstraint("key_hash", name=op.f("uq_workspace_api_keys_key_hash")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_api_keys_workspace_id"),
+        "workspace_api_keys",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_consent",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_consent_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_consent_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_consent")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_consent_workspace_id"),
+        "workspace_consent",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_forms",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "form_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'form_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "custom_url",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc #> '{settings,custom_url}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "private",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc #> '{settings,private}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "hidden",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc #> '{settings,hidden}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "pinned",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc #> '{settings,pinned}')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_forms_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_forms_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_forms")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_forms_form_id"),
+        "workspace_forms",
+        ["form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        "ix_workspace_forms_workspace_custom_url",
+        "workspace_forms",
+        ["workspace_id", "custom_url"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        "ix_workspace_forms_workspace_form",
+        "workspace_forms",
+        ["workspace_id", "form_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_invites",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "email",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'email')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "invitation_token",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'invitation_token')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "invitation_status",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'invitation_status')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "role",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'role')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "expiry",
+            sa.BigInteger(),
+            sa.Computed("app.bc_int(doc -> 'expiry')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_invites_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_invites_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_invites")),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "email",
+            name=op.f("uq_workspace_invites_workspace_id_email"),
+        ),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_invites_invitation_token"),
+        "workspace_invites",
+        ["invitation_token"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_responder",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "email",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'email')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_responder_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_responder_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_responder")),
+        schema="app",
+    )
+    op.create_index(
+        "ix_workspace_responder_workspace_email",
+        "workspace_responder",
+        ["workspace_id", "email"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_tags",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "title",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'title')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_tags_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_tags_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_tags")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_tags_workspace_id"),
+        "workspace_tags",
+        ["workspace_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspace_users",
+        sa.Column(
+            "workspace_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "disabled",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'disabled')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_workspace_users_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspace_users_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspace_users")),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspace_users_user_id"),
+        "workspace_users",
+        ["user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        "ix_workspace_users_workspace_user",
+        "workspace_users",
+        ["workspace_id", "user_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_table(
+        "workspaces",
+        sa.Column(
+            "workspace_name",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'workspace_name')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "custom_domain",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'custom_domain')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "owner_id",
+            sa.Text(),
+            sa.Computed("app.bc_text(doc -> 'owner_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'default')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "disabled",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'disabled')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "custom_domain_verified",
+            sa.Boolean(),
+            sa.Computed("app.bc_bool(doc -> 'custom_domain_verified')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')", name=op.f("ck_workspaces_id_matches_doc")
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_workspaces_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_workspaces")),
+        sa.UniqueConstraint(
+            "workspace_name", name=op.f("uq_workspaces_workspace_name")
+        ),
+        schema="app",
+    )
+    op.create_index(
+        op.f("ix_app_workspaces_owner_id"),
+        "workspaces",
+        ["owner_id"],
+        unique=False,
+        schema="app",
+    )
+    op.create_index(
+        "uq_workspaces_custom_domain",
+        "workspaces",
+        ["custom_domain"],
+        unique=True,
+        schema="app",
+        postgresql_where=sa.text("custom_domain IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_workspaces_custom_domain",
+        table_name="workspaces",
+        schema="app",
+        postgresql_where=sa.text("custom_domain IS NOT NULL"),
+    )
+    op.drop_index(
+        op.f("ix_app_workspaces_owner_id"), table_name="workspaces", schema="app"
+    )
+    op.drop_table("workspaces", schema="app")
+    op.drop_index(
+        "ix_workspace_users_workspace_user", table_name="workspace_users", schema="app"
+    )
+    op.drop_index(
+        op.f("ix_app_workspace_users_user_id"),
+        table_name="workspace_users",
+        schema="app",
+    )
+    op.drop_table("workspace_users", schema="app")
+    op.drop_index(
+        op.f("ix_app_workspace_tags_workspace_id"),
+        table_name="workspace_tags",
+        schema="app",
+    )
+    op.drop_table("workspace_tags", schema="app")
+    op.drop_index(
+        "ix_workspace_responder_workspace_email",
+        table_name="workspace_responder",
+        schema="app",
+    )
+    op.drop_table("workspace_responder", schema="app")
+    op.drop_index(
+        op.f("ix_app_workspace_invites_invitation_token"),
+        table_name="workspace_invites",
+        schema="app",
+    )
+    op.drop_table("workspace_invites", schema="app")
+    op.drop_index(
+        "ix_workspace_forms_workspace_form", table_name="workspace_forms", schema="app"
+    )
+    op.drop_index(
+        "ix_workspace_forms_workspace_custom_url",
+        table_name="workspace_forms",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_workspace_forms_form_id"),
+        table_name="workspace_forms",
+        schema="app",
+    )
+    op.drop_table("workspace_forms", schema="app")
+    op.drop_index(
+        op.f("ix_app_workspace_consent_workspace_id"),
+        table_name="workspace_consent",
+        schema="app",
+    )
+    op.drop_table("workspace_consent", schema="app")
+    op.drop_index(
+        op.f("ix_app_workspace_api_keys_workspace_id"),
+        table_name="workspace_api_keys",
+        schema="app",
+    )
+    op.drop_table("workspace_api_keys", schema="app")
+    op.drop_table("workspace_ai_profiles", schema="app")
+    op.drop_index(
+        "ix_workspace_actions_workspace_action",
+        table_name="workspace_actions",
+        schema="app",
+    )
+    op.drop_table("workspace_actions", schema="app")
+    op.drop_index(
+        op.f("ix_app_user_tags_user_id"), table_name="user_tags", schema="app"
+    )
+    op.drop_table("user_tags", schema="app")
+    op.drop_table("user_feedback", schema="app")
+    op.drop_index(
+        op.f("ix_app_scheduler_form_configs_workspace_id"),
+        table_name="scheduler_form_configs",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_scheduler_form_configs_form_id"),
+        table_name="scheduler_form_configs",
+        schema="app",
+    )
+    op.drop_table("scheduler_form_configs", schema="app")
+    op.drop_index(
+        op.f("ix_app_responses_deletion_requests_status"),
+        table_name="responses_deletion_requests",
+        schema="app",
+    )
+    op.drop_table("responses_deletion_requests", schema="app")
+    op.drop_index(
+        "ix_responder_group_member_group_identifier",
+        table_name="responder_group_member",
+        schema="app",
+    )
+    op.drop_table("responder_group_member", schema="app")
+    op.drop_index(
+        op.f("ix_app_responder_group_form_group_id"),
+        table_name="responder_group_form",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_responder_group_form_form_id"),
+        table_name="responder_group_form",
+        schema="app",
+    )
+    op.drop_table("responder_group_form", schema="app")
+    op.drop_index(
+        op.f("ix_app_responder_group_workspace_id"),
+        table_name="responder_group",
+        schema="app",
+    )
+    op.drop_table("responder_group", schema="app")
+    op.drop_index(
+        op.f("ix_app_price_suggestion_user_id"),
+        table_name="price_suggestion",
+        schema="app",
+    )
+    op.drop_table("price_suggestion", schema="app")
+    op.drop_table("mirror_write_failures", schema="app")
+    op.drop_index(
+        op.f("ix_app_media_libraries_workspace_id"),
+        table_name="media_libraries",
+        schema="app",
+    )
+    op.drop_table("media_libraries", schema="app")
+    op.drop_index(
+        "ix_mcp_audit_logs_workspace_at", table_name="mcp_audit_logs", schema="app"
+    )
+    op.drop_table("mcp_audit_logs", schema="app")
+    op.drop_index(
+        op.f("ix_app_forms_plugin_configs_provider_name"),
+        table_name="forms_plugin_configs",
+        schema="app",
+    )
+    op.drop_table("forms_plugin_configs", schema="app")
+    op.drop_index(
+        op.f("ix_app_forms_imported_form_id"), table_name="forms", schema="app"
+    )
+    op.drop_index(op.f("ix_app_forms_custom_url"), table_name="forms", schema="app")
+    op.drop_table("forms", schema="app")
+    op.drop_table("form_versions", schema="app")
+    op.drop_index(
+        op.f("ix_app_form_templates_workspace_id"),
+        table_name="form_templates",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_templates_category"),
+        table_name="form_templates",
+        schema="app",
+    )
+    op.drop_table("form_templates", schema="app")
+    op.drop_index(
+        "ix_form_responses_form_created", table_name="form_responses", schema="app"
+    )
+    op.drop_index(
+        op.f("ix_app_form_responses_submission_uuid"),
+        table_name="form_responses",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_responses_expiration"),
+        table_name="form_responses",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_responses_data_owner_identifier"),
+        table_name="form_responses",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_responses_anonymous_identity"),
+        table_name="form_responses",
+        schema="app",
+    )
+    op.drop_table("form_responses", schema="app")
+    op.drop_index(
+        op.f("ix_app_form_flow_events_session_id"),
+        table_name="form_flow_events",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_flow_events_form_id"),
+        table_name="form_flow_events",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_form_flow_events_created_at"),
+        table_name="form_flow_events",
+        schema="app",
+    )
+    op.drop_table("form_flow_events", schema="app")
+    op.drop_index(
+        "ix_form_ai_sessions_workspace_form_user",
+        table_name="form_ai_sessions",
+        schema="app",
+    )
+    op.drop_table("form_ai_sessions", schema="app")
+    op.drop_index(
+        "ix_form_ai_insights_workspace_form",
+        table_name="form_ai_insights",
+        schema="app",
+    )
+    op.drop_table("form_ai_insights", schema="app")
+    op.drop_index(
+        op.f("ix_app_create_form_prompts_form_id"),
+        table_name="create_form_prompts",
+        schema="app",
+    )
+    op.drop_table("create_form_prompts", schema="app")
+    op.drop_table("coupon_codes", schema="app")
+    op.drop_index(
+        op.f("ix_app_blacklisted_refresh_tokens_token"),
+        table_name="blacklisted_refresh_tokens",
+        schema="app",
+    )
+    op.drop_index(
+        op.f("ix_app_blacklisted_refresh_tokens_expiry"),
+        table_name="blacklisted_refresh_tokens",
+        schema="app",
+    )
+    op.drop_table("blacklisted_refresh_tokens", schema="app")
+    op.drop_index(
+        op.f("ix_app_allowed_origins_origin"),
+        table_name="allowed_origins",
+        schema="app",
+    )
+    op.drop_table("allowed_origins", schema="app")
+    op.drop_index(
+        "ix_ai_preference_memories_workspace_user",
+        table_name="ai_preference_memories",
+        schema="app",
+    )
+    op.drop_table("ai_preference_memories", schema="app")
+    op.drop_index(op.f("ix_app_actions_name"), table_name="actions", schema="app")
+    op.drop_index(op.f("ix_app_actions_created_by"), table_name="actions", schema="app")
+    op.drop_table("actions", schema="app")
+    drop_helper_functions(op, SCHEMA)

--- a/backend/tests/app/db/test_migrations.py
+++ b/backend/tests/app/db/test_migrations.py
@@ -1,0 +1,113 @@
+"""The Alembic revisions must create exactly the tables the models declare, and roll back clean.
+
+Runs against a throw-away database created for the test (so the local
+app-postgres roles and the CI service database are never touched), skipped
+when DATABASE_URL is unset. Synchronous on purpose: Alembic's env.py drives its
+own event loop.
+"""
+
+import asyncio
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+import backend.db.models  # noqa: F401
+from backend.db.base import SCHEMA, Base
+from common.db.alembic_support import metadata_diff
+from common.db.engine import normalise_url
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set (start app-postgres from docker-compose.local.yml)",
+)
+SERVICE_DIR = Path(__file__).resolve().parents[3]  # .../backend
+
+
+def _with_database(url: str, database: str) -> str:
+    base, _, _ = url.rpartition("/")
+    return f"{base}/{database}"
+
+
+async def _admin(url: str, statement: str) -> None:
+    engine = create_async_engine(
+        _with_database(url, "postgres"),
+        poolclass=NullPool,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text(statement))
+    finally:
+        await engine.dispose()
+
+
+async def _diff(url: str) -> list:
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            return await conn.run_sync(metadata_diff, Base.metadata, SCHEMA)
+    finally:
+        await engine.dispose()
+
+
+async def _tables(url: str) -> list[str]:
+    engine = create_async_engine(url, poolclass=NullPool)
+    try:
+        async with engine.connect() as conn:
+            rows = await conn.execute(
+                text(
+                    "SELECT table_name FROM information_schema.tables WHERE table_schema = :s ORDER BY 1"
+                ),
+                {"s": SCHEMA},
+            )
+            return [r[0] for r in rows]
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def scratch_url():
+    base_url = normalise_url(os.environ["DATABASE_URL"])
+    name = f"bc_migtest_{uuid.uuid4().hex[:10]}"
+    asyncio.run(_admin(base_url, f'CREATE DATABASE "{name}"'))
+    try:
+        yield _with_database(base_url, name)
+    finally:
+        asyncio.run(_admin(base_url, f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)'))
+
+
+def _config(url: str) -> Config:
+    config = Config(str(SERVICE_DIR / "alembic.ini"))
+    config.set_main_option(
+        "script_location", str(SERVICE_DIR / "backend" / "migrations")
+    )
+    config.set_main_option("sqlalchemy.url", url)
+    return config
+
+
+def test_upgrade_head_matches_the_models_and_downgrade_base_is_clean(scratch_url):
+    config = _config(scratch_url)
+
+    command.upgrade(config, "head")
+    diffs = asyncio.run(_diff(scratch_url))
+    assert diffs == [], f"models and migrations have drifted: {diffs}"
+    created = asyncio.run(_tables(scratch_url))
+    expected = sorted(t.name for t in Base.metadata.sorted_tables) + ["alembic_version"]
+    assert created == sorted(expected)
+
+    command.downgrade(config, "base")
+    assert asyncio.run(_tables(scratch_url)) == ["alembic_version"]
+
+
+def test_upgrade_is_idempotent(scratch_url):
+    config = _config(scratch_url)
+    command.upgrade(config, "head")
+    command.upgrade(config, "head")  # nothing to do, must not fail
+    assert asyncio.run(_diff(scratch_url)) == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -199,6 +199,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -719,6 +734,7 @@ name = "common"
 version = "0.1.0"
 source = { editable = "../common" }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "beanie" },
     { name = "cryptography" },
@@ -728,6 +744,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.19.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "beanie", specifier = ">=2.1.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
@@ -1684,6 +1701,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
 ]
 
 [[package]]

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -9,6 +9,11 @@ Mongo except the Mongo-side outbox document.
 """
 
 from common.db.base import BaseRow, NAMING_CONVENTION, OBJECT_ID_PATTERN, make_base
+from common.db.ddl import (
+    HELPER_FUNCTIONS,
+    drop_helper_function_ddl,
+    helper_function_ddl,
+)
 from common.db.canonical import (
     canonical_document,
     canonical_json,
@@ -18,6 +23,7 @@ from common.db.canonical import (
 )
 from common.db.engine import DatabaseSettings, make_engine, make_sessionmaker, ping
 from common.db.flags import DbFlags, JobsBackend, ReadSource, WriteMode, load_flags
+from common.db.spine import SpineColumns
 from common.db.outbox import (
     MIRROR_OPS,
     MirrorWriteFailureDocument,

--- a/common/common/db/alembic_support.py
+++ b/common/common/db/alembic_support.py
@@ -1,0 +1,120 @@
+"""Shared Alembic plumbing so each service's ``migrations/env.py`` is a few lines.
+
+    # <service>/migrations/env.py
+    from alembic import context
+    from common.db.alembic_support import run_migrations
+    from <pkg>.app.db.base import SCHEMA, Base
+    import <pkg>.app.db.models  # noqa: F401  (registers the tables)
+
+    run_migrations(context, Base.metadata, SCHEMA)
+
+Each service owns exactly one schema: the version table lives in it, and
+autogenerate only sees objects in it, so three services can share one database
+without stepping on each other's migrations.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from sqlalchemy import MetaData, text
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.pool import NullPool
+
+from common.db.ddl import drop_helper_function_ddl, helper_function_ddl
+from common.db.engine import normalise_url
+
+
+def _include_object_for(schema: str):
+    def include_object(obj, name, type_, reflected, compare_to) -> bool:
+        if type_ == "table":
+            return obj.schema == schema
+        table = getattr(obj, "table", None)
+        if table is not None:
+            return table.schema == schema
+        return True
+
+    return include_object
+
+
+def context_options(metadata: MetaData, schema: str) -> dict[str, Any]:
+    return dict(
+        target_metadata=metadata,
+        include_schemas=True,
+        include_object=_include_object_for(schema),
+        version_table_schema=schema,
+        compare_type=True,
+    )
+
+
+def resolve_url(config) -> str:
+    url = config.get_main_option("sqlalchemy.url") or os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError(
+            "set DATABASE_URL (or sqlalchemy.url in alembic.ini) to run migrations"
+        )
+    return normalise_url(url)
+
+
+def _run_sync(connection: Connection, context, metadata: MetaData, schema: str) -> None:
+    # The schema exists already in deployments (postgres/init/01-roles-schemas.sh);
+    # CI service containers and fresh test databases get it here.
+    connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+    context.configure(connection=connection, **context_options(metadata, schema))
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations(context, metadata: MetaData, schema: str) -> None:
+    """Entry point for ``env.py``: offline SQL emission or online async execution."""
+    url = resolve_url(context.config)
+    if context.is_offline_mode():
+        context.configure(
+            url=url,
+            literal_binds=True,
+            dialect_opts={"paramstyle": "named"},
+            **context_options(metadata, schema),
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+        return
+
+    async def _online() -> None:
+        engine = create_async_engine(url, poolclass=NullPool)
+        try:
+            async with engine.connect() as connection:
+                await connection.run_sync(_run_sync, context, metadata, schema)
+                await connection.commit()
+        finally:
+            await engine.dispose()
+
+    asyncio.run(_online())
+
+
+# -- helpers for revision files ---------------------------------------------
+def ensure_schema(op, schema: str) -> None:
+    op.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+
+
+def create_helper_functions(op, schema: str) -> None:
+    for statement in helper_function_ddl(schema):
+        op.execute(statement)
+
+
+def drop_helper_functions(op, schema: str) -> None:
+    for statement in drop_helper_function_ddl(schema):
+        op.execute(statement)
+
+
+# -- for tests: "do the migrations produce exactly the models?" ---------------
+def metadata_diff(connection: Connection, metadata: MetaData, schema: str) -> list:
+    """Empty list when the live schema matches ``metadata``; else Alembic's diff ops."""
+    opts = context_options(metadata, schema)
+    opts.pop("target_metadata")
+    migration_context = MigrationContext.configure(connection, opts=opts)
+    return compare_metadata(migration_context, metadata)

--- a/common/common/db/base.py
+++ b/common/common/db/base.py
@@ -9,7 +9,7 @@ round-trips losslessly to the Mongo document it mirrors.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 from sqlalchemy import CheckConstraint, MetaData, Text, event, text
 from sqlalchemy.dialects.postgresql import JSONB, TIMESTAMP
@@ -29,6 +29,7 @@ NAMING_CONVENTION = {
 
 OBJECT_ID_PATTERN = r"^[0-9a-f]{24}$"
 ID_CHECK_NAME = "id_is_object_id"
+ID_DOC_CHECK_NAME = "id_matches_doc"
 
 SOURCE_APP = "app"
 SOURCE_BACKFILL = "backfill"
@@ -61,6 +62,15 @@ class BaseRow:
     values copied from Mongo.
     """
 
+    #: Mongo collection this table mirrors; defaults to the table name. Set it
+    #: where the two differ (Beanie names a collection after the class when no
+    #: ``Settings.name`` is given, e.g. ``GoogleFormDocument``).
+    __mongo_collection__: ClassVar[Optional[str]] = None
+
+    @classmethod
+    def mongo_collection(cls) -> str:
+        return cls.__mongo_collection__ or cls.__tablename__  # type: ignore[attr-defined]
+
     id: Mapped[str] = mapped_column(Text, primary_key=True)
     created_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
     updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
@@ -72,21 +82,25 @@ class BaseRow:
 
 
 @event.listens_for(BaseRow, "instrument_class", propagate=True)
-def _add_id_check(mapper, class_) -> None:
-    """Every concrete BaseRow table gets the ObjectId CHECK on ``id``.
+def _add_id_checks(mapper, class_) -> None:
+    """Every concrete BaseRow table gets the ``id`` CHECK constraints.
 
     Done here rather than via ``__table_args__`` so a model that declares its
-    own ``__table_args__`` (a unique constraint, an index) cannot lose it.
+    own ``__table_args__`` (a unique constraint, an index) cannot lose them.
+    The naming convention rewrites names to ck_<table>_<name>, hence the
+    suffix match.
     """
     table = class_.__table__
-    # The naming convention rewrites the name to ck_<table>_<name>; match on the suffix.
-    if any(
-        str(getattr(c, "name", "")).endswith(ID_CHECK_NAME) for c in table.constraints
-    ):
-        return
-    table.append_constraint(
-        CheckConstraint(f"id ~ '{OBJECT_ID_PATTERN}'", name=ID_CHECK_NAME)
-    )
+    existing = {str(getattr(c, "name", "")) for c in table.constraints}
+    if not any(n.endswith(ID_CHECK_NAME) for n in existing):
+        table.append_constraint(
+            CheckConstraint(f"id ~ '{OBJECT_ID_PATTERN}'", name=ID_CHECK_NAME)
+        )
+    # ``id`` is a copy of ``doc._id.$oid``; refuse rows where the two disagree.
+    if not any(n.endswith(ID_DOC_CHECK_NAME) for n in existing):
+        table.append_constraint(
+            CheckConstraint("id = (doc -> '_id' ->> '$oid')", name=ID_DOC_CHECK_NAME)
+        )
 
 
 def _stamp(target: BaseRow, *, inserting: bool) -> None:

--- a/common/common/db/ddl.py
+++ b/common/common/db/ddl.py
@@ -1,0 +1,96 @@
+"""Per-schema SQL helper functions that spine columns are generated from.
+
+Every migrated table keeps the whole document in ``doc`` (BSON Extended JSON)
+and derives its typed "spine" columns from it with ``GENERATED ALWAYS AS (...)
+STORED`` expressions. Those expressions may only call IMMUTABLE functions, so
+the extraction lives in four small SQL functions created in each service's
+schema by its first migration:
+
+    bc_text(v)  string / number / boolean as text; ``{"$oid": ...}``,
+                ``{"$numberLong": ...}``, ``{"$numberDecimal": ...}`` unwrapped
+    bc_ts(v)    ``{"$date": "...Z"}``, ``{"$date": {"$numberLong": ms}}`` or a
+                bare ISO-8601 string (form_responses stores those); strings
+                without an offset are taken as UTC, so the result never depends
+                on the session time zone — which is what makes it IMMUTABLE
+    bc_bool(v)  boolean, or the strings "true"/"false"
+    bc_int(v)   number (truncated), ``{"$numberLong": ...}`` or a digit string
+
+All return NULL for NULL / absent / other-typed input rather than raising, so
+a document with an unexpected shape lands as a row with a NULL spine value and
+is caught by verification instead of breaking a write.
+"""
+
+from __future__ import annotations
+
+HELPER_FUNCTIONS = ("bc_text", "bc_ts", "bc_bool", "bc_int")
+
+_TEXT = """
+CREATE OR REPLACE FUNCTION {schema}.bc_text(v jsonb) RETURNS text
+LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS $$
+    SELECT CASE jsonb_typeof(v)
+        WHEN 'string'  THEN v #>> '{{}}'
+        WHEN 'number'  THEN v #>> '{{}}'
+        WHEN 'boolean' THEN v #>> '{{}}'
+        WHEN 'object'  THEN COALESCE(v ->> '$oid', v ->> '$numberLong', v ->> '$numberDecimal')
+        ELSE NULL
+    END
+$$;
+"""
+
+_TS = r"""
+CREATE OR REPLACE FUNCTION {schema}.bc_ts(v jsonb) RETURNS timestamptz
+LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS $$
+    SELECT CASE
+        WHEN jsonb_typeof(v) = 'object' AND jsonb_typeof(v -> '$date') = 'string'
+            THEN (v ->> '$date')::timestamptz
+        WHEN jsonb_typeof(v) = 'object' AND jsonb_typeof(v -> '$date') = 'object'
+            THEN to_timestamp(((v -> '$date' ->> '$numberLong')::bigint) / 1000.0)
+        WHEN jsonb_typeof(v) = 'string' AND (v #>> '{{}}') ~ '(Z|[+-]\d\d:?\d\d)$'
+            THEN (v #>> '{{}}')::timestamptz
+        WHEN jsonb_typeof(v) = 'string' AND (v #>> '{{}}') ~ '^\d{{4}}-\d\d-\d\d'
+            THEN ((v #>> '{{}}')::timestamp AT TIME ZONE 'UTC')
+        ELSE NULL
+    END
+$$;
+"""
+
+_BOOL = """
+CREATE OR REPLACE FUNCTION {schema}.bc_bool(v jsonb) RETURNS boolean
+LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS $$
+    SELECT CASE jsonb_typeof(v)
+        WHEN 'boolean' THEN (v #>> '{{}}')::boolean
+        WHEN 'string'  THEN CASE lower(v #>> '{{}}') WHEN 'true' THEN true WHEN 'false' THEN false ELSE NULL END
+        ELSE NULL
+    END
+$$;
+"""
+
+_INT = r"""
+CREATE OR REPLACE FUNCTION {schema}.bc_int(v jsonb) RETURNS bigint
+LANGUAGE sql IMMUTABLE PARALLEL SAFE RETURNS NULL ON NULL INPUT AS $$
+    SELECT CASE jsonb_typeof(v)
+        WHEN 'number' THEN trunc((v #>> '{{}}')::numeric)::bigint
+        WHEN 'object' THEN (v ->> '$numberLong')::bigint
+        WHEN 'string' THEN CASE WHEN (v #>> '{{}}') ~ '^-?\d+$' THEN (v #>> '{{}}')::bigint ELSE NULL END
+        ELSE NULL
+    END
+$$;
+"""
+
+
+def _check_schema(schema: str) -> None:
+    if not schema.isidentifier() or not schema.islower():
+        raise ValueError(f"schema must be a plain lowercase identifier, got {schema!r}")
+
+
+def helper_function_ddl(schema: str) -> list[str]:
+    """The CREATE statements for ``schema``, in dependency-free order."""
+    _check_schema(schema)
+    return [tpl.format(schema=schema).strip() for tpl in (_TEXT, _TS, _BOOL, _INT)]
+
+
+def drop_helper_function_ddl(schema: str) -> list[str]:
+    _check_schema(schema)
+    return [
+        f"DROP FUNCTION IF EXISTS {schema}.{name}(jsonb)" for name in HELPER_FUNCTIONS
+    ]

--- a/common/common/db/spine.py
+++ b/common/common/db/spine.py
@@ -1,0 +1,65 @@
+"""Typed spine columns generated from ``doc`` (decision D2).
+
+    S = SpineColumns("app")
+
+    class FormRow(Base, BaseRow):
+        __tablename__ = "forms"
+        form_id = S.text("form_id")
+        custom_url = S.text("settings", "custom_url")      # nested path
+        published_at = S.ts("published_at")
+        is_default = S.bool("default", name="is_default")  # rename reserved words
+
+Each becomes ``GENERATED ALWAYS AS (<schema>.bc_<type>(doc -> 'key')) STORED``,
+so the application writes ``doc`` alone and a spine value can never disagree
+with the document it was derived from. Generated columns can be indexed and
+carry unique constraints like any other.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import BigInteger, Boolean, Computed, Text
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy.orm import mapped_column
+
+_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
+
+
+class SpineColumns:
+    def __init__(self, schema: str):
+        if not schema.isidentifier() or not schema.islower():
+            raise ValueError(
+                f"schema must be a plain lowercase identifier, got {schema!r}"
+            )
+        self.schema = schema
+
+    @staticmethod
+    def _source(path: tuple[str, ...]) -> str:
+        if not path:
+            raise ValueError("a spine column needs at least one key")
+        for key in path:
+            if not _KEY.match(key):
+                raise ValueError(f"unsafe document key {key!r}")
+        if len(path) == 1:
+            return f"doc -> '{path[0]}'"
+        return "doc #> '{" + ",".join(path) + "}'"
+
+    def _column(self, sqltype, function: str, path: tuple[str, ...], name: str | None):
+        expression = f"{self.schema}.{function}({self._source(path)})"
+        computed = Computed(expression, persisted=True)
+        if name is not None:
+            return mapped_column(name, sqltype, computed, nullable=True)
+        return mapped_column(sqltype, computed, nullable=True)
+
+    def text(self, *path: str, name: str | None = None):
+        return self._column(Text, "bc_text", path, name)
+
+    def ts(self, *path: str, name: str | None = None):
+        return self._column(TIMESTAMP(timezone=True), "bc_ts", path, name)
+
+    def bool(self, *path: str, name: str | None = None):
+        return self._column(Boolean, "bc_bool", path, name)
+
+    def int(self, *path: str, name: str | None = None):
+        return self._column(BigInteger, "bc_int", path, name)

--- a/common/pyproject.toml
+++ b/common/pyproject.toml
@@ -31,6 +31,7 @@ license = { text = "no" }
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "alembic>=1.19.0",
     "asyncpg>=0.30.0",
     "beanie>=2.1.0",
     "cryptography>=50.0.0",

--- a/common/tests/test_base_row.py
+++ b/common/tests/test_base_row.py
@@ -112,6 +112,16 @@ async def test_backfilled_rows_keep_the_timestamps_copied_from_mongo(engine):
 async def test_id_must_be_a_24_hex_object_id(engine):
     Session = make_sessionmaker(engine)
     async with Session() as session:
-        session.add(Probe(id="not-an-object-id", doc={}))
-        with pytest.raises(IntegrityError, match="id_is_object_id"):
+        session.add(
+            Probe(id="not-an-object-id", doc={"_id": {"$oid": "not-an-object-id"}})
+        )
+        with pytest.raises(IntegrityError, match="id_is_object_id|id_matches_doc"):
+            await session.commit()
+
+
+async def test_id_must_match_the_documents_id(engine):
+    Session = make_sessionmaker(engine)
+    async with Session() as session:
+        session.add(Probe(id=str(ObjectId()), doc={"_id": {"$oid": str(ObjectId())}}))
+        with pytest.raises(IntegrityError, match="id_matches_doc"):
             await session.commit()

--- a/common/tests/test_helper_functions_pg.py
+++ b/common/tests/test_helper_functions_pg.py
@@ -1,0 +1,109 @@
+"""The four helper functions, exercised on a live Postgres."""
+
+import os
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+
+from common.db import DatabaseSettings, helper_function_ddl, make_engine
+from common.db.ddl import drop_helper_function_ddl
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL"),
+    reason="DATABASE_URL not set (start app-postgres from docker-compose.local.yml)",
+)
+SCHEMA = "common_fn_test"
+
+
+@pytest.fixture
+async def conn():
+    engine = make_engine(
+        DatabaseSettings.from_env(), application_name="common-fn-tests"
+    )
+    async with engine.begin() as c:
+        await c.execute(text(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}"))
+        for stmt in helper_function_ddl(SCHEMA):
+            await c.execute(text(stmt))
+    async with engine.connect() as c:
+        yield c
+    async with engine.begin() as c:
+        for stmt in drop_helper_function_ddl(SCHEMA):
+            await c.execute(text(stmt))
+        await c.execute(text(f"DROP SCHEMA IF EXISTS {SCHEMA} CASCADE"))
+    await engine.dispose()
+
+
+async def call(conn, fn, value_json):
+    return (
+        await conn.execute(
+            text(f"SELECT {SCHEMA}.{fn}(CAST(:v AS jsonb))"), {"v": value_json}
+        )
+    ).scalar_one_or_none()
+
+
+async def test_bc_text_unwraps_extended_json_and_scalars(conn):
+    assert await call(conn, "bc_text", '"plain"') == "plain"
+    assert (
+        await call(conn, "bc_text", '{"$oid": "64ae38bcdea80b08417d058a"}')
+        == "64ae38bcdea80b08417d058a"
+    )
+    assert await call(conn, "bc_text", '{"$numberLong": "42"}') == "42"
+    assert await call(conn, "bc_text", "7") == "7"
+    assert await call(conn, "bc_text", "true") == "true"
+    assert await call(conn, "bc_text", "null") is None
+    assert await call(conn, "bc_text", '{"nested": 1}') is None
+    assert await call(conn, "bc_text", "[1,2]") is None
+
+
+async def test_bc_ts_handles_every_datetime_shape_the_data_has(conn):
+    expected = datetime(2026, 9, 6, 10, 0, 0, 123000, tzinfo=timezone.utc)
+    assert (
+        await call(conn, "bc_ts", '{"$date": "2026-09-06T10:00:00.123Z"}') == expected
+    )
+    ms = int(expected.timestamp() * 1000)
+    assert (
+        await call(conn, "bc_ts", '{"$date": {"$numberLong": "%d"}}' % ms) == expected
+    )
+    # bare ISO strings (form_responses' bson_encoders): Z, explicit offset, and naive-as-UTC
+    assert await call(conn, "bc_ts", '"2026-09-06T10:00:00.123Z"') == expected
+    assert await call(conn, "bc_ts", '"2026-09-06T15:45:00.123+05:45"') == expected
+    assert await call(conn, "bc_ts", '"2026-09-06T10:00:00.123"') == expected
+    assert await call(conn, "bc_ts", '"2026-09-06T10:00:00.123000"') == expected
+    assert await call(conn, "bc_ts", '"not a date"') is None
+    assert await call(conn, "bc_ts", "null") is None
+    assert await call(conn, "bc_ts", "12") is None
+
+
+async def test_naive_strings_do_not_depend_on_the_session_time_zone(conn):
+    await conn.execute(text("SET TIME ZONE 'Asia/Kathmandu'"))
+    got = await call(conn, "bc_ts", '"2026-09-06T10:00:00"')
+    assert got == datetime(2026, 9, 6, 10, 0, tzinfo=timezone.utc)
+
+
+async def test_bc_bool_and_bc_int(conn):
+    assert await call(conn, "bc_bool", "true") is True
+    assert await call(conn, "bc_bool", '"False"') is False
+    assert await call(conn, "bc_bool", '"maybe"') is None
+    assert await call(conn, "bc_bool", "1") is None
+    assert await call(conn, "bc_int", "3") == 3
+    assert await call(conn, "bc_int", "3.9") == 3
+    assert (
+        await call(conn, "bc_int", '{"$numberLong": "9007199254740993"}')
+        == 9007199254740993
+    )
+    assert await call(conn, "bc_int", '"12"') == 12
+    assert await call(conn, "bc_int", '"twelve"') is None
+
+
+async def test_functions_are_immutable_so_generated_columns_may_use_them(conn):
+    rows = (
+        await conn.execute(
+            text(
+                "SELECT p.proname, p.provolatile::text FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace "
+                f"WHERE n.nspname = '{SCHEMA}' ORDER BY 1"
+            )
+        )
+    ).all()
+    assert {r[0] for r in rows} == {"bc_bool", "bc_int", "bc_text", "bc_ts"}
+    assert all(r[1] == "i" for r in rows)  # 'i' = IMMUTABLE

--- a/common/tests/test_spine_and_ddl.py
+++ b/common/tests/test_spine_and_ddl.py
@@ -1,0 +1,66 @@
+import pytest
+from sqlalchemy import Computed
+
+from common.db import SpineColumns, drop_helper_function_ddl, helper_function_ddl
+from common.db.base import BaseRow, make_base
+
+
+def test_spine_columns_render_schema_qualified_generated_expressions():
+    S = SpineColumns("app")
+    Base = make_base("app")
+
+    class Row(Base, BaseRow):
+        __tablename__ = "spine_probe"
+        form_id = S.text("form_id")
+        custom_url = S.text("settings", "custom_url")
+        published_at = S.ts("published_at")
+        is_default = S.bool("default", name="is_default")
+        version = S.int("version")
+
+    cols = {c.name: c for c in Row.__table__.columns}
+    assert isinstance(cols["form_id"].computed, Computed)
+    assert cols["form_id"].computed.sqltext.text == "app.bc_text(doc -> 'form_id')"
+    assert (
+        cols["custom_url"].computed.sqltext.text
+        == "app.bc_text(doc #> '{settings,custom_url}')"
+    )
+    assert (
+        cols["published_at"].computed.sqltext.text == "app.bc_ts(doc -> 'published_at')"
+    )
+    assert cols["is_default"].computed.sqltext.text == "app.bc_bool(doc -> 'default')"
+    assert cols["version"].computed.sqltext.text == "app.bc_int(doc -> 'version')"
+    assert all(
+        cols[n].computed.persisted for n in ("form_id", "custom_url", "published_at")
+    )
+
+
+@pytest.mark.parametrize("bad", ["", "settings.custom_url", "x y", "a;drop"])
+def test_unsafe_keys_are_rejected_at_definition_time(bad):
+    with pytest.raises(ValueError):
+        SpineColumns("app").text(bad)
+
+
+def test_mongo_collection_defaults_to_table_name():
+    Base = make_base("google")
+
+    class A(Base, BaseRow):
+        __tablename__ = "google_forms"
+        __mongo_collection__ = "GoogleFormDocument"
+
+    class B(Base, BaseRow):
+        __tablename__ = "plain"
+
+    assert A.mongo_collection() == "GoogleFormDocument"
+    assert B.mongo_collection() == "plain"
+
+
+def test_helper_ddl_is_per_schema_and_immutable():
+    ddl = helper_function_ddl("auth")
+    assert len(ddl) == 4
+    assert all("auth.bc_" in s and "IMMUTABLE" in s for s in ddl)
+    assert (
+        drop_helper_function_ddl("auth")[0]
+        == "DROP FUNCTION IF EXISTS auth.bc_text(jsonb)"
+    )
+    with pytest.raises(ValueError):
+        helper_function_ddl("Bad-Schema")

--- a/common/uv.lock
+++ b/common/uv.lock
@@ -12,6 +12,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -273,6 +288,7 @@ name = "common"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "beanie" },
     { name = "cryptography" },
@@ -289,6 +305,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.19.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "beanie", specifier = ">=2.1.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
@@ -486,6 +503,103 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/85/e25dc36dee49cf0726c03a1558b5c311a17095bc9361bcbf47226cb3075a/lazy-model-0.4.0.tar.gz", hash = "sha256:a851d85d0b518b0b9c8e626bbee0feb0494c0e0cb5636550637f032dbbf9c55f", size = 8256, upload-time = "2025-08-07T20:05:34.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/54/653ea0d7c578741e9867ccf0cbf47b7eac09ff22e4238f311ac20671a911/lazy_model-0.4.0-py3-none-any.whl", hash = "sha256:95ea59551c1ac557a2c299f75803c56cc973923ef78c67ea4839a238142f7927", size = 13749, upload-time = "2025-08-07T20:05:36.303Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]

--- a/deploy.sh
+++ b/deploy.sh
@@ -59,6 +59,18 @@ function dockerup() {
     fi
   done
 
+  # Schema migrations run once, here, before the services roll — never from
+  # application startup, where several replicas would race each other
+  # (plans/postgres-consolidation.md). Each service owns one schema and its own
+  # Alembic history; `run --rm --no-deps` executes inside the freshly pulled
+  # image with the same DATABASE_URL the service will use.
+  "$docker_compose_cmd" -f "docker-compose.deployment.yml" pull -q backend auth $([ "$googleform_flag" = true ] && echo integrations-googleform)
+  "$docker_compose_cmd" -f "docker-compose.deployment.yml" up -d --wait app-postgres
+  "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps backend /api/backend/.venv/bin/alembic -c /api/backend/alembic.ini upgrade head
+  "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps auth /api/auth/.venv/bin/alembic -c /api/auth/alembic.ini upgrade head
+  if [ "$googleform_flag" = true ]; then
+    "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps integrations-googleform alembic -c /api/integrations/google/alembic.ini upgrade head
+  fi
   GOOGLE_ENABLED="$googleform_flag" TYPEFORM_ENABLED="$typeform_flag" "$docker_compose_cmd" -f "docker-compose.deployment.yml" up --build -d "$@"
 }
 

--- a/integrations/google/alembic.ini
+++ b/integrations/google/alembic.ini
@@ -1,0 +1,43 @@
+# Alembic for the Google integration's schema (`google`). Run from anywhere:
+#   uv run alembic upgrade head            (local; DATABASE_URL from the environment)
+#   alembic -c /api/integrations/google/alembic.ini upgrade head   (in the image; deploy.sh does this)
+[alembic]
+script_location = %(here)s/googleform/migrations
+prepend_sys_path = %(here)s
+file_template = %%(rev)s_%%(slug)s
+# sqlalchemy.url is intentionally empty: env.py reads DATABASE_URL.
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/integrations/google/googleform/db/__init__.py
+++ b/integrations/google/googleform/db/__init__.py
@@ -1,0 +1,6 @@
+"""Postgres rows for the Google integration (schema ``google``) — plans/postgres-consolidation.md.
+
+This package deliberately lives beside ``app``, not inside it: importing anything
+under ``app`` runs ``app/__init__`` and boots the whole application (settings, APM,
+database clients), which Alembic and the tests must never do.
+"""

--- a/integrations/google/googleform/db/base.py
+++ b/integrations/google/googleform/db/base.py
@@ -1,0 +1,5 @@
+from common.db import SpineColumns, make_base
+
+SCHEMA = "google"
+Base = make_base(SCHEMA)
+S = SpineColumns(SCHEMA)

--- a/integrations/google/googleform/db/models.py
+++ b/integrations/google/googleform/db/models.py
@@ -1,0 +1,47 @@
+"""The three Beanie documents here have no ``Settings.name``, so their Mongo
+collections are literally named after the classes; the tables get sane names
+and record the collection they mirror."""
+
+from __future__ import annotations
+
+from sqlalchemy import Index
+
+from common.db import BaseRow, MirrorWriteFailureMixin
+from googleform.db.base import S, Base
+
+
+class GoogleFormRow(Base, BaseRow):
+    __tablename__ = "google_forms"
+    __mongo_collection__ = "GoogleFormDocument"
+    google_form_id = S.text("formId", name="google_form_id")
+    provider = S.text("provider")
+    __table_args__ = (Index(None, "google_form_id"),)
+
+
+class GoogleFormResponseRow(Base, BaseRow):
+    __tablename__ = "google_form_responses"
+    __mongo_collection__ = "GoogleFormResponseDocument"
+    google_form_id = S.text("formId", name="google_form_id")
+    google_response_id = S.text("responseId", name="google_response_id")
+    provider = S.text("provider")
+    __table_args__ = (
+        Index(
+            "ix_google_form_responses_form_response",
+            "google_form_id",
+            "google_response_id",
+        ),
+    )
+
+
+class OAuthCredentialRow(Base, BaseRow):
+    __tablename__ = "oauth_credentials"
+    __mongo_collection__ = "Oauth2CredentialDocument"
+    email = S.text("email")
+    user_id = S.text("user_id")
+    provider = S.text("provider")
+    state = S.text("state")
+    __table_args__ = (Index(None, "email"), Index(None, "user_id"))
+
+
+class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
+    __tablename__ = "mirror_write_failures"

--- a/integrations/google/googleform/migrations/env.py
+++ b/integrations/google/googleform/migrations/env.py
@@ -1,0 +1,7 @@
+from alembic import context
+
+import googleform.db.models  # noqa: F401  registers every table on Base.metadata
+from common.db.alembic_support import run_migrations
+from googleform.db.base import SCHEMA, Base
+
+run_migrations(context, Base.metadata, SCHEMA)

--- a/integrations/google/googleform/migrations/script.py.mako
+++ b/integrations/google/googleform/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/integrations/google/googleform/migrations/versions/0001_initial_google_schema.py
+++ b/integrations/google/googleform/migrations/versions/0001_initial_google_schema.py
@@ -1,0 +1,223 @@
+"""initial google schema
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-09-06 13:17:04.070648
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from common.db.alembic_support import (
+    create_helper_functions,
+    drop_helper_functions,
+    ensure_schema,
+)
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0001"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+SCHEMA = "google"
+
+
+def upgrade() -> None:
+    # The schema exists in deployments (postgres/init); CI and scratch databases get it here.
+    ensure_schema(op, SCHEMA)
+    # Spine columns are GENERATED from doc through these IMMUTABLE helpers, so they come first.
+    create_helper_functions(op, SCHEMA)
+    op.create_table(
+        "google_form_responses",
+        sa.Column(
+            "google_form_id",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'formId')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "google_response_id",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'responseId')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_google_form_responses_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'",
+            name=op.f("ck_google_form_responses_id_is_object_id"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_google_form_responses")),
+        schema="google",
+    )
+    op.create_index(
+        "ix_google_form_responses_form_response",
+        "google_form_responses",
+        ["google_form_id", "google_response_id"],
+        unique=False,
+        schema="google",
+    )
+    op.create_table(
+        "google_forms",
+        sa.Column(
+            "google_form_id",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'formId')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_google_forms_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_google_forms_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_google_forms")),
+        schema="google",
+    )
+    op.create_index(
+        op.f("ix_google_google_forms_google_form_id"),
+        "google_forms",
+        ["google_form_id"],
+        unique=False,
+        schema="google",
+    )
+    op.create_table(
+        "mirror_write_failures",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("table_name", sa.Text(), nullable=False),
+        sa.Column("row_id", sa.Text(), nullable=False),
+        sa.Column("op", sa.Text(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=False),
+        sa.Column(
+            "attempts", sa.Integer(), server_default=sa.text("0"), nullable=False
+        ),
+        sa.Column(
+            "created_at",
+            postgresql.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("resolved_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_mirror_write_failures")),
+        schema="google",
+    )
+    op.create_table(
+        "oauth_credentials",
+        sa.Column(
+            "email",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'email')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'user_id')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "provider",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'provider')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "state",
+            sa.Text(),
+            sa.Computed("google.bc_text(doc -> 'state')", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("created_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("doc", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "_bc_source", sa.Text(), server_default=sa.text("'app'"), nullable=False
+        ),
+        sa.Column("_bc_checksum", sa.Text(), nullable=False),
+        sa.CheckConstraint(
+            "id = (doc -> '_id' ->> '$oid')",
+            name=op.f("ck_oauth_credentials_id_matches_doc"),
+        ),
+        sa.CheckConstraint(
+            "id ~ '^[0-9a-f]{24}$'", name=op.f("ck_oauth_credentials_id_is_object_id")
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_oauth_credentials")),
+        schema="google",
+    )
+    op.create_index(
+        op.f("ix_google_oauth_credentials_email"),
+        "oauth_credentials",
+        ["email"],
+        unique=False,
+        schema="google",
+    )
+    op.create_index(
+        op.f("ix_google_oauth_credentials_user_id"),
+        "oauth_credentials",
+        ["user_id"],
+        unique=False,
+        schema="google",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_google_oauth_credentials_user_id"),
+        table_name="oauth_credentials",
+        schema="google",
+    )
+    op.drop_index(
+        op.f("ix_google_oauth_credentials_email"),
+        table_name="oauth_credentials",
+        schema="google",
+    )
+    op.drop_table("oauth_credentials", schema="google")
+    op.drop_table("mirror_write_failures", schema="google")
+    op.drop_index(
+        op.f("ix_google_google_forms_google_form_id"),
+        table_name="google_forms",
+        schema="google",
+    )
+    op.drop_table("google_forms", schema="google")
+    op.drop_index(
+        "ix_google_form_responses_form_response",
+        table_name="google_form_responses",
+        schema="google",
+    )
+    op.drop_table("google_form_responses", schema="google")
+    drop_helper_functions(op, SCHEMA)

--- a/integrations/google/uv.lock
+++ b/integrations/google/uv.lock
@@ -188,6 +188,21 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/10/181eecdd552217d0342492bd6f3b8a96e973083379aace3d3402830ddc03/alembic-1.19.2.tar.gz", hash = "sha256:297950a8a91f6770eb82bfbce9bea55c728b90a5386c6e81430191a319d138b0", size = 2082643, upload-time = "2026-09-04T17:10:11.212Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/cb/9014784dcb0585977ae23b6f43331d0a33c51ac0d692506d12b4f5ee9f3b/alembic-1.19.2-py3-none-any.whl", hash = "sha256:32d553dcd577e6fe5c3c63e91468526d35e4dcecafe865d7db4e9b328fa93cb2", size = 267399, upload-time = "2026-09-04T17:10:12.796Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -601,6 +616,7 @@ name = "common"
 version = "0.1.0"
 source = { editable = "../../common" }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "beanie" },
     { name = "cryptography" },
@@ -610,6 +626,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.19.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "beanie", specifier = ">=2.1.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
@@ -1512,6 +1529,103 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/12/b5fa2353e2754cd67fb9f83793fa48ff42c213a5da7e719869d2301f6ab8/mako-1.4.1.tar.gz", hash = "sha256:d7904710b662996425a21627710c4777c45053146942cf8a7aebf757c92b8c27", size = 410165, upload-time = "2026-08-05T06:10:56.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/54/12ed58d458474aaab5c3d180173e745a4fe131bb330370596876d19ff60f/mako-1.4.1-py3-none-any.whl", hash = "sha256:a359d9a94a541213958742b2698d0a7757bb83551767bc468a74b9905aba9617", size = 80010, upload-time = "2026-08-05T06:10:58.248Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 0, **PR 3 of ~10** in `plans/postgres-consolidation.md` (§3). Stacked on #660 (imports `common.db`). **Nothing reads or writes these tables yet — no behaviour change.**

## What

Every Mongo collection now has a Postgres table: the whole document in `doc` (BSON Extended JSON, from #660) plus **typed spine columns** for exactly the fields the repositories filter, join, sort, or need unique — measured from the code, not guessed.

**Spine columns are `GENERATED ALWAYS AS (…) STORED` from `doc`**, through four small `IMMUTABLE` SQL functions created in each schema (`bc_text`, `bc_ts`, `bc_bool`, `bc_int` — [common/db/ddl.py](common/common/db/ddl.py)). The application writes `doc` alone; a spine value cannot disagree with the document it was derived from, and the backfill has nothing extra to compute. `bc_ts` accepts every datetime shape the data actually has — `{"$date": "…Z"}`, `{"$date": {"$numberLong": ms}}`, and the bare ISO strings `form_responses` stores via its `bson_encoders` — and reads naive strings as UTC, which is what makes it honestly immutable (verified: a `SET TIME ZONE 'Asia/Kathmandu'` session gets the same answer).

`id` gets a second CHECK: `id = doc->'_id'->>'$oid'`.

| schema | tables | notable constraints |
|---|---|---|
| `app` (backend) | 35 incl. `mirror_write_failures` | unique: `workspaces.workspace_name`, `custom_domain` (partial), `workspace_invites(workspace_id,email)`, `responses_deletion_requests(form_id,response_id,provider)` **`NULLS NOT DISTINCT`** (Mongo treats a missing provider as one value), `workspace_api_keys.key_hash`, `coupon_codes.code`, `workspace_ai_profiles.workspace_id`, `forms.form_id`, `form_responses.response_id`, `form_versions(form_id,version)` |
| `auth` | 3 | unique `users.email`; `providers` maps to the class-named Mongo collection `Provider` |
| `google` | 4 | the three Beanie documents have no `Settings.name`, so their collections are literally `GoogleFormDocument` etc.; tables get real names and record the source via `__mongo_collection__` |

Deliberately **not** unique yet: `workspace_forms(workspace_id, form_id)` and `workspace_users(workspace_id, user_id)` — Mongo never enforced them; they become unique after the migration preflight proves the data clean. `form_flow_events` is a plain table until preflight reports its size (partitioning decision).

## Alembic

One `alembic.ini` + `migrations/` per service, all on [common/db/alembic_support.py](common/common/db/alembic_support.py): async runner, version table **inside the service's schema**, autogenerate scoped to that schema (three services share one database without seeing each other), `CREATE SCHEMA IF NOT EXISTS` so CI service containers and scratch databases work without the init script. Initial revisions were autogenerated from the models, then wired to create the schema and helper functions first.

**`deploy.sh` now runs `alembic upgrade head`** for backend, auth and (when enabled) google inside the freshly pulled images, *before* the services roll — never at app startup, where replicas would race. The Swarm stack needs the equivalent step.

## Two things I had to fix along the way

- **The `db` packages live beside `app/`, not inside it.** Every service's `app/__init__.py` imports `get_application`, so importing `app.anything` boots the whole service — settings validation, Elastic APM client, Mongo client. Alembic and the tests must never do that; the google autogenerate failed on exactly this until the move.
- **auth's `common` path dependency was non-editable** (backend's and google's are editable). Its venv held a stale snapshot of `common` that silently lacked new modules. Now `editable = true` like the others.

## Tests

- backend + auth: a migration test that creates a **scratch database**, upgrades to head, asserts Alembic sees **no difference** between the live schema and the models, upgrades again (idempotent), downgrades to base cleanly, then drops the database. Skips without `DATABASE_URL`.
- google: same procedure run by hand (its suite is pre-broken, see #660's note) — upgrade OK, diff none, downgrade OK.
- common: +13 tests — `SpineColumns` rendering and key validation, helper DDL, the four SQL functions on a live Postgres (every datetime shape, time-zone independence, `IMMUTABLE` volatility), the new `id_matches_doc` CHECK. 48 total.

Next: PR 4 — extract repository `Protocol`s and rename the existing classes `Mongo*Repository` (pure refactor), then the `Postgres*` implementations group by group.
