### PR TITLE
refactor(backend): route responses-group data access through repositories

### DIFF
--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -22,6 +22,7 @@ from backend.app.repositories.form_plugin_provider_repository import (
 )
 from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.form_response_repository import FormResponseRepository
+from backend.app.repositories.flow_event_repository import FlowEventRepository
 from backend.app.repositories.media_library_repository import MediaLibraryRepository
 from backend.app.repositories.mcp_audit_log_repository import McpAuditLogRepository
 from backend.app.repositories.responder_groups_repository import (
@@ -111,6 +112,7 @@ class AppContainer(containers.DeclarativeContainer):
     form_response_repo: FormResponseRepository = providers.Singleton(
         FormResponseRepository, crypto=crypto
     )
+    flow_event_repo: FlowEventRepository = providers.Singleton(FlowEventRepository)
     workspace_form_repo: WorkspaceFormRepository = providers.Singleton(
         WorkspaceFormRepository
     )
@@ -178,6 +180,7 @@ class AppContainer(containers.DeclarativeContainer):
     form_response_service: FormResponseService = providers.Singleton(
         FormResponseService,
         form_response_repo=form_response_repo,
+        form_repo=form_repo,
         workspace_form_repo=workspace_form_repo,
         workspace_user_repo=workspace_user_repo,
         aws_service=aws_service,
@@ -199,7 +202,10 @@ class AppContainer(containers.DeclarativeContainer):
     )
 
     form_import_service: FormImportService = providers.Singleton(
-        FormImportService, form_service=form_service, workspace_repo=workspace_repo
+        FormImportService,
+        form_service=form_service,
+        workspace_repo=workspace_repo,
+        form_response_repo=form_response_repo,
     )
 
     form_schedular = providers.Singleton(

--- a/backend/backend/app/controllers/workspace_responses.py
+++ b/backend/backend/app/controllers/workspace_responses.py
@@ -13,8 +13,8 @@ from backend.app.models.dtos.response_dtos import StandardFormResponseCamelModel
 from backend.app.models.enum.user_tag_enum import UserTagType
 from backend.app.models.filter_queries.form_responses import FormResponseFilterQuery
 from backend.app.models.filter_queries.sort import SortRequest
+from backend.app.repositories.flow_event_repository import FlowEventRepository
 from backend.app.router import router
-from backend.app.schemas.flow_event import FlowEventDocument
 from backend.app.services.form_response_service import FormResponseService
 from backend.app.services.user_service import get_logged_user
 from backend.app.utils.custom_routable import CustomRoutable
@@ -41,11 +41,13 @@ class WorkspaceResponsesRouter(CustomRoutable):
     def __init__(
         self,
         form_response_service: FormResponseService = container.form_response_service(),
+        flow_event_repo: FlowEventRepository = container.flow_event_repo(),
         *args,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
         self._form_response_service = form_response_service
+        self._flow_event_repo = flow_event_repo
 
     @get(
         "/forms/{form_id}/submissions",
@@ -95,14 +97,18 @@ class WorkspaceResponsesRouter(CustomRoutable):
         FlowEventDocument. Inputs are length-capped so the open endpoint can't
         be used to store arbitrary payloads.
         """
-        if len(event.session_id) > 64 or len(event.from_page) > 64 or len(event.to_page) > 64:
+        if (
+            len(event.session_id) > 64
+            or len(event.from_page) > 64
+            or len(event.to_page) > 64
+        ):
             return {"ok": False}
-        await FlowEventDocument(
+        await self._flow_event_repo.add(
             form_id=form_id,
             session_id=event.session_id,
             from_page=event.from_page,
             to_page=event.to_page,
-        ).save()
+        )
         return {"ok": True}
 
     @get("/forms/{form_id}/flow-analytics")
@@ -113,9 +119,7 @@ class WorkspaceResponsesRouter(CustomRoutable):
         user: User = Depends(get_logged_user),
     ):
         """Aggregate drop-off + transition counts for the builder's Insights overlay."""
-        events = await FlowEventDocument.find(
-            FlowEventDocument.form_id == form_id
-        ).to_list()
+        events = await self._flow_event_repo.list_by_form_id(form_id)
         return aggregate_flow_events([e.model_dump() for e in events])
 
     @get(

--- a/backend/backend/app/mcp/server.py
+++ b/backend/backend/app/mcp/server.py
@@ -30,6 +30,7 @@ from backend.app.services.ai.chat import persist_ops_to_form
 from backend.app.services.ai.ops import parse_ops
 from backend.app.services.ai.profile import AIProfileService
 
+
 def _c():
     # Resolved at call time: the container imports services this module depends on.
     from backend.app.container import container
@@ -92,7 +93,9 @@ async def _audit(tool: str, ok: bool, detail: str = "") -> None:
         pass
 
 
-async def _workspace_form_ids(workspace_id: PydanticObjectId) -> Dict[str, WorkspaceFormDocument]:
+async def _workspace_form_ids(
+    workspace_id: PydanticObjectId,
+) -> Dict[str, WorkspaceFormDocument]:
     docs = await _c().workspace_form_repo().list_in_workspace(workspace_id)
     return {d.form_id: d for d in docs}
 
@@ -112,7 +115,11 @@ async def list_forms() -> str:
         {
             "formId": f.form_id,
             "title": f.title,
-            "slug": workspace_forms[f.form_id].settings.custom_url if workspace_forms[f.form_id].settings else None,
+            "slug": (
+                workspace_forms[f.form_id].settings.custom_url
+                if workspace_forms[f.form_id].settings
+                else None
+            ),
             "published": f.published_at is not None,
         }
         for f in forms
@@ -130,9 +137,9 @@ async def get_form(form_id: str) -> str:
     form = await _c().form_repo().get_form_document_by_id(form_id)
     await _audit("get_form", True, form_id)
     return json.dumps(
-        StandardFormCamelModel(**StandardForm(**form.model_dump()).model_dump()).model_dump(
-            mode="json", by_alias=True, exclude_none=True
-        )
+        StandardFormCamelModel(
+            **StandardForm(**form.model_dump()).model_dump()
+        ).model_dump(mode="json", by_alias=True, exclude_none=True)
     )
 
 
@@ -162,14 +169,20 @@ async def create_form(title: str, description: str = "") -> str:
         title=title,
         description=description or None,
         builder_version="v2",
-        welcome_page=WelcomePageField(title="", layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND),
-        thankyou_page=[ThankYouPageField(layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND)],
+        welcome_page=WelcomePageField(
+            title="", layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND
+        ),
+        thankyou_page=[
+            ThankYouPageField(layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND)
+        ],
         fields=[
             StandardFormField(
                 id=str(_uuid.uuid4()),
                 index=0,
                 type=StandardFormFieldType.SLIDE,
-                properties=StandardFieldProperty(fields=[], layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND),
+                properties=StandardFieldProperty(
+                    fields=[], layout=LayoutType.SINGLE_COLUMN_NO_BACKGROUND
+                ),
             )
         ],
     )
@@ -224,9 +237,13 @@ async def update_form(form_id: str, ops: List[Dict[str, Any]]) -> str:
     form_document = await _c().form_repo().get_form_document_by_id(form_id)
     parsed = parse_ops(ops)
     form = StandardForm(**form_document.model_dump())
-    _, results, updated_settings = await persist_ops_to_form(form_document, form, parsed)
+    _, results, updated_settings = await persist_ops_to_form(
+        form_document, form, parsed
+    )
     payload = [r.model_dump(by_alias=True) for r in results]
-    await _audit("update_form", all(r.ok for r in results), f"{form_id}: {len(results)} ops")
+    await _audit(
+        "update_form", all(r.ok for r in results), f"{form_id}: {len(results)} ops"
+    )
     return json.dumps({"results": payload, "settings": updated_settings})
 
 
@@ -239,9 +256,13 @@ async def publish_form(form_id: str) -> str:
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     _require_form_in_workspace(form_id, workspace_forms)
     await container.workspace_form_service().publish_form(
-        workspace_id=key.workspace_id, form_id=PydanticObjectId(form_id), user=_acting_user(key)
+        workspace_id=key.workspace_id,
+        form_id=PydanticObjectId(form_id),
+        user=_acting_user(key),
     )
-    refreshed = await _c().workspace_form_repo().find_workspace_form(key.workspace_id, form_id)
+    refreshed = (
+        await _c().workspace_form_repo().find_workspace_form(key.workspace_id, form_id)
+    )
     slug = refreshed.settings.custom_url if refreshed and refreshed.settings else None
     await _audit("publish_form", True, form_id)
     return json.dumps({"formId": form_id, "published": True, "slug": slug})
@@ -274,7 +295,7 @@ async def list_responses(form_id: str, limit: int = 20) -> str:
 async def get_response(response_id: str) -> str:
     """Get one response's full answers."""
     key = _key("responses:read")
-    response = await _c().form_response_repo().find_by_response_id(response_id)
+    response = await _c().form_response_repo().get_response(response_id)
     workspace_forms = await _workspace_form_ids(key.workspace_id)
     if not response or response.form_id not in workspace_forms:
         raise ValueError("Response not found in this workspace.")
@@ -285,7 +306,9 @@ async def get_response(response_id: str) -> str:
         from common.services.crypto_service import crypto_service
 
         answers = json.loads(
-            crypto_service.decrypt(workspace_id=key.workspace_id, form_id=response.form_id, data=answers)
+            crypto_service.decrypt(
+                workspace_id=key.workspace_id, form_id=response.form_id, data=answers
+            )
         )
     await _audit("get_response", True, response_id)
     return json.dumps(
@@ -293,7 +316,9 @@ async def get_response(response_id: str) -> str:
             "responseId": response.response_id,
             "formId": response.form_id,
             "submittedAt": str(getattr(response, "created_at", "")),
-            "answers": json.loads(json.dumps(answers if isinstance(answers, dict) else {}, default=str)),
+            "answers": json.loads(
+                json.dumps(answers if isinstance(answers, dict) else {}, default=str)
+            ),
         }
     )
 
@@ -304,7 +329,11 @@ async def list_deletion_requests() -> str:
     privacy queue an operator (or agent) should act on."""
     key = _key("deletion_requests:read")
     workspace_forms = await _workspace_form_ids(key.workspace_id)
-    requests = await _c().form_response_repo().list_deletion_requests_for_form_ids(list(workspace_forms))
+    requests = (
+        await _c()
+        .form_response_repo()
+        .list_deletion_requests_for_form_ids(list(workspace_forms))
+    )
     items = [
         {
             "responseId": r.response_id,
@@ -349,12 +378,17 @@ class MCPAuthMiddleware:
         try:
             key = await APIKeyService.authenticate(token)
         except HTTPException:
-            body = json.dumps({"error": "Provide a valid workspace API key as a Bearer token."}).encode()
+            body = json.dumps(
+                {"error": "Provide a valid workspace API key as a Bearer token."}
+            ).encode()
             await send(
                 {
                     "type": "http.response.start",
                     "status": 401,
-                    "headers": [(b"content-type", b"application/json"), (b"content-length", str(len(body)).encode())],
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                        (b"content-length", str(len(body)).encode()),
+                    ],
                 }
             )
             await send({"type": "http.response.body", "body": body})

--- a/backend/backend/app/repositories/flow_event_repository.py
+++ b/backend/backend/app/repositories/flow_event_repository.py
@@ -1,0 +1,15 @@
+from typing import List
+
+from backend.app.schemas.flow_event import FlowEventDocument
+
+
+class FlowEventRepository:
+    async def add(
+        self, form_id: str, session_id: str, from_page: str, to_page: str
+    ) -> FlowEventDocument:
+        return await FlowEventDocument(
+            form_id=form_id, session_id=session_id, from_page=from_page, to_page=to_page
+        ).save()
+
+    async def list_by_form_id(self, form_id: str) -> List[FlowEventDocument]:
+        return await FlowEventDocument.find({"form_id": form_id}).to_list()

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -246,11 +246,6 @@ class FormResponseRepository(BaseRepository):
     async def delete(self, item_id: str, provider: FormProvider):
         pass
 
-    async def find_by_response_id(
-        self, response_id: str
-    ) -> Optional[FormResponseDocument]:
-        return await FormResponseDocument.find_one({"response_id": response_id})
-
     async def list_recent_by_form_id(
         self, form_id: str, limit: int
     ) -> List[FormResponseDocument]:
@@ -267,6 +262,39 @@ class FormResponseRepository(BaseRepository):
         return await FormResponseDeletionRequest.find(
             {"form_id": {"$in": form_ids}}
         ).to_list()
+
+    async def list_by_form_id(self, form_id: str) -> List[FormResponseDocument]:
+        return await FormResponseDocument.find({"form_id": form_id}).to_list()
+
+    async def save(self, response: FormResponseDocument) -> FormResponseDocument:
+        return await response.save()
+
+    async def find_deletion_request_by_response_id(
+        self, response_id: str
+    ) -> Optional[FormResponseDeletionRequest]:
+        return await FormResponseDeletionRequest.find_one({"response_id": response_id})
+
+    async def delete_by_form_id_except(
+        self, form_id: str, keep_response_ids: List[str]
+    ):
+        return await FormResponseDocument.find(
+            {"form_id": form_id, "response_id": {"$nin": keep_response_ids}}
+        ).delete()
+
+    async def mark_deletion_requests_success_except(
+        self, form_id: str, provider: str, keep_response_ids: List[str], now
+    ) -> int:
+        """Imported-form refresh: responses gone at the source count as deleted."""
+        result = await FormResponseDeletionRequest.find(
+            {
+                "form_id": form_id,
+                "provider": provider,
+                "response_id": {"$nin": keep_response_ids},
+            }
+        ).update_many(
+            {"$set": {"status": DeletionRequestStatus.SUCCESS, "updated_at": now}}
+        )
+        return result.modified_count
 
     async def delete_by_form_id(self, form_id):
         return await FormResponseDocument.find({"form_id": form_id}).delete()
@@ -288,12 +316,12 @@ class FormResponseRepository(BaseRepository):
         response: StandardFormResponse,
         workspace_id: PydanticObjectId,
     ):
-        response_document = FormResponseDocument(**response.model_dump(mode='json'))
+        response_document = FormResponseDocument(**response.model_dump(mode="json"))
         response_document.submission_uuid = str(uuid4())
         if workspace_id:
             for k, v in response_document.answers.items():
                 if type(v) == StandardFormResponseAnswer:
-                    response_document.answers[k] = v.model_dump(mode='json')
+                    response_document.answers[k] = v.model_dump(mode="json")
             response_document.answers = crypto_service.encrypt(
                 workspace_id=workspace_id,
                 form_id=form_id,
@@ -326,7 +354,7 @@ class FormResponseRepository(BaseRepository):
             )
         for k, v in response.answers.items():
             if type(v) == StandardFormResponseAnswer:
-                response_document.answers[k] = v.model_dump(mode='json')
+                response_document.answers[k] = v.model_dump(mode="json")
             response_document.answers = crypto_service.encrypt(
                 workspace_id=workspace_id,
                 form_id=form_id,

--- a/backend/backend/app/repositories/workspace_form_repository.py
+++ b/backend/backend/app/repositories/workspace_form_repository.py
@@ -25,12 +25,22 @@ class WorkspaceFormRepository:
             {"form_id": form_id, "workspace_id": workspace_id}
         )
 
+    async def find_first_by_form_id(
+        self, form_id: str
+    ) -> Optional[WorkspaceFormDocument]:
+        """Any workspace's row for this form (imported forms can live in several)."""
+        return await WorkspaceFormDocument.find_one({"form_id": form_id})
+
     async def list_in_workspace(
         self, workspace_id: PydanticObjectId
     ) -> List[WorkspaceFormDocument]:
-        return await WorkspaceFormDocument.find({"workspace_id": workspace_id}).to_list()
+        return await WorkspaceFormDocument.find(
+            {"workspace_id": workspace_id}
+        ).to_list()
 
-    async def save(self, workspace_form: WorkspaceFormDocument) -> WorkspaceFormDocument:
+    async def save(
+        self, workspace_form: WorkspaceFormDocument
+    ) -> WorkspaceFormDocument:
         return await workspace_form.save()
 
     async def update(

--- a/backend/backend/app/services/form_import_service.py
+++ b/backend/backend/app/services/form_import_service.py
@@ -6,10 +6,9 @@ from beanie import PydanticObjectId
 
 from backend.app.models.enum.user_tag_enum import UserTagType
 from backend.app.models.workspace import WorkspaceResponseDto
+from backend.app.repositories.form_response_repository import FormResponseRepository
 from backend.app.repositories.workspace_repository import WorkspaceRepository
 from backend.app.schemas.standard_form_response import (
-    DeletionRequestStatus,
-    FormResponseDeletionRequest,
     FormResponseDocument,
 )
 from backend.app.services.form_service import FormService
@@ -23,9 +22,11 @@ class FormImportService:
         self,
         form_service: FormService,
         workspace_repo: WorkspaceRepository,
+        form_response_repo: FormResponseRepository,
     ):
         self.form_service = form_service
         self._workspace_repo = workspace_repo
+        self._form_response_repo = form_response_repo
 
     async def get_form_workspace_by_id(self, workspace_id: PydanticObjectId):
         return await self._workspace_repo.get_workspace_by_id(workspace_id=workspace_id)
@@ -65,33 +66,22 @@ class FormImportService:
                     form_id=response_document.form_id,
                     data=json.dumps(response_document.answers),
                 )
-            await response_document.save()
+            await self._form_response_repo.save(response_document)
             updated_responses_id.append(response.response_id)
 
-        deletion_requests_query = {
-            "form_id": standard_form.form_id,
-            "provider": standard_form.settings.provider,
-            "response_id": {"$nin": updated_responses_id},
-        }
-
-        await FormResponseDocument.find(
-            {
-                "form_id": standard_form.form_id,
-                "response_id": {"$nin": updated_responses_id},
-            }
-        ).delete()
-
-        updated_result = await FormResponseDeletionRequest.find(
-            deletion_requests_query
-        ).update_many(
-            {
-                "$set": {
-                    "status": DeletionRequestStatus.SUCCESS,
-                    "updated_at": datetime.datetime.now(datetime.timezone.utc),
-                },
-            }
+        await self._form_response_repo.delete_by_form_id_except(
+            standard_form.form_id, updated_responses_id
         )
-        if updated_result.modified_count >= 1:
+
+        modified_count = (
+            await self._form_response_repo.mark_deletion_requests_success_except(
+                form_id=standard_form.form_id,
+                provider=standard_form.settings.provider,
+                keep_response_ids=updated_responses_id,
+                now=datetime.datetime.now(datetime.timezone.utc),
+            )
+        )
+        if modified_count >= 1:
             workspace = await self._workspace_repo.get_workspace_by_id(
                 workspace_id=workspace_id
             )

--- a/backend/backend/app/services/form_response_service.py
+++ b/backend/backend/app/services/form_response_service.py
@@ -3,7 +3,6 @@ from http import HTTPStatus
 from typing import List, Sequence
 
 from beanie import PydanticObjectId
-from beanie.odm.enums import SortDirection
 from common.constants import MESSAGE_FORBIDDEN, MESSAGE_NOT_FOUND
 from common.models.standard_form import (
     StandardFormResponse,
@@ -25,16 +24,14 @@ from backend.app.models.dtos.response_dtos import (
 )
 from backend.app.models.filter_queries.form_responses import FormResponseFilterQuery
 from backend.app.models.filter_queries.sort import SortRequest
+from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.form_response_repository import FormResponseRepository
 from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
 from backend.app.repositories.workspace_user_repository import WorkspaceUserRepository
-from backend.app.schemas.form_versions import FormVersionsDocument
-from backend.app.schemas.standard_form import FormDocument
 from backend.app.schemas.standard_form_response import (
     FormResponseDeletionRequest,
     FormResponseDocument,
 )
-from backend.app.schemas.workspace_form import WorkspaceFormDocument
 from backend.app.services.aws_service import AWSS3Service
 from backend.app.utils.hash import hash_string
 
@@ -43,11 +40,13 @@ class FormResponseService:
     def __init__(
         self,
         form_response_repo: FormResponseRepository,
+        form_repo: FormRepository,
         workspace_form_repo: WorkspaceFormRepository,
         workspace_user_repo: WorkspaceUserRepository,
         aws_service: AWSS3Service,
     ):
         self._form_response_repo = form_response_repo
+        self._form_repo = form_repo
         self._workspace_form_repo = workspace_form_repo
         self._workspace_user_repo = workspace_user_repo
         self._aws_service = aws_service
@@ -128,7 +127,7 @@ class FormResponseService:
         form_responses = await self._form_response_repo.list(
             [form_id], request_for_deletion, filter_query, sort
         )
-        form = await FormDocument.find_one({"form_id": form_id})
+        form = await self._form_repo.get_form_document_by_id(form_id)
         file_fields = []
         if form is not None:
             file_fields = get_fields_of_type_file_upload(form)
@@ -166,7 +165,7 @@ class FormResponseService:
             raise HTTPException(
                 HTTPStatus.NOT_FOUND, "Form not found in the workspace."
             )
-        form_responses = await FormResponseDocument.find({"form_id": form_id}).to_list()
+        form_responses = await self._form_response_repo.list_by_form_id(form_id)
         return self.decrypt_form_responses(
             workspace_id=workspace_id, responses=form_responses
         )
@@ -177,33 +176,25 @@ class FormResponseService:
         is_admin = await self._workspace_user_repo.has_user_access_in_workspace(
             workspace_id, user
         )
-        response = await FormResponseDocument.find_one({"response_id": response_id})
+        response = await self._form_response_repo.get_response(response_id)
         if not response:
             raise HTTPException(HTTPStatus.NOT_FOUND, MESSAGE_NOT_FOUND)
         if response.form_version:
-            form = await FormVersionsDocument.find_one(
-                {
-                    "form_id": response.form_id,
-                    "version": response.form_version if response.form_version else 1,
-                }
+            form = await self._form_repo.get_form_by_by_version(
+                response.form_id, response.form_version if response.form_version else 1
             )
         else:
-            form = (
-                await FormVersionsDocument.find({"form_id": response.form_id})
-                .sort(("version", SortDirection.DESCENDING))
-                .first_or_none()
-            )
-            form = await FormDocument.find_one({"form_id": response.form_id})
+            form = await self._form_repo.get_latest_version_of_form(response.form_id)
+            form = await self._form_repo.get_form_document_by_id(response.form_id)
         if not form:
-            form = await FormDocument.find_one({"form_id": response.form_id})
-        deletion_request = await FormResponseDeletionRequest.find_one(
-            {"response_id": response_id}
+            form = await self._form_repo.get_form_document_by_id(response.form_id)
+        deletion_request = (
+            await self._form_response_repo.find_deletion_request_by_response_id(
+                response_id
+            )
         )
-        workspace_form = await WorkspaceFormDocument.find_one(
-            {
-                "workspace_id": workspace_id,
-                "form_id": form.form_id,
-            }
+        workspace_form = await self._workspace_form_repo.find_workspace_form(
+            workspace_id, form.form_id
         )
         if not workspace_form:
             raise HTTPException(404, "Form not found in this workspace")
@@ -247,7 +238,7 @@ class FormResponseService:
             workspace_id, user
         )
         # TODO : Handle case for multiple form import by other user
-        response = await FormResponseDocument.find_one({"response_id": response_id})
+        response = await self._form_response_repo.get_response(response_id)
 
         # Anonymous responses carry no dataOwnerIdentifier — their owner is
         # recognisable only by the anonymous identity hash. Without this check
@@ -256,12 +247,17 @@ class FormResponseService:
         if not (
             is_admin
             or response.dataOwnerIdentifier == user.sub
-            or (response.anonymous_identity is not None and response.anonymous_identity == hash_string(user.sub))
+            or (
+                response.anonymous_identity is not None
+                and response.anonymous_identity == hash_string(user.sub)
+            )
         ):
             raise HTTPException(403, "You are not authorized to perform this action.")
 
-        deletion_request = await FormResponseDeletionRequest.find_one(
-            {"response_id": response_id}
+        deletion_request = (
+            await self._form_response_repo.find_deletion_request_by_response_id(
+                response_id
+            )
         )
         if deletion_request:
             raise HTTPException(
@@ -407,16 +403,15 @@ class FormResponseService:
         await self._form_response_repo.verify_response_exists_in_workspace(
             workspace_id=workspace_id, response_id=response.response_id
         )
-        form = await FormVersionsDocument.find_one(
-            {
-                "form_id": response.form_id,
-                "version": response.form_version if response.form_version else 1,
-            }
+        form = await self._form_repo.get_form_by_by_version(
+            response.form_id, response.form_version if response.form_version else 1
         )
         if not form:
-            form = await FormDocument.find_one({"form_id": response.form_id})
+            form = await self._form_repo.get_form_document_by_id(response.form_id)
 
-        workspace_form = await WorkspaceFormDocument.find_one({"form_id": form.form_id})
+        workspace_form = await self._workspace_form_repo.find_first_by_form_id(
+            form.form_id
+        )
         form.settings = workspace_form.settings
 
         decrypted_response = self.decrypt_form_response(
@@ -433,15 +428,17 @@ class FormResponseService:
     async def request_for_response_deletion_by_uuid(
         self, workspace_id, submission_uuid
     ):
-        response = await FormResponseDocument.find_one(
-            {"submission_uuid": submission_uuid}
+        response = await self._form_response_repo.get_by_submission_uuid(
+            submission_uuid
         )
         response_id = response.response_id
         await self._form_response_repo.verify_response_exists_in_workspace(
             workspace_id=workspace_id, response_id=response_id
         )
-        deletion_request = await FormResponseDeletionRequest.find_one(
-            {"response_id": response_id}
+        deletion_request = (
+            await self._form_response_repo.find_deletion_request_by_response_id(
+                response_id
+            )
         )
         if deletion_request:
             raise HTTPException(


### PR DESCRIPTION
Phase 0, **PR 4c** — third slice of routing every read and write through the repository layer (see #663 for why and the slice table). **Pure refactor — no behaviour change, no query change.** Backend suite: **233 passed**; black clean.

## Scope: responses group

`form_response_service`, `form_import_service`, and the flow-events endpoints in `controllers/workspace_responses.py`.

## New repository surface

| repository | added |
|---|---|
| `FormResponseRepository` | `list_by_form_id`, `save`, `find_deletion_request_by_response_id`, `delete_by_form_id_except`, `mark_deletion_requests_success_except` (imported-form refresh: responses gone at the source count as deleted; returns the modified count the service already checked) |
| `WorkspaceFormRepository` | `find_first_by_form_id` — any workspace's row for a form; imported forms can live in several |
| new `FlowEventRepository` | `add`, `list_by_form_id` |

One tidy-up: the `find_by_response_id` I added in #664 duplicated the pre-existing `get_response`; removed, and `mcp/server` uses `get_response`.

## Wiring

`FormResponseService` gets `form_repo` and uses the existing `FormRepository` lookups (`get_form_document_by_id`, `get_form_by_by_version`, `get_latest_version_of_form`) instead of `FormDocument` / `FormVersionsDocument`. `FormImportService` gets `form_response_repo`. The responses router takes `flow_event_repo` from the container the same way it already took the service.

Zero `*Document.find*/get/save` calls remain in the three files. After this slice the only direct document access left in `backend/app` outside `repositories/` is the AI group (`services/ai/*`, `api_keys`, `memory`) and two `coupon_document.save()` calls — slice 4d.
