### PR TITLE
refactor(backend): route workspace-group data access through repositories

### DIFF
--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -12,6 +12,10 @@ from dependency_injector import containers, providers
 from pymongo import AsyncMongoClient
 
 from backend.app.repositories.action_repository import ActionRepository
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
+from backend.app.repositories.blacklisted_refresh_token_repository import (
+    BlacklistedRefreshTokenRepository,
+)
 from backend.app.repositories.coupon_repository import CouponRepository
 from backend.app.repositories.form_plugin_provider_repository import (
     FormPluginProviderRepository,
@@ -95,6 +99,12 @@ class AppContainer(containers.DeclarativeContainer):
         WorkspaceUserRepository
     )
     workspace_repo: WorkspaceRepository = providers.Singleton(WorkspaceRepository)
+    allowed_origins_repo: AllowedOriginsRepository = providers.Singleton(
+        AllowedOriginsRepository
+    )
+    blacklisted_refresh_token_repo: BlacklistedRefreshTokenRepository = (
+        providers.Singleton(BlacklistedRefreshTokenRepository)
+    )
 
     form_repo: FormRepository = providers.Singleton(FormRepository)
     form_response_repo: FormResponseRepository = providers.Singleton(
@@ -169,7 +179,9 @@ class AppContainer(containers.DeclarativeContainer):
     )
 
     workspace_user_service: WorkspaceUserService = providers.Singleton(
-        WorkspaceUserService, workspace_user_repository=workspace_user_repo
+        WorkspaceUserService,
+        workspace_user_repository=workspace_user_repo,
+        workspace_repo=workspace_repo,
     )
 
     job_store = providers.Singleton(MongoDBJobStore, host=settings.mongo_settings.URI)
@@ -235,6 +247,8 @@ class AppContainer(containers.DeclarativeContainer):
         WorkspaceService,
         http_client=http_client,
         workspace_repo=workspace_repo,
+        workspace_user_repo=workspace_user_repo,
+        allowed_origins_repo=allowed_origins_repo,
         aws_service=aws_service,
         workspace_user_service=workspace_user_service,
         workspace_form_service=workspace_form_service,
@@ -305,6 +319,7 @@ class AppContainer(containers.DeclarativeContainer):
         WorkspaceMembersService,
         workspace_user_service=workspace_user_service,
         workspace_invitation_repo=workspace_invitation_repo,
+        workspace_repo=workspace_repo,
         http_client=http_client,
         workspace_form_service=workspace_form_service,
     )

--- a/backend/backend/app/middlewares/dynamic_cors_middleware.py
+++ b/backend/backend/app/middlewares/dynamic_cors_middleware.py
@@ -3,7 +3,13 @@ import datetime
 from starlette.middleware.cors import CORSMiddleware
 from starlette.types import Receive, Scope, Send
 
-from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+
+
+async def _allowed_origins() -> list[str]:
+    # Resolved at call time: the container imports services that import this module.
+    from backend.app.container import container
+
+    return await container.allowed_origins_repo().list_origins()
 
 
 class DynamicCORSMiddleware(CORSMiddleware):
@@ -22,15 +28,13 @@ class DynamicCORSMiddleware(CORSMiddleware):
         now = datetime.datetime.now(datetime.timezone.utc)
         if (now - self._cache_refreshed_at).total_seconds() < self._cache_ttl_seconds:
             return
-        docs = await AllowedOriginsDocument.find().to_list()
-        DynamicCORSMiddleware._allowed_origins = [doc.origin for doc in docs]
+        DynamicCORSMiddleware._allowed_origins = await _allowed_origins()
         DynamicCORSMiddleware._cache_refreshed_at = now
 
     @classmethod
     async def force_refresh_origins(cls) -> None:
         """Force reload allowed origins from the database, bypassing the cache TTL."""
-        docs = await AllowedOriginsDocument.find().to_list()
-        cls._allowed_origins = [doc.origin for doc in docs]
+        cls._allowed_origins = await _allowed_origins()
         cls._cache_refreshed_at = datetime.datetime.now(datetime.timezone.utc)
 
     def is_allowed_origin(self, origin: str) -> bool:

--- a/backend/backend/app/repositories/allowed_origins_repository.py
+++ b/backend/backend/app/repositories/allowed_origins_repository.py
@@ -1,0 +1,20 @@
+from typing import List, Optional
+
+from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+
+
+class AllowedOriginsRepository:
+    """The origins the dynamic CORS middleware accepts (seeded + custom domains)."""
+
+    async def list_origins(self) -> List[str]:
+        docs = await AllowedOriginsDocument.find().to_list()
+        return [doc.origin for doc in docs]
+
+    async def find_by_origin(self, origin: str) -> Optional[AllowedOriginsDocument]:
+        return await AllowedOriginsDocument.find_one({"origin": origin})
+
+    async def add(self, origin: str) -> AllowedOriginsDocument:
+        return await AllowedOriginsDocument(origin=origin).save()
+
+    async def delete_by_origin(self, origin: str) -> None:
+        await AllowedOriginsDocument.find_one({"origin": origin}).delete()

--- a/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
+++ b/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+from backend.app.schemas.blacklisted_refresh_tokens import BlackListedRefreshTokens
+
+
+class BlacklistedRefreshTokenRepository:
+    async def find_by_token(self, token: str) -> Optional[BlackListedRefreshTokens]:
+        return await BlackListedRefreshTokens.find_one({"token": token})
+
+    async def add(self, token: str, expiry) -> BlackListedRefreshTokens:
+        return await BlackListedRefreshTokens(token=token, expiry=expiry).save()

--- a/backend/backend/app/repositories/workspace_invitation_repo.py
+++ b/backend/backend/app/repositories/workspace_invitation_repo.py
@@ -16,6 +16,11 @@ from common.enums.workspace_invitation_status import InvitationStatus
 
 
 class WorkspaceInvitationRepo:
+    async def save(
+        self, invitation: WorkspaceUserInvitesDocument
+    ) -> WorkspaceUserInvitesDocument:
+        return await invitation.save()
+
     async def create_workspace_invitation(
         self, workspace_id: PydanticObjectId, invitation: InvitationRequest
     ):

--- a/backend/backend/app/repositories/workspace_repository.py
+++ b/backend/backend/app/repositories/workspace_repository.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from beanie import PydanticObjectId
 
@@ -40,6 +40,25 @@ class WorkspaceRepository(BaseRepository):
         if not workspace:
             raise HTTPException(HTTPStatus.NOT_FOUND)
         return workspace
+
+    async def find_by_id(self, workspace_id: PydanticObjectId) -> Optional[WorkspaceDocument]:
+        return await WorkspaceDocument.find_one({"_id": workspace_id})
+
+    async def find_by_name(self, workspace_name: str) -> Optional[WorkspaceDocument]:
+        return await WorkspaceDocument.find_one({"workspace_name": workspace_name})
+
+    async def find_by_custom_domain(self, custom_domain: str) -> Optional[WorkspaceDocument]:
+        return await WorkspaceDocument.find_one({"custom_domain": custom_domain})
+
+    async def get_or_404(self, workspace_id: PydanticObjectId) -> WorkspaceDocument:
+        """Like ``find_by_id`` but raises the document layer's NotFoundError when missing."""
+        return await WorkspaceDocument.get(workspace_id)
+
+    async def save(self, workspace: WorkspaceDocument) -> WorkspaceDocument:
+        return await workspace.save()
+
+    async def set_fields(self, workspace: WorkspaceDocument, fields: Dict[str, Any]) -> None:
+        await workspace.update({"$set": fields})
 
     async def get_workspace_by_query(self, query: str):
         workspace = await WorkspaceDocument.find_one(

--- a/backend/backend/app/repositories/workspace_user_repository.py
+++ b/backend/backend/app/repositories/workspace_user_repository.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import List
+from typing import List, Optional
 
 from beanie import PydanticObjectId
 
@@ -50,6 +50,13 @@ class WorkspaceUserRepository:
         return await WorkspaceUserDocument.find(
             {"workspace_id": workspace_id}
         ).to_list()
+
+    async def find_workspace_user(
+        self, workspace_id: PydanticObjectId, user_id: PydanticObjectId
+    ) -> Optional[WorkspaceUserDocument]:
+        return await WorkspaceUserDocument.find_one(
+            {"workspace_id": workspace_id, "user_id": user_id}
+        )
 
     async def save(self, workspace_user: WorkspaceUserDocument):
         return await workspace_user.save()

--- a/backend/backend/app/services/user_service.py
+++ b/backend/backend/app/services/user_service.py
@@ -8,7 +8,6 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from backend.app.exceptions import HTTPException
-from backend.app.schemas.blacklisted_refresh_tokens import BlackListedRefreshTokens
 from backend.app.services.auth_cookie_service import set_access_token_to_response
 from backend.config import settings
 
@@ -97,8 +96,10 @@ async def check_if_refresh_token_is_blacklisted(token: str):
         key=settings.auth_settings.JWT_SECRET,
         algorithms=["HS256"],
     )
-    blacklisted_tokens = await BlackListedRefreshTokens.find_one({"token": token})
-    if blacklisted_tokens:
+    from backend.app.container import container  # at call time: container imports this module
+
+    blacklisted = await container.blacklisted_refresh_token_repo().find_by_token(token)
+    if blacklisted:
         raise HTTPException(401, "Invalid JWT")
 
 
@@ -109,7 +110,8 @@ async def add_refresh_token_to_blacklist(request: Request):
         key=settings.auth_settings.JWT_SECRET,
         algorithms=["HS256"],
     )
-    token_to_save = BlackListedRefreshTokens(
+    from backend.app.container import container  # at call time: container imports this module
+
+    await container.blacklisted_refresh_token_repo().add(
         token=refresh_token, expiry=jwt_response.get("exp")
     )
-    await token_to_save.save()

--- a/backend/backend/app/services/workspace_members_service.py
+++ b/backend/backend/app/services/workspace_members_service.py
@@ -10,7 +10,7 @@ from backend.app.models.dtos.workspace_member_dto import WorkspaceMemberDto
 from backend.app.models.enum.invitation_response import InvitationResponse
 from backend.app.models.invitation_request import InvitationRequest
 from backend.app.repositories.workspace_invitation_repo import WorkspaceInvitationRepo
-from backend.app.schemas.workspace import WorkspaceDocument
+from backend.app.repositories.workspace_repository import WorkspaceRepository
 from backend.app.schemas.workspace_invitation import WorkspaceUserInvitesDocument
 from backend.app.services.auth_cookie_service import get_expiry_epoch_after
 from backend.app.services.workspace_form_service import WorkspaceFormService
@@ -28,11 +28,13 @@ class WorkspaceMembersService:
         self,
         workspace_user_service: WorkspaceUserService,
         workspace_invitation_repo: WorkspaceInvitationRepo,
+        workspace_repo: WorkspaceRepository,
         http_client: HttpClient,
         workspace_form_service: WorkspaceFormService,
     ):
         self.workspace_user_service = workspace_user_service
         self.workspace_invitation_repository = workspace_invitation_repo
+        self.workspace_repo = workspace_repo
         self.http_client = http_client
         self.workspace_form_service = workspace_form_service
 
@@ -64,7 +66,7 @@ class WorkspaceMembersService:
             workspace_id=workspace_id, user=user
         )
 
-        workspace = await WorkspaceDocument.get(workspace_id)
+        workspace = await self.workspace_repo.get_or_404(workspace_id)
 
         workspace_invitation = (
             await self.workspace_invitation_repository.create_workspace_invitation(
@@ -153,7 +155,7 @@ class WorkspaceMembersService:
 
         if invitation_request.expiry < get_expiry_epoch_after(time_delta=timedelta()):
             invitation_request.invitation_status = InvitationStatus.EXPIRED
-            await invitation_request.save()
+            await self.workspace_invitation_repository.save(invitation_request)
             raise HTTPException(
                 status_code=HTTPStatus.GONE, content="Token has expired"
             )
@@ -170,7 +172,7 @@ class WorkspaceMembersService:
 
         else:
             invitation_request.invitation_status = InvitationStatus.DECLINED
-        await invitation_request.save()
+        await self.workspace_invitation_repository.save(invitation_request)
         return "Request Processed Successfully."
 
     async def _get_user_info_from_ids(

--- a/backend/backend/app/services/workspace_service.py
+++ b/backend/backend/app/services/workspace_service.py
@@ -22,9 +22,10 @@ from backend.app.models.workspace import (
     WorkspaceResponseDto,
     WorkspaceThemeDto,
 )
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
 from backend.app.repositories.workspace_repository import WorkspaceRepository
+from backend.app.repositories.workspace_user_repository import WorkspaceUserRepository
 from backend.app.middlewares.dynamic_cors_middleware import DynamicCORSMiddleware
-from backend.app.schemas.allowed_origin import AllowedOriginsDocument
 from backend.app.schemas.workspace import WorkspaceDocument
 from backend.app.schemas.workspace_user import WorkspaceUserDocument
 from backend.app.services.aws_service import AWSS3Service
@@ -42,6 +43,8 @@ class WorkspaceService:
         self,
         http_client: HttpClient,
         workspace_repo: WorkspaceRepository,
+        workspace_user_repo: WorkspaceUserRepository,
+        allowed_origins_repo: AllowedOriginsRepository,
         aws_service: AWSS3Service,
         workspace_user_service: WorkspaceUserService,
         workspace_form_service: WorkspaceFormService,
@@ -51,6 +54,8 @@ class WorkspaceService:
     ):
         self.http_client = http_client
         self._workspace_repo = workspace_repo
+        self._workspace_user_repo = workspace_user_repo
+        self._allowed_origins_repo = allowed_origins_repo
         self._aws_service = aws_service
         self._workspace_user_service = workspace_user_service
         self.workspace_form_service = workspace_form_service
@@ -99,8 +104,8 @@ class WorkspaceService:
                 status_code=HTTPStatus.CONFLICT, content="Cannot add more workspaces"
             )
         if workspace_name:
-            existing_workspace_with_name = await WorkspaceDocument.find_one(
-                {"workspace_name": workspace_name}
+            existing_workspace_with_name = await self._workspace_repo.find_by_name(
+                workspace_name
             )
             if existing_workspace_with_name is not None:
                 raise HTTPException(
@@ -119,20 +124,17 @@ class WorkspaceService:
             profile_image_file=profile_image_file,
             banner_image_file=banner_image_file,
         )
-        workspace_document = await workspace_document.save()
-        existing_workspace_user = await WorkspaceUserDocument.find_one(
-            {
-                "workspace_id": workspace_document.id,
-                "user_id": PydanticObjectId(user.id),
-            }
-        )
+        workspace_document = await self._workspace_repo.save(workspace_document)
+        existing_workspace_user = await self._workspace_user_repo.find_workspace_user(
+                workspace_document.id, PydanticObjectId(user.id)
+            )
         if not existing_workspace_user:
             workspace_user = WorkspaceUserDocument(
                 workspace_id=workspace_document.id,
                 user_id=user.id,
                 roles=[WorkspaceRoles.ADMIN],
             )
-            await workspace_user.save()
+            await self._workspace_user_repo.save(workspace_user)
         return WorkspaceResponseDto(**workspace_document.model_dump(mode='json'))
 
     async def patch_workspace(
@@ -164,8 +166,8 @@ class WorkspaceService:
             workspace_patch.workspace_name
             and workspace_patch.workspace_name != workspace_document.workspace_name
         ):
-            exists_by_handle = await WorkspaceDocument.find_one(
-                {"workspace_name": workspace_patch.workspace_name}
+            exists_by_handle = await self._workspace_repo.find_by_name(
+                workspace_patch.workspace_name
             )
             await self.user_tags_service.add_user_tag(
                 user_id=user.id, tag=UserTagType.WORKSPACE_HANDLE_CHANGE
@@ -192,8 +194,8 @@ class WorkspaceService:
                 raise HTTPException(status_code=403, content=MESSAGE_FORBIDDEN)
 
             try:
-                workspace = await WorkspaceDocument.find_one(
-                    {"custom_domain": workspace_patch.custom_domain}
+                workspace = await self._workspace_repo.find_by_custom_domain(
+                    workspace_patch.custom_domain
                 )
                 if not workspace:
                     existing_custom_domain = (
@@ -201,17 +203,15 @@ class WorkspaceService:
                         if workspace_document.custom_domain
                         else ""
                     )
-                    await AllowedOriginsDocument.find_one(
-                        {"origin": "https://" + existing_custom_domain or ""}
-                    ).delete()
-                    allowed_origin = await AllowedOriginsDocument.find_one(
-                        {"origin": "https://" + workspace_patch.custom_domain}
+                    await self._allowed_origins_repo.delete_by_origin(
+                        "https://" + existing_custom_domain or ""
+                    )
+                    allowed_origin = await self._allowed_origins_repo.find_by_origin(
+                        "https://" + workspace_patch.custom_domain
                     )
                     if not allowed_origin:
-                        await AllowedOriginsDocument.save(
-                            AllowedOriginsDocument(
-                                origin="https://" + workspace_patch.custom_domain
-                            )
+                        await self._allowed_origins_repo.add(
+                            "https://" + workspace_patch.custom_domain
                         )
                     await DynamicCORSMiddleware.force_refresh_origins()
                     await self.update_https_server_for_certificate(
@@ -312,7 +312,7 @@ class WorkspaceService:
         )
         workspace_document.custom_domain = ""
         await DynamicCORSMiddleware.force_refresh_origins()
-        saved_workspace = await workspace_document.save()
+        saved_workspace = await self._workspace_repo.save(workspace_document)
         return WorkspaceResponseDto(**saved_workspace.model_dump(mode='json'))
 
     async def generate_unique_names_from_the_workspace_handle(
@@ -344,11 +344,9 @@ class WorkspaceService:
         predefined_workspace_name = ["submissions", "forms", "templates"]
         if workspace_name in predefined_workspace_name:
             return False
-        existing_workspace = await WorkspaceDocument.find_one(
-            {"workspace_name": workspace_name}
-        )
+        existing_workspace = await self._workspace_repo.find_by_name(workspace_name)
         if workspace_id is not None:
-            current_workspace = await WorkspaceDocument.find_one({"_id": workspace_id})
+            current_workspace = await self._workspace_repo.find_by_id(workspace_id)
             if existing_workspace and not existing_workspace == current_workspace:
                 return False
             return True
@@ -411,7 +409,7 @@ class WorkspaceService:
                 workspace.disabled = True
             workspace.is_pro = False
             workspace.custom_domain_disabled = True
-            await workspace.save()
+            await self._workspace_repo.save(workspace)
             await self._workspace_user_service.disable_other_users_in_workspace(
                 workspace_id=workspace.id, user_id=PydanticObjectId(user_id)
             )
@@ -422,7 +420,7 @@ class WorkspaceService:
             workspace.disabled = False
             workspace.is_pro = True
             workspace.custom_domain_disabled = False
-            await workspace.save()
+            await self._workspace_repo.save(workspace)
             await self._workspace_user_service.enable_all_users_in_workspace(
                 workspace_id=workspace.id
             )
@@ -506,7 +504,7 @@ class WorkspaceService:
         await self._workspace_user_service.check_is_admin_in_workspace(
             workspace_id=workspace_id, user=user
         )
-        workspace = await WorkspaceDocument.find_one({"_id": workspace_id})
+        workspace = await self._workspace_repo.find_by_id(workspace_id)
         if (
             not workspace.custom_domain
             or workspace.custom_domain_disabled
@@ -525,7 +523,9 @@ class WorkspaceService:
             verified = False
             if response.get("domain_verified") and response.get("txt_verified"):
                 verified = True
-            await workspace.update({"$set": {"custom_domain_verified": verified}})
+            await self._workspace_repo.set_fields(
+                workspace, {"custom_domain_verified": verified}
+            )
             return response
         except Exception as e:
             loguru.logger.error(e)
@@ -533,7 +533,11 @@ class WorkspaceService:
 
 
 async def create_workspace(user: User):
-    workspace = await WorkspaceDocument.find_one({"owner_id": user.id, "default": True})
+    from backend.app.container import container  # at call time: container imports this module
+
+    workspace_repo = container.workspace_repo()
+    workspace_user_repo = container.workspace_user_repo()
+    workspace = await workspace_repo.get_default_workspace_by_owner_id(user.id)
     if not workspace:
         await event_logger_service.send_event(
             event_type=UserEventType.USER_CREATED, user_id=user.id, email=user.sub
@@ -548,13 +552,13 @@ async def create_workspace(user: User):
             workspace_name=str(user.id),
             custom_domain=None,
         )
-        await workspace.save()
+        await workspace_repo.save(workspace)
     # Save new workspace user if it is not associated yet
-    existing_workspace_user = await WorkspaceUserDocument.find_one(
-        {"workspace_id": workspace.id, "user_id": PydanticObjectId(user.id)}
+    existing_workspace_user = await workspace_user_repo.find_workspace_user(
+        workspace.id, PydanticObjectId(user.id)
     )
     if not existing_workspace_user:
         workspace_user = WorkspaceUserDocument(
             workspace_id=workspace.id, user_id=user.id, roles=[WorkspaceRoles.ADMIN]
         )
-        await workspace_user.save()
+        await workspace_user_repo.save(workspace_user)

--- a/backend/backend/app/services/workspace_user_service.py
+++ b/backend/backend/app/services/workspace_user_service.py
@@ -5,8 +5,8 @@ from beanie import PydanticObjectId
 
 from backend.app.exceptions import HTTPException
 from backend.app.models.enum.workspace_roles import WorkspaceRoles
+from backend.app.repositories.workspace_repository import WorkspaceRepository
 from backend.app.repositories.workspace_user_repository import WorkspaceUserRepository
-from backend.app.schemas.workspace import WorkspaceDocument
 from backend.app.schemas.workspace_user import WorkspaceUserDocument
 from backend.config import settings
 from common.constants import MESSAGE_FORBIDDEN
@@ -14,13 +14,18 @@ from common.models.user import User
 
 
 class WorkspaceUserService:
-    def __init__(self, workspace_user_repository: WorkspaceUserRepository):
+    def __init__(
+        self,
+        workspace_user_repository: WorkspaceUserRepository,
+        workspace_repo: WorkspaceRepository,
+    ):
         self.workspace_user_repository = workspace_user_repository
+        self.workspace_repo = workspace_repo
 
     async def check_user_has_access_in_workspace(
         self, workspace_id: PydanticObjectId, user: User
     ):
-        workspace = await WorkspaceDocument.find_one({"_id": workspace_id})
+        workspace = await self.workspace_repo.find_by_id(workspace_id)
         has_access = await self.workspace_user_repository.has_user_access_in_workspace(
             workspace_id, user
         )
@@ -32,7 +37,7 @@ class WorkspaceUserService:
     async def check_user_has_access_by_workspace_name(
         self, workspace_name: str, user: User
     ):
-        workspace = await WorkspaceDocument.find_one({"workspace_name": workspace_name})
+        workspace = await self.workspace_repo.find_by_name(workspace_name)
         has_access = await self.workspace_user_repository.has_user_access_in_workspace(
             workspace_id=workspace.id, user=user
         )
@@ -44,7 +49,7 @@ class WorkspaceUserService:
     async def check_is_admin_in_workspace(
         self, workspace_id: PydanticObjectId, user: User
     ):
-        workspace = await WorkspaceDocument.find_one({"_id": workspace_id})
+        workspace = await self.workspace_repo.find_by_id(workspace_id)
         is_admin = await self.workspace_user_repository.is_user_admin_in_workspace(
             workspace_id=workspace_id, user=user
         )
@@ -62,8 +67,8 @@ class WorkspaceUserService:
     async def add_user_to_workspace_with_role(
         self, workspace_id: PydanticObjectId, user: User, role: WorkspaceRoles
     ):
-        existing_user = await WorkspaceUserDocument.find_one(
-            {"workspace_id": workspace_id, "user_id": PydanticObjectId(user.id)}
+        existing_user = await self.workspace_user_repository.find_workspace_user(
+            workspace_id, PydanticObjectId(user.id)
         )
         if existing_user:
             return


### PR DESCRIPTION
Phase 0, **PR 4a** of the Postgres consolidation. **Pure refactor — no behaviour change, no query change.** Backend suite 233 green; live smoke of every touched path unchanged.

## Why this slice exists

The plan's step 4 assumed the repository layer was the only data-access path, so a `Protocol` + `Mongo*Repository` rename would give us the switching seam. Measured on develop, that's false: **70 direct `Document.find*/get` calls outside `backend/app/repositories/` across 19 files, plus ~50 `document.save()` writes inside services.** Each one is a place where a Mongo/Postgres switch — and the dual-write safety net — would be silently bypassed.

So step 4 becomes small slices that first route every read and write through a repository, then the seam on top:

| slice | group | files |
|---|---|---|
| **4a (this PR)** | workspaces | workspace_service, workspace_user_service, workspace_members_service, user_service, dynamic_cors_middleware |
| 4b | forms | form_service, workspace_form_service, form_schedular, template_service, integration providers, mcp/server |
| 4c | responses | form_response_service, form_import_service, workspace_responses controller |
| 4d | ai / misc | ai/*, api_keys, memory, coupon |
| 4e | the seam | `Protocol` per repository, `Mongo*Repository` rename, DI `Selector` |

## What changed

- `WorkspaceRepository`: `find_by_id`, `find_by_name`, `find_by_custom_domain`, `get_or_404` (raises exactly what `Document.get` did), `save`, `set_fields`.
- `WorkspaceUserRepository.find_workspace_user`; `WorkspaceInvitationRepo.save`.
- New `AllowedOriginsRepository` and `BlacklistedRefreshTokenRepository`.
- The three workspace services call repositories instead of documents; `document.save()` → `repo.save(document)`; the container injects the extra repositories.
- Code that isn't DI-wired — the module-level `create_workspace()`, the `get_logged_user` FastAPI dependencies, `DynamicCORSMiddleware` — resolves its repository from the container **at call time** (imported inside the function, since the container imports these modules).

Zero `*Document.find*/get/save` calls remain in the five files.

## Verified

- backend pytest: **233 passed**.
- Live: CORS preflight from an allowed origin → 200 with ACAO; from an unknown origin → 400; `GET /workspaces?workspace_name=` → 200; `/auth/status` without cookie → 401 (blacklist repository path); the #655 `all-submissions` guard still 401.
