### PR TITLE
refactor(backend): route forms-group data access through repositories

### DIFF
--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -23,6 +23,7 @@ from backend.app.repositories.form_plugin_provider_repository import (
 from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.form_response_repository import FormResponseRepository
 from backend.app.repositories.media_library_repository import MediaLibraryRepository
+from backend.app.repositories.mcp_audit_log_repository import McpAuditLogRepository
 from backend.app.repositories.responder_groups_repository import (
     ResponderGroupsRepository,
 )
@@ -123,7 +124,10 @@ class AppContainer(containers.DeclarativeContainer):
     action_repository = providers.Singleton(ActionRepository, crypto=crypto)
 
     integration_action_service: IntegrationActionService = providers.Singleton(
-        IntegrationActionService
+        IntegrationActionService, form_repo=form_repo
+    )
+    mcp_audit_log_repo: McpAuditLogRepository = providers.Singleton(
+        McpAuditLogRepository
     )
 
     temporal_service = providers.Singleton(
@@ -157,6 +161,7 @@ class AppContainer(containers.DeclarativeContainer):
         crypto=crypto,
         http_client=http_client,
         integration_action_service=integration_action_service,
+        form_repo=form_repo,
     )
 
     form_service: FormService = providers.Singleton(
@@ -204,6 +209,7 @@ class AppContainer(containers.DeclarativeContainer):
         jwt_service=jwt_service,
         temporal_service=temporal_service,
         form_response_service=form_response_service,
+        workspace_form_repo=workspace_form_repo,
     )
 
     responder_groups_service = providers.Singleton(
@@ -231,6 +237,7 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_user_service=workspace_user_service,
         form_service=form_service,
         workspace_form_repository=workspace_form_repo,
+        form_repo=form_repo,
         form_schedular=form_schedular,
         form_import_service=form_import_service,
         schedular=schedular,
@@ -399,6 +406,7 @@ class AppContainer(containers.DeclarativeContainer):
         crypto=crypto,
         http_client=http_client,
         integration_action_service=integration_action_service,
+        form_repo=form_repo,
     )
 
     form_actions_service: FormActionsService = providers.Singleton(

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -23,18 +23,19 @@ from mcp.server.transport_security import TransportSecuritySettings
 from backend.app.exceptions import HTTPException
 from backend.app.models.dtos.request_dtos import CreateFormWithAI
 from backend.app.models.dtos.response_dtos import StandardFormCamelModel
-from backend.app.schemas.mcp_audit_log import MCPAuditLogDocument
-from backend.app.schemas.standard_form import FormDocument
-from backend.app.schemas.standard_form_response import (
-    FormResponseDeletionRequest,
-    FormResponseDocument,
-)
 from backend.app.schemas.workspace_api_key import WorkspaceAPIKeyDocument
 from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.ai.api_keys import APIKeyService
 from backend.app.services.ai.chat import persist_ops_to_form
 from backend.app.services.ai.ops import parse_ops
 from backend.app.services.ai.profile import AIProfileService
+
+def _c():
+    # Resolved at call time: the container imports services this module depends on.
+    from backend.app.container import container
+
+    return container
+
 
 current_api_key: ContextVar[Optional[WorkspaceAPIKeyDocument]] = ContextVar(
     "current_api_key", default=None
@@ -79,22 +80,20 @@ async def _audit(tool: str, ok: bool, detail: str = "") -> None:
         key = current_api_key.get()
         if key is None:
             return
-        await MCPAuditLogDocument(
+        await _c().mcp_audit_log_repo().add(
             workspace_id=key.workspace_id,
             key_id=str(key.id),
             tool=tool,
             ok=ok,
             detail=detail[:300],
             at=dt.datetime.now(dt.timezone.utc),
-        ).save()
+        )
     except Exception:  # noqa: BLE001 — auditing must not break tool calls
         pass
 
 
 async def _workspace_form_ids(workspace_id: PydanticObjectId) -> Dict[str, WorkspaceFormDocument]:
-    docs = await WorkspaceFormDocument.find(
-        WorkspaceFormDocument.workspace_id == workspace_id
-    ).to_list()
+    docs = await _c().workspace_form_repo().list_in_workspace(workspace_id)
     return {d.form_id: d for d in docs}
 
 
@@ -108,7 +107,7 @@ async def list_forms() -> str:
     """List the workspace's forms: id, title, share slug and publish state."""
     key = _key("forms:read")
     workspace_forms = await _workspace_form_ids(key.workspace_id)
-    forms = await FormDocument.find({"form_id": {"$in": list(workspace_forms)}}).to_list()
+    forms = await _c().form_repo().get_forms_by_form_ids(list(workspace_forms))
     items = [
         {
             "formId": f.form_id,
@@ -128,7 +127,7 @@ async def get_form(form_id: str) -> str:
     key = _key("forms:read")
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     _require_form_in_workspace(form_id, workspace_forms)
-    form = await FormDocument.find_one({"form_id": form_id})
+    form = await _c().form_repo().get_form_document_by_id(form_id)
     await _audit("get_form", True, form_id)
     return json.dumps(
         StandardFormCamelModel(**StandardForm(**form.model_dump()).model_dump()).model_dump(
@@ -222,7 +221,7 @@ async def update_form(form_id: str, ops: List[Dict[str, Any]]) -> str:
     key = _key("forms:write")
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     _require_form_in_workspace(form_id, workspace_forms)
-    form_document = await FormDocument.find_one({"form_id": form_id})
+    form_document = await _c().form_repo().get_form_document_by_id(form_id)
     parsed = parse_ops(ops)
     form = StandardForm(**form_document.model_dump())
     _, results, updated_settings = await persist_ops_to_form(form_document, form, parsed)
@@ -242,10 +241,7 @@ async def publish_form(form_id: str) -> str:
     await container.workspace_form_service().publish_form(
         workspace_id=key.workspace_id, form_id=PydanticObjectId(form_id), user=_acting_user(key)
     )
-    refreshed = await WorkspaceFormDocument.find_one(
-        WorkspaceFormDocument.workspace_id == key.workspace_id,
-        WorkspaceFormDocument.form_id == form_id,
-    )
+    refreshed = await _c().workspace_form_repo().find_workspace_form(key.workspace_id, form_id)
     slug = refreshed.settings.custom_url if refreshed and refreshed.settings else None
     await _audit("publish_form", True, form_id)
     return json.dumps({"formId": form_id, "published": True, "slug": slug})
@@ -259,12 +255,7 @@ async def list_responses(form_id: str, limit: int = 20) -> str:
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     _require_form_in_workspace(form_id, workspace_forms)
     limit = max(1, min(limit, 100))
-    responses = (
-        await FormResponseDocument.find(FormResponseDocument.form_id == form_id)
-        .sort("-created_at")
-        .limit(limit)
-        .to_list()
-    )
+    responses = await _c().form_response_repo().list_recent_by_form_id(form_id, limit)
     items = [
         {
             "responseId": r.response_id,
@@ -283,7 +274,7 @@ async def list_responses(form_id: str, limit: int = 20) -> str:
 async def get_response(response_id: str) -> str:
     """Get one response's full answers."""
     key = _key("responses:read")
-    response = await FormResponseDocument.find_one(FormResponseDocument.response_id == response_id)
+    response = await _c().form_response_repo().find_by_response_id(response_id)
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     if not response or response.form_id not in workspace_forms:
         raise ValueError("Response not found in this workspace.")
@@ -313,9 +304,7 @@ async def list_deletion_requests() -> str:
     privacy queue an operator (or agent) should act on."""
     key = _key("deletion_requests:read")
     workspace_forms = await _workspace_form_ids(key.workspace_id)
-    requests = await FormResponseDeletionRequest.find(
-        {"form_id": {"$in": list(workspace_forms)}}
-    ).to_list()
+    requests = await _c().form_response_repo().list_deletion_requests_for_form_ids(list(workspace_forms))
     items = [
         {
             "responseId": r.response_id,

--- a/backend/backend/app/repositories/form_repository.py
+++ b/backend/backend/app/repositories/form_repository.py
@@ -284,6 +284,19 @@ class FormRepository:
     async def save_form(self, form: FormDocument):
         return await form.save()
 
+    async def save_form_version(
+        self, form_version: FormVersionsDocument
+    ) -> FormVersionsDocument:
+        return await form_version.save()
+
+    async def delete_versions_by_imported_form_id(self, imported_form_id: str):
+        return await FormVersionsDocument.find(
+            {"imported_form_id": imported_form_id}
+        ).delete()
+
+    async def get_forms_by_form_ids(self, form_ids: List[str]) -> List[FormDocument]:
+        return await FormDocument.find({"form_id": {"$in": form_ids}}).to_list()
+
     async def delete_form(self, form_id: str):
         form = await FormDocument.find_one({"form_id": form_id})
         if not form:

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -1,6 +1,6 @@
 import json
 from http import HTTPStatus
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 import fastapi_pagination.ext.beanie
@@ -245,6 +245,28 @@ class FormResponseRepository(BaseRepository):
 
     async def delete(self, item_id: str, provider: FormProvider):
         pass
+
+    async def find_by_response_id(
+        self, response_id: str
+    ) -> Optional[FormResponseDocument]:
+        return await FormResponseDocument.find_one({"response_id": response_id})
+
+    async def list_recent_by_form_id(
+        self, form_id: str, limit: int
+    ) -> List[FormResponseDocument]:
+        return (
+            await FormResponseDocument.find({"form_id": form_id})
+            .sort("-created_at")
+            .limit(limit)
+            .to_list()
+        )
+
+    async def list_deletion_requests_for_form_ids(
+        self, form_ids: List[str]
+    ) -> List[FormResponseDeletionRequest]:
+        return await FormResponseDeletionRequest.find(
+            {"form_id": {"$in": form_ids}}
+        ).to_list()
 
     async def delete_by_form_id(self, form_id):
         return await FormResponseDocument.find({"form_id": form_id}).delete()

--- a/backend/backend/app/repositories/mcp_audit_log_repository.py
+++ b/backend/backend/app/repositories/mcp_audit_log_repository.py
@@ -1,0 +1,6 @@
+from backend.app.schemas.mcp_audit_log import MCPAuditLogDocument
+
+
+class McpAuditLogRepository:
+    async def add(self, **fields) -> MCPAuditLogDocument:
+        return await MCPAuditLogDocument(**fields).save()

--- a/backend/backend/app/repositories/template.py
+++ b/backend/backend/app/repositories/template.py
@@ -119,6 +119,9 @@ class FormTemplateRepository:
         template.cover_image = template_body.cover_image
         return await template.save()
 
+    async def save(self, template: FormTemplateDocument) -> FormTemplateDocument:
+        return await template.save()
+
     async def delete_template(self, template_id: PydanticObjectId):
         template = await FormTemplateDocument.find_one({"_id": template_id})
         if not template:

--- a/backend/backend/app/repositories/workspace_form_repository.py
+++ b/backend/backend/app/repositories/workspace_form_repository.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from http import HTTPStatus
-from typing import Dict, Any, List
+from typing import Any, Dict, List, Optional
 
 from beanie import PydanticObjectId
 from common.constants import MESSAGE_DATABASE_EXCEPTION
@@ -18,6 +18,21 @@ from backend.app.schemas.workspace_form import WorkspaceFormDocument
 
 
 class WorkspaceFormRepository:
+    async def find_workspace_form(
+        self, workspace_id: PydanticObjectId, form_id: str
+    ) -> Optional[WorkspaceFormDocument]:
+        return await WorkspaceFormDocument.find_one(
+            {"form_id": form_id, "workspace_id": workspace_id}
+        )
+
+    async def list_in_workspace(
+        self, workspace_id: PydanticObjectId
+    ) -> List[WorkspaceFormDocument]:
+        return await WorkspaceFormDocument.find({"workspace_id": workspace_id}).to_list()
+
+    async def save(self, workspace_form: WorkspaceFormDocument) -> WorkspaceFormDocument:
+        return await workspace_form.save()
+
     async def update(
         self, item_id: str, item: WorkspaceFormDocument
     ) -> WorkspaceFormDocument:

--- a/backend/backend/app/schedulers/form_schedular.py
+++ b/backend/backend/app/schedulers/form_schedular.py
@@ -11,11 +11,11 @@ from loguru import logger
 
 from backend.app.exceptions import HTTPException
 from backend.app.models.enum.update_status import UpdateStatus
-from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.form_import_service import FormImportService
 from backend.app.services.form_plugin_provider_service import FormPluginProviderService
 from backend.app.services.form_response_service import FormResponseService
 from backend.app.services.temporal_service import TemporalService
+from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
 from backend.app.utils import AiohttpClient
 from backend.config import settings
 
@@ -28,12 +28,14 @@ class FormSchedular:
         jwt_service: JwtService,
         temporal_service: TemporalService,
         form_response_service: FormResponseService,
+        workspace_form_repo: WorkspaceFormRepository,
     ):
         self.form_provider_service = form_provider_service
         self.form_import_service = form_import_service
         self.jwt_service = jwt_service
         self.temporal_service = temporal_service
         self.form_response_service = form_response_service
+        self.workspace_form_repo = workspace_form_repo
 
     async def update_form(
         self,
@@ -41,8 +43,8 @@ class FormSchedular:
         form_id,
         workspace_id: PydanticObjectId = None,
     ):
-        workspace_form = await WorkspaceFormDocument.find_one(
-            {"form_id": form_id, "workspace_id": workspace_id}
+        workspace_form = await self.workspace_form_repo.find_workspace_form(
+            workspace_id, form_id
         )
         if not workspace_form:
             return
@@ -79,15 +81,15 @@ class FormSchedular:
             except HTTPException as e:
                 if e.status_code == HTTPStatus.NOT_FOUND:
                     workspace_form.last_update_status = UpdateStatus.NOT_FOUND
-                    await workspace_form.save()
+                    await self.workspace_form_repo.save(workspace_form)
                     return
                 elif e.status_code == HTTPStatus.UNAUTHORIZED:
                     workspace_form.last_update_status = UpdateStatus.INVALID_GRANT
-                    await workspace_form.save()
+                    await self.workspace_form_repo.save(workspace_form)
                     return
                 elif e.status_code == HTTPStatus.FORBIDDEN:
                     workspace_form.last_update_status = UpdateStatus.REVOKED
-                    await workspace_form.save()
+                    await self.workspace_form_repo.save(workspace_form)
                     return
             if not raw_form:
                 logger.info(
@@ -119,7 +121,7 @@ class FormSchedular:
         else:
             workspace_form.last_update_status = UpdateStatus.FAILED
             logger.info(f"Error while updating form with id {form_id} by schedular")
-        await workspace_form.save()
+        await self.workspace_form_repo.save(workspace_form)
 
     async def perform_conversion_request(
         self,

--- a/backend/backend/app/services/form_service.py
+++ b/backend/backend/app/services/form_service.py
@@ -280,7 +280,7 @@ class FormService:
     async def save_form(self, form: StandardForm):
         form_document = FormDocument(**form.model_dump(mode='json'))
         form_version_document = FormVersionsDocument(**form.model_dump(mode='json'), version=1)
-        await form_version_document.save()
+        await self._form_repo.save_form_version(form_version_document)
         return await self._form_repo.save_form(form_document)
 
     async def patch_settings_in_workspace_form(
@@ -527,7 +527,7 @@ class FormService:
             else:
                 form.secrets = {str(add_action_to_form_params.action_id): secrets}
 
-        return await form.save()
+        return await self._form_repo.save_form(form)
 
     async def remove_action_from_form(
         self, form_id: PydanticObjectId, action_id: PydanticObjectId, trigger: Trigger
@@ -545,7 +545,7 @@ class FormService:
         if form.secrets and str(action_id) in form.secrets:
             del form.secrets[str(action_id)]
 
-        return (await form.save()).actions
+        return (await self._form_repo.save_form(form)).actions
 
     async def update_state_of_action_in_form(
         self, form_id: PydanticObjectId, update_action_dto: UpdateActionInFormDto
@@ -560,7 +560,7 @@ class FormService:
                         else False
                     )
 
-        return await form.save()
+        return await self._form_repo.save_form(form)
 
     async def handle_external_integrations_services(
         self,

--- a/backend/backend/app/services/google_sheet_integration_provider.py
+++ b/backend/backend/app/services/google_sheet_integration_provider.py
@@ -8,10 +8,10 @@ from common.services.http_client import HttpClient
 
 from backend.app.models.dtos.action_dto import AddActionToFormDto
 from backend.app.models.workspace import ParameterValue
-from backend.app.schemas.standard_form import FormDocument
 from backend.app.services.base_integration_provider import BaseIntegrationProvider
 from backend.app.services.form_plugin_provider_service import FormPluginProviderService
 from backend.app.services.integration_action_service import IntegrationActionService
+from backend.app.repositories.form_repository import FormRepository
 
 
 class GoogleSheetIntegrationProvider(BaseIntegrationProvider):
@@ -21,11 +21,13 @@ class GoogleSheetIntegrationProvider(BaseIntegrationProvider):
         crypto: Crypto,
         http_client: HttpClient,
         integration_action_service: IntegrationActionService,
+        form_repo: FormRepository,
     ):
         self.form_provider_service = form_provider_service
         self.crypto = crypto
         self.http_client = http_client
         self.integration_action_service = integration_action_service
+        self._form_repo = form_repo
 
     async def get_basic_integration_oauth_url(
         self, client_referer_url: str, *args, **kwargs
@@ -70,7 +72,7 @@ class GoogleSheetIntegrationProvider(BaseIntegrationProvider):
         create_google_sheet_url = (
             f"{provider_url}/{FormProvider.GOOGLE}/forms/create_google_sheet"
         )
-        form = await FormDocument.find_one({"form_id": form_id})
+        form = await self._form_repo.get_form_document_by_id(form_id)
         title = [
             params.value
             for params in action_params.parameters

--- a/backend/backend/app/services/integration_action_service.py
+++ b/backend/backend/app/services/integration_action_service.py
@@ -1,14 +1,16 @@
 from backend.app.models.workspace import ParameterValue
-from backend.app.schemas.standard_form import FormDocument
+from backend.app.repositories.form_repository import FormRepository
 
 
 class IntegrationActionService:
+    def __init__(self, form_repo: FormRepository):
+        self._form_repo = form_repo
 
     async def add_credentials_to_form_action(
         self, form_id: str, action_id: str, credentials: str
     ):
-        form = await FormDocument.find_one({"form_id": form_id})
+        form = await self._form_repo.get_form_document_by_id(form_id)
         form.secrets = {
             str(action_id): [ParameterValue(name="Credentials", value=credentials)]
         }
-        await form.save()
+        await self._form_repo.save_form(form)

--- a/backend/backend/app/services/integration_provider_factory.py
+++ b/backend/backend/app/services/integration_provider_factory.py
@@ -8,14 +8,16 @@ from backend.app.models.enum.form_integration import FormIntegrationType
 from backend.app.services.form_plugin_provider_service import FormPluginProviderService
 from backend.app.services.google_sheet_integration_provider import GoogleSheetIntegrationProvider
 from backend.app.services.integration_action_service import IntegrationActionService
+from backend.app.repositories.form_repository import FormRepository
 
 
 class IntegrationProviderFactory:
     def __init__(self, form_provider_service: FormPluginProviderService,
                  crypto: Crypto,
-                 http_client: HttpClient, integration_action_service: IntegrationActionService) -> None:
+                 http_client: HttpClient, integration_action_service: IntegrationActionService,
+                 form_repo: FormRepository) -> None:
         self.google_integration_provider = GoogleSheetIntegrationProvider(form_provider_service, crypto, http_client,
-                                                                          integration_action_service)
+                                                                          integration_action_service, form_repo)
 
     def get_integration_provider(self, integration_type: FormIntegrationType):
         if integration_type == FormIntegrationType.GOOGLE_SHEET:

--- a/backend/backend/app/services/integration_service.py
+++ b/backend/backend/app/services/integration_service.py
@@ -5,6 +5,7 @@ from common.services.http_client import HttpClient
 from backend.app.models.enum.form_integration import FormIntegrationType
 from backend.app.services.form_plugin_provider_service import FormPluginProviderService
 from backend.app.services.integration_action_service import IntegrationActionService
+from backend.app.repositories.form_repository import FormRepository
 from backend.app.services.integration_provider_factory import IntegrationProviderFactory
 
 
@@ -15,9 +16,14 @@ class IntegrationService:
         crypto: Crypto,
         http_client: HttpClient,
         integration_action_service: IntegrationActionService,
+        form_repo: FormRepository,
     ):
         self.integration__provider_factory = IntegrationProviderFactory(
-            form_provider_service, crypto, http_client, integration_action_service
+            form_provider_service,
+            crypto,
+            http_client,
+            integration_action_service,
+            form_repo,
         )
 
     async def get_oauth_url(

--- a/backend/backend/app/services/template_service.py
+++ b/backend/backend/app/services/template_service.py
@@ -196,7 +196,7 @@ class FormTemplateService:
             )
         if settings is not None:
             template.settings.is_public = settings.is_public
-        template = await template.save()
+        template = await self.form_template_repo.save(template)
         return template
 
     async def delete_template(
@@ -230,4 +230,4 @@ class FormTemplateService:
             previous_image=template.preview_image,
         )
         template.preview_image = preview_image
-        return await template.save()
+        return await self.form_template_repo.save(template)

--- a/backend/backend/app/services/workspace_form_service.py
+++ b/backend/backend/app/services/workspace_form_service.py
@@ -29,9 +29,9 @@ from backend.app.models.dtos.response_dtos import (
     StandardFormResponseCamelModel,
 )
 from backend.app.models.workspace import WorkspaceFormSettings, WorkspaceRequestDto
+from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
 from backend.app.schedulers.form_schedular import FormSchedular
-from backend.app.schemas.form_versions import FormVersionsDocument
 from backend.app.schemas.standard_form import FormDocument
 from backend.app.schemas.template import FormTemplateDocument
 from backend.app.schemas.workspace_form import WorkspaceFormDocument
@@ -62,6 +62,7 @@ class WorkspaceFormService:
         workspace_user_service: WorkspaceUserService,
         form_service: FormService,
         workspace_form_repository: WorkspaceFormRepository,
+        form_repo: FormRepository,
         form_schedular: FormSchedular,
         form_import_service: FormImportService,
         schedular: AsyncIOScheduler,
@@ -78,6 +79,7 @@ class WorkspaceFormService:
         self.workspace_user_service = workspace_user_service
         self.form_service = form_service
         self.workspace_form_repository = workspace_form_repository
+        self._form_repo = form_repo
         self.form_schedular = form_schedular
         self.form_import_service = form_import_service
         self.schedular = schedular
@@ -228,9 +230,9 @@ class WorkspaceFormService:
 
         form = await self.form_service.get_form_document_by_id(form_id)
         if form and form.imported_form_id:
-            await FormVersionsDocument.find(
-                {"imported_form_id": form.imported_form_id}
-            ).delete()
+            await self._form_repo.delete_versions_by_imported_form_id(
+                form.imported_form_id
+            )
         await self.form_service.delete_form(form_id=form_id)
         await self.form_response_service.delete_form_responses(form_id=form_id)
         await self.form_response_service.delete_deletion_requests(form_id=form_id)
@@ -410,7 +412,7 @@ class WorkspaceFormService:
                 workspace_form.settings.response_expiration_type = (
                     form.settings.response_expiration_type
                 )
-            await workspace_form.save()
+            await self.workspace_form_repository.save(workspace_form)
 
         existing_form = await self.form_service.get_form_document_by_id(str(form_id))
 
@@ -633,7 +635,7 @@ class WorkspaceFormService:
         )
         if new_slug != current_slug:
             workspace_form.settings.custom_url = new_slug
-            await workspace_form.save()
+            await self.workspace_form_repository.save(workspace_form)
 
     async def get_form_workspace_by_id(self, workspace_id: PydanticObjectId):
         return await self.form_import_service.get_form_workspace_by_id(
@@ -680,7 +682,7 @@ class WorkspaceFormService:
             duplicated_form.created_by = user.id
         else:
             duplicated_form.form_id = str(PydanticObjectId())
-        duplicated_form = await duplicated_form.save()
+        duplicated_form = await self._form_repo.save_form(duplicated_form)
 
         if not is_template:
             workspace_form = WorkspaceFormDocument(
@@ -691,7 +693,7 @@ class WorkspaceFormService:
             )
             workspace_form.settings.provider = "self"
             workspace_form.settings.custom_url = str(duplicated_form.id)
-            workspace_form = await workspace_form.save()
+            workspace_form = await self.workspace_form_repository.save(workspace_form)
             duplicated_form.settings = workspace_form.settings
         return duplicated_form
 
@@ -816,5 +818,5 @@ class WorkspaceFormService:
             if action.id == action_id
         ][0]
         form_action.enabled = False
-        await form.save()
+        await self._form_repo.save_form(form)
         return form


### PR DESCRIPTION
Phase 0, **PR 4b** — second slice of routing every read and write through the repository layer (see #663 for why and the slice table). **Pure refactor — no behaviour change, no query change.** Backend suite: **233 passed**; black clean.

## Scope: forms group

`form_service`, `workspace_form_service`, `form_schedular`, `template_service`, `integration_action_service`, `google_sheet_integration_provider`, and `mcp/server.py` — taken whole so the file is touched once (its response and audit-log lookups came along).

## New repository surface

| repository | added |
|---|---|
| `FormRepository` | `save_form_version`, `delete_versions_by_imported_form_id`, `get_forms_by_form_ids` (existing `save_form` / `get_form_document_by_id` now carry the callers that used `form.save()` / `FormDocument.find_one` directly) |
| `WorkspaceFormRepository` | `find_workspace_form` — the exact workspace+form lookup, deliberately distinct from `get_workspace_form_in_workspace`'s `$or` on the custom slug — `list_in_workspace`, `save` |
| `FormTemplateRepository` | `save` |
| `FormResponseRepository` | `find_by_response_id`, `list_recent_by_form_id`, `list_deletion_requests_for_form_ids` (for MCP) |
| new `McpAuditLogRepository` | `add` |

## Wiring

`WorkspaceFormService` and `FormSchedular` get `form_repo` / `workspace_form_repo` injected. `IntegrationActionService`, `GoogleSheetIntegrationProvider` and `IntegrationProviderFactory` take `form_repo` — the factory is built both by the container **and** inside `IntegrationService.__init__`, so both paths pass it. `mcp/server.py` resolves repositories from the container at call time via a small `_c()` helper (the container imports it).

Zero `*Document.find*/get/save` calls remain in the seven files. Next: 4c — responses (`form_response_service`, `form_import_service`, the flow-events controller).
