### PR TITLE
feat(backend): put every repository behind the Mongo/Postgres routing seam

### DIFF
--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -14,6 +14,9 @@ from pymongo import AsyncMongoClient
 from backend.app.repositories.ai_preference_memory_repository import (
     AIPreferenceMemoryRepository,
 )
+from common.db import load_flags
+from common.db.routing import RoutingRepository
+
 from backend.app.repositories.action_repository import ActionRepository
 from backend.app.repositories.form_ai_insight_repository import FormAIInsightRepository
 from backend.app.repositories.form_ai_session_repository import FormAISessionRepository
@@ -98,8 +101,16 @@ class AppContainer(containers.DeclarativeContainer):
     http_client: HttpClient = providers.Singleton(HttpClient)
 
     database_client: AsyncMongoClient = providers.Object(None)
+    # Mongo/Postgres switching (plans/postgres-consolidation.md D5): read once at boot,
+    # validated; a bad combination refuses to start.
+    flags = providers.Singleton(load_flags)
 
-    user_tags_repo = providers.Singleton(UserTagsRepository)
+    user_tags_repo = providers.Singleton(
+        RoutingRepository,
+        group="identity",
+        flags=flags,
+        mongo=providers.Singleton(UserTagsRepository),
+    )
     user_tags_service = providers.Singleton(
         UserTagsService, user_tags_repo=user_tags_repo
     )
@@ -107,45 +118,123 @@ class AppContainer(containers.DeclarativeContainer):
 
     # Repositories
 
-    coupon_repository: CouponRepository = providers.Singleton(CouponRepository)
-    workspace_user_repo: WorkspaceUserRepository = providers.Singleton(
-        WorkspaceUserRepository
+    coupon_repository: CouponRepository = providers.Singleton(
+        RoutingRepository,
+        group="refdata",
+        flags=flags,
+        mongo=providers.Singleton(CouponRepository),
     )
-    workspace_repo: WorkspaceRepository = providers.Singleton(WorkspaceRepository)
+    workspace_user_repo: WorkspaceUserRepository = providers.Singleton(
+        RoutingRepository,
+        group="identity",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceUserRepository),
+    )
+    workspace_repo: WorkspaceRepository = providers.Singleton(
+        RoutingRepository,
+        group="identity",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceRepository),
+    )
     allowed_origins_repo: AllowedOriginsRepository = providers.Singleton(
-        AllowedOriginsRepository
+        RoutingRepository,
+        group="refdata",
+        flags=flags,
+        mongo=providers.Singleton(AllowedOriginsRepository),
     )
     blacklisted_refresh_token_repo: BlacklistedRefreshTokenRepository = (
-        providers.Singleton(BlacklistedRefreshTokenRepository)
+        providers.Singleton(
+            RoutingRepository,
+            group="identity",
+            flags=flags,
+            mongo=providers.Singleton(BlacklistedRefreshTokenRepository),
+        )
     )
 
-    form_repo: FormRepository = providers.Singleton(FormRepository)
-    form_response_repo: FormResponseRepository = providers.Singleton(
-        FormResponseRepository, crypto=crypto
+    form_repo: FormRepository = providers.Singleton(
+        RoutingRepository,
+        group="forms",
+        flags=flags,
+        mongo=providers.Singleton(FormRepository),
     )
-    flow_event_repo: FlowEventRepository = providers.Singleton(FlowEventRepository)
-    form_ai_insight_repo = providers.Singleton(FormAIInsightRepository)
-    form_ai_session_repo = providers.Singleton(FormAISessionRepository)
-    workspace_ai_profile_repo = providers.Singleton(WorkspaceAIProfileRepository)
-    workspace_api_key_repo = providers.Singleton(WorkspaceAPIKeyRepository)
-    ai_preference_memory_repo = providers.Singleton(AIPreferenceMemoryRepository)
+    form_response_repo: FormResponseRepository = providers.Singleton(
+        RoutingRepository,
+        group="responses",
+        flags=flags,
+        mongo=providers.Singleton(FormResponseRepository, crypto=crypto),
+    )
+    flow_event_repo: FlowEventRepository = providers.Singleton(
+        RoutingRepository,
+        group="analytics",
+        flags=flags,
+        mongo=providers.Singleton(FlowEventRepository),
+    )
+    form_ai_insight_repo = providers.Singleton(
+        RoutingRepository,
+        group="ai",
+        flags=flags,
+        mongo=providers.Singleton(FormAIInsightRepository),
+    )
+    form_ai_session_repo = providers.Singleton(
+        RoutingRepository,
+        group="ai",
+        flags=flags,
+        mongo=providers.Singleton(FormAISessionRepository),
+    )
+    workspace_ai_profile_repo = providers.Singleton(
+        RoutingRepository,
+        group="ai",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceAIProfileRepository),
+    )
+    workspace_api_key_repo = providers.Singleton(
+        RoutingRepository,
+        group="identity",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceAPIKeyRepository),
+    )
+    ai_preference_memory_repo = providers.Singleton(
+        RoutingRepository,
+        group="ai",
+        flags=flags,
+        mongo=providers.Singleton(AIPreferenceMemoryRepository),
+    )
     workspace_form_repo: WorkspaceFormRepository = providers.Singleton(
-        WorkspaceFormRepository
+        RoutingRepository,
+        group="forms",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceFormRepository),
     )
 
     form_provider_repo: FormPluginProviderRepository = providers.Singleton(
-        FormPluginProviderRepository
+        RoutingRepository,
+        group="refdata",
+        flags=flags,
+        mongo=providers.Singleton(FormPluginProviderRepository),
     )
 
-    responder_groups_repository = providers.Singleton(ResponderGroupsRepository)
+    responder_groups_repository = providers.Singleton(
+        RoutingRepository,
+        group="responses",
+        flags=flags,
+        mongo=providers.Singleton(ResponderGroupsRepository),
+    )
 
-    action_repository = providers.Singleton(ActionRepository, crypto=crypto)
+    action_repository = providers.Singleton(
+        RoutingRepository,
+        group="actions",
+        flags=flags,
+        mongo=providers.Singleton(ActionRepository, crypto=crypto),
+    )
 
     integration_action_service: IntegrationActionService = providers.Singleton(
         IntegrationActionService, form_repo=form_repo
     )
     mcp_audit_log_repo: McpAuditLogRepository = providers.Singleton(
-        McpAuditLogRepository
+        RoutingRepository,
+        group="ai",
+        flags=flags,
+        mongo=providers.Singleton(McpAuditLogRepository),
     )
 
     temporal_service = providers.Singleton(
@@ -354,7 +443,10 @@ class AppContainer(containers.DeclarativeContainer):
     )
 
     workspace_invitation_repo: WorkspaceInvitationRepo = providers.Singleton(
-        WorkspaceInvitationRepo
+        RoutingRepository,
+        group="identity",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceInvitationRepo),
     )
 
     workspace_members_service: WorkspaceMembersService = providers.Singleton(
@@ -375,14 +467,24 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_service=workspace_service,
     )
 
-    workspace_responders_repo = providers.Singleton(WorkspaceRespondersRepository)
+    workspace_responders_repo = providers.Singleton(
+        RoutingRepository,
+        group="responses",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceRespondersRepository),
+    )
     workspace_responders_service = providers.Singleton(
         WorkspaceRespondersService,
         workspace_responders_repo=workspace_responders_repo,
         workspace_user_service=workspace_user_service,
         form_response_service=form_response_service,
     )
-    workspace_consent_repo = providers.Singleton(WorkspaceConsentRepo)
+    workspace_consent_repo = providers.Singleton(
+        RoutingRepository,
+        group="forms",
+        flags=flags,
+        mongo=providers.Singleton(WorkspaceConsentRepo),
+    )
 
     workspace_consent_service = providers.Singleton(
         WorkspaceConsentService,
@@ -390,7 +492,12 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_consent_repo=workspace_consent_repo,
     )
 
-    form_template_repo = providers.Singleton(FormTemplateRepository)
+    form_template_repo = providers.Singleton(
+        RoutingRepository,
+        group="forms",
+        flags=flags,
+        mongo=providers.Singleton(FormTemplateRepository),
+    )
 
     form_template_service = providers.Singleton(
         FormTemplateService,
@@ -401,7 +508,12 @@ class AppContainer(containers.DeclarativeContainer):
         temporal_service=temporal_service,
     )
 
-    user_feedback_repo = providers.Singleton(UserFeedbackRepo)
+    user_feedback_repo = providers.Singleton(
+        RoutingRepository,
+        group="refdata",
+        flags=flags,
+        mongo=providers.Singleton(UserFeedbackRepo),
+    )
 
     user_feedback_service = providers.Singleton(
         UserFeedbackService, user_feedback_repo=user_feedback_repo
@@ -420,7 +532,12 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_service=workspace_service,
     )
 
-    media_library_repo = providers.Singleton(MediaLibraryRepository)
+    media_library_repo = providers.Singleton(
+        RoutingRepository,
+        group="forms",
+        flags=flags,
+        mongo=providers.Singleton(MediaLibraryRepository),
+    )
 
     media_library_service = providers.Singleton(
         MediaLibraryService,

--- a/backend/backend/app/repositories/action_repository.py
+++ b/backend/backend/app/repositories/action_repository.py
@@ -7,12 +7,14 @@ from common.models.user import User
 from backend.app.models.dtos.action_dto import ActionDto, ActionResponse
 from backend.app.schemas.action_document import ActionDocument, WorkspaceActionsDocument
 from backend.app.schemas.standard_form import FormDocument
+from common.db.routing import write_op
 
 
 class ActionRepository:
     def __init__(self, crypto: Crypto):
         self.crypto = crypto
 
+    @write_op
     async def create_action(
         self, workspace_id: PydanticObjectId, action: ActionDto, user: User
     ):
@@ -20,13 +22,14 @@ class ActionRepository:
             for secret in action.secrets:
                 secret.value = self.crypto.encrypt(secret.value)
         new_action = ActionDocument(
-            **action.model_dump(mode='json'),
+            **action.model_dump(mode="json"),
             created_by=PydanticObjectId(user.id),
             workspace_id=workspace_id,
         )
         new_action = await new_action.save()
-        return ActionResponse(**new_action.model_dump(mode='json'))
+        return ActionResponse(**new_action.model_dump(mode="json"))
 
+    @write_op
     async def delete_action(self, action_id: PydanticObjectId):
         await ActionDocument.find_one(ActionDocument.id == action_id).delete()
         return action_id
@@ -100,6 +103,7 @@ class ActionRepository:
         # return [ActionResponse(**action, id=action["_id"]) for action in actions]
 
     # TODO resolve circular deps with action_service and workspace_form_service and update in workspace form repo
+    @write_op
     async def remove_action_form_all_forms(self, action_id: PydanticObjectId):
         await FormDocument.find(
             {
@@ -118,6 +122,7 @@ class ActionRepository:
             }
         )
 
+    @write_op
     async def create_action_in_workspace_from_action(
         self,
         workspace_id: PydanticObjectId,
@@ -139,10 +144,11 @@ class ActionRepository:
         await workspace_action.save()
         return workspace_action
 
+    @write_op
     async def create_global_action(self, action: ActionDto, user: User):
         if action.secrets is not None:
             for secret in action.secrets:
                 secret.value = self.crypto.encrypt(secret.value)
         return await ActionDocument(
-            **action.model_dump(mode='json'), created_by=PydanticObjectId(user.id)
+            **action.model_dump(mode="json"), created_by=PydanticObjectId(user.id)
         ).save()

--- a/backend/backend/app/repositories/ai_preference_memory_repository.py
+++ b/backend/backend/app/repositories/ai_preference_memory_repository.py
@@ -3,6 +3,7 @@ from typing import Optional
 from beanie import PydanticObjectId
 
 from backend.app.schemas.ai_preference_memory import UserAIPreferenceMemoryDocument
+from common.db.routing import write_op
 
 
 class AIPreferenceMemoryRepository:
@@ -13,6 +14,7 @@ class AIPreferenceMemoryRepository:
             {"workspace_id": workspace_id, "user_id": user_id}
         )
 
+    @write_op
     async def save(
         self, document: UserAIPreferenceMemoryDocument
     ) -> UserAIPreferenceMemoryDocument:

--- a/backend/backend/app/repositories/allowed_origins_repository.py
+++ b/backend/backend/app/repositories/allowed_origins_repository.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+from common.db.routing import write_op
 
 
 class AllowedOriginsRepository:
@@ -13,8 +14,10 @@ class AllowedOriginsRepository:
     async def find_by_origin(self, origin: str) -> Optional[AllowedOriginsDocument]:
         return await AllowedOriginsDocument.find_one({"origin": origin})
 
+    @write_op
     async def add(self, origin: str) -> AllowedOriginsDocument:
         return await AllowedOriginsDocument(origin=origin).save()
 
+    @write_op
     async def delete_by_origin(self, origin: str) -> None:
         await AllowedOriginsDocument.find_one({"origin": origin}).delete()

--- a/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
+++ b/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
@@ -1,11 +1,13 @@
 from typing import Optional
 
 from backend.app.schemas.blacklisted_refresh_tokens import BlackListedRefreshTokens
+from common.db.routing import write_op
 
 
 class BlacklistedRefreshTokenRepository:
     async def find_by_token(self, token: str) -> Optional[BlackListedRefreshTokens]:
         return await BlackListedRefreshTokens.find_one({"token": token})
 
+    @write_op
     async def add(self, token: str, expiry) -> BlackListedRefreshTokens:
         return await BlackListedRefreshTokens(token=token, expiry=expiry).save()

--- a/backend/backend/app/repositories/coupon_repository.py
+++ b/backend/backend/app/repositories/coupon_repository.py
@@ -2,13 +2,16 @@ from typing import List
 
 from backend.app.models.types.coupon_code import CouponCode
 from backend.app.schemas.coupon_codes import CouponCodeDocument
+from common.db.routing import write_op
 
 
 class CouponRepository:
+    @write_op
     async def create_coupons(self, coupons: List[CouponCodeDocument]):
         await CouponCodeDocument.insert_many(coupons)
         return "Created"
 
+    @write_op
     async def save(self, coupon: CouponCodeDocument) -> CouponCodeDocument:
         return await coupon.save()
 

--- a/backend/backend/app/repositories/deletion_requests_repository.py
+++ b/backend/backend/app/repositories/deletion_requests_repository.py
@@ -52,7 +52,13 @@ class DeletionRequestsRepository:
                     "as": "response_doc",
                 },
             },
-            {"$set": {"submission_uuid": {"$arrayElemAt": ["$response_doc.submission_uuid", 0]}}},
+            {
+                "$set": {
+                    "submission_uuid": {
+                        "$arrayElemAt": ["$response_doc.submission_uuid", 0]
+                    }
+                }
+            },
             {"$unset": "response_doc"},
         ]
 

--- a/backend/backend/app/repositories/flow_event_repository.py
+++ b/backend/backend/app/repositories/flow_event_repository.py
@@ -1,9 +1,11 @@
 from typing import List
 
 from backend.app.schemas.flow_event import FlowEventDocument
+from common.db.routing import write_op
 
 
 class FlowEventRepository:
+    @write_op
     async def add(
         self, form_id: str, session_id: str, from_page: str, to_page: str
     ) -> FlowEventDocument:

--- a/backend/backend/app/repositories/form_ai_insight_repository.py
+++ b/backend/backend/app/repositories/form_ai_insight_repository.py
@@ -3,6 +3,7 @@ from typing import Optional
 from beanie import PydanticObjectId
 
 from backend.app.schemas.form_ai_insight import FormAIInsightDocument
+from common.db.routing import write_op
 
 
 class FormAIInsightRepository:
@@ -13,5 +14,6 @@ class FormAIInsightRepository:
             {"workspace_id": workspace_id, "form_id": form_id}
         )
 
+    @write_op
     async def save(self, document: FormAIInsightDocument) -> FormAIInsightDocument:
         return await document.save()

--- a/backend/backend/app/repositories/form_ai_session_repository.py
+++ b/backend/backend/app/repositories/form_ai_session_repository.py
@@ -1,6 +1,7 @@
 from beanie import PydanticObjectId
 
 from backend.app.schemas.form_ai_session import FormAISessionDocument
+from common.db.routing import write_op
 
 
 class FormAISessionRepository:
@@ -8,5 +9,6 @@ class FormAISessionRepository:
         """Raises the document layer's NotFoundError when missing, like Document.get."""
         return await FormAISessionDocument.get(session_id)
 
+    @write_op
     async def save(self, session: FormAISessionDocument) -> FormAISessionDocument:
         return await session.save()

--- a/backend/backend/app/repositories/form_plugin_provider_repository.py
+++ b/backend/backend/app/repositories/form_plugin_provider_repository.py
@@ -14,6 +14,7 @@ from backend.app.models.form_plugin_config import FormProviderConfigDto
 from backend.app.schemas.form_plugin_config import FormPluginConfigDocument
 from common.base.repo import BaseRepository
 from common.constants import MESSAGE_DATABASE_EXCEPTION
+from common.db.routing import write_op
 
 
 class FormPluginProviderRepository(BaseRepository):
@@ -22,7 +23,7 @@ class FormPluginProviderRepository(BaseRepository):
             document = await FormPluginConfigDocument.find_many().to_list()
             if document:
                 return [
-                    FormProviderConfigDto(**provider.model_dump(mode='json'))
+                    FormProviderConfigDto(**provider.model_dump(mode="json"))
                     for provider in document
                 ]
             return []
@@ -55,6 +56,7 @@ class FormPluginProviderRepository(BaseRepository):
             {"provider_name": provider_name}, projection_model=self.ProviderUrlProject
         )
 
+    @write_op
     async def add(self, item: FormPluginConfigDocument) -> FormPluginConfigDocument:
         try:
             return await item.save()
@@ -64,6 +66,7 @@ class FormPluginProviderRepository(BaseRepository):
                 content=MESSAGE_DATABASE_EXCEPTION,
             )
 
+    @write_op
     async def update(
         self, provider_name: str, item: FormPluginConfigDocument
     ) -> FormPluginConfigDocument:

--- a/backend/backend/app/repositories/form_repository.py
+++ b/backend/backend/app/repositories/form_repository.py
@@ -11,6 +11,7 @@ from backend.app.schemas.form_versions import FormVersionsDocument
 from backend.app.schemas.standard_form import FormDocument
 from backend.app.models.dtos.form_actions_dto import FormActionsDto
 from backend.app.utils.aggregation_query_builder import create_filter_pipeline
+from common.db.routing import write_op
 
 
 class FormRepository:
@@ -281,14 +282,17 @@ class FormRepository:
             .to_list()
         )
 
+    @write_op
     async def save_form(self, form: FormDocument):
         return await form.save()
 
+    @write_op
     async def save_form_version(
         self, form_version: FormVersionsDocument
     ) -> FormVersionsDocument:
         return await form_version.save()
 
+    @write_op
     async def delete_versions_by_imported_form_id(self, imported_form_id: str):
         return await FormVersionsDocument.find(
             {"imported_form_id": imported_form_id}
@@ -297,19 +301,23 @@ class FormRepository:
     async def get_forms_by_form_ids(self, form_ids: List[str]) -> List[FormDocument]:
         return await FormDocument.find({"form_id": {"$in": form_ids}}).to_list()
 
+    @write_op
     async def delete_form(self, form_id: str):
         form = await FormDocument.find_one({"form_id": form_id})
         if not form:
             raise HTTPException(status_code=404, content="Form not found")
         return await form.delete()
 
+    @write_op
     async def delete_forms(self, form_ids: List[str]):
         return await FormDocument.find({"form_id": {"$in": form_ids}}).delete()
 
+    @write_op
     async def create_form(self, form: StandardForm) -> FormDocument:
-        form_document = FormDocument(**form.model_dump(mode='json'))
+        form_document = FormDocument(**form.model_dump(mode="json"))
         return await form_document.save()
 
+    @write_op
     async def update_form(self, form_id: PydanticObjectId, form: StandardForm):
         form_document = await FormDocument.find_one({"form_id": str(form_id)})
         form_document.fields = form.fields
@@ -349,14 +357,18 @@ class FormRepository:
             {"form_id": form_id, "version": version}
         )
 
+    @write_op
     async def publish_form(self, form: FormDocument, version: int):
-        new_form_version = FormVersionsDocument(**form.model_dump(mode='json'), version=version)
+        new_form_version = FormVersionsDocument(
+            **form.model_dump(mode="json"), version=version
+        )
         new_form_version.id = None
         return await new_form_version.save()
 
     async def get_form_by_id(self, form_id: PydanticObjectId):
         return await FormDocument.find_one({"form_id": str(form_id)})
 
+    @write_op
     async def update_form_actions(
         self,
         form_id: PydanticObjectId,

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -27,6 +27,7 @@ from backend.app.schemas.standard_form_response import (
     DeletionRequestStatus,
 )
 from backend.app.utils.aggregation_query_builder import create_filter_pipeline
+from common.db.routing import write_op
 
 
 class FormResponseRepository(BaseRepository):
@@ -266,6 +267,7 @@ class FormResponseRepository(BaseRepository):
     async def list_by_form_id(self, form_id: str) -> List[FormResponseDocument]:
         return await FormResponseDocument.find({"form_id": form_id}).to_list()
 
+    @write_op
     async def save(self, response: FormResponseDocument) -> FormResponseDocument:
         return await response.save()
 
@@ -274,6 +276,7 @@ class FormResponseRepository(BaseRepository):
     ) -> Optional[FormResponseDeletionRequest]:
         return await FormResponseDeletionRequest.find_one({"response_id": response_id})
 
+    @write_op
     async def delete_by_form_id_except(
         self, form_id: str, keep_response_ids: List[str]
     ):
@@ -281,6 +284,7 @@ class FormResponseRepository(BaseRepository):
             {"form_id": form_id, "response_id": {"$nin": keep_response_ids}}
         ).delete()
 
+    @write_op
     async def mark_deletion_requests_success_except(
         self, form_id: str, provider: str, keep_response_ids: List[str], now
     ) -> int:
@@ -296,20 +300,25 @@ class FormResponseRepository(BaseRepository):
         )
         return result.modified_count
 
+    @write_op
     async def delete_by_form_id(self, form_id):
         return await FormResponseDocument.find({"form_id": form_id}).delete()
 
+    @write_op
     async def delete_deletion_requests(self, form_id: str):
         return await FormResponseDeletionRequest.find({"form_id": form_id}).delete()
 
+    @write_op
     async def delete_by_form_ids(self, form_ids):
         return await FormResponseDocument.find({"form_id": {"$in": form_ids}}).delete()
 
+    @write_op
     async def delete_deletion_requests_by_form_ids(self, form_ids):
         return await FormResponseDeletionRequest.find(
             {"form_id": {"$in": form_ids}}
         ).delete()
 
+    @write_op
     async def save_form_response(
         self,
         form_id: PydanticObjectId,
@@ -337,6 +346,7 @@ class FormResponseRepository(BaseRepository):
         response_document.provider = "self"
         return await response_document.save()
 
+    @write_op
     async def patch_form_response(
         self,
         form_id: PydanticObjectId,
@@ -362,6 +372,7 @@ class FormResponseRepository(BaseRepository):
             )
         return await response_document.save()
 
+    @write_op
     async def delete_form_response(self, form_id: PydanticObjectId, response_id: str):
         await FormResponseDocument.find(
             {"form_id": str(form_id), "response_id": response_id}
@@ -379,6 +390,7 @@ class FormResponseRepository(BaseRepository):
             {"expiration_type": {"$in": ["date", "days"]}}
         ).to_list()
 
+    @write_op
     async def delete_response(self, response_id: str):
         await FormResponseDocument.find_one({"response_id": response_id}).delete()
         return response_id

--- a/backend/backend/app/repositories/mcp_audit_log_repository.py
+++ b/backend/backend/app/repositories/mcp_audit_log_repository.py
@@ -1,6 +1,8 @@
 from backend.app.schemas.mcp_audit_log import MCPAuditLogDocument
+from common.db.routing import write_op
 
 
 class McpAuditLogRepository:
+    @write_op
     async def add(self, **fields) -> MCPAuditLogDocument:
         return await MCPAuditLogDocument(**fields).save()

--- a/backend/backend/app/repositories/media_library_repository.py
+++ b/backend/backend/app/repositories/media_library_repository.py
@@ -1,6 +1,7 @@
 from beanie import PydanticObjectId
 from backend.app.exceptions.http import HTTPException
 from backend.app.schemas.media_library import MediaLibraryDocument
+from common.db.routing import write_op
 
 
 class MediaLibraryRepository:
@@ -41,6 +42,7 @@ class MediaLibraryRepository:
             {"workspace_id": workspace_id, "media_id": media_id}
         )
 
+    @write_op
     async def add_media_in_workspace_library(
         self,
         workspace_id: str,
@@ -60,6 +62,7 @@ class MediaLibraryRepository:
         await media.save()
         return media
 
+    @write_op
     async def delete_media_from_library(
         self, workspace_id: str, media_id: PydanticObjectId
     ):

--- a/backend/backend/app/repositories/responder_groups_repository.py
+++ b/backend/backend/app/repositories/responder_groups_repository.py
@@ -9,9 +9,11 @@ from backend.app.schemas.responder_group import (
     ResponderGroupMemberDocument,
     ResponderGroupFormDocument,
 )
+from common.db.routing import write_op
 
 
 class ResponderGroupsRepository:
+    @write_op
     async def create_group(
         self,
         workspace_id: PydanticObjectId,
@@ -42,6 +44,7 @@ class ResponderGroupsRepository:
             )
         return responder_group
 
+    @write_op
     async def update_group(
         self,
         workspace_id: PydanticObjectId,
@@ -87,6 +90,7 @@ class ResponderGroupsRepository:
             {"workspace_id": workspace_id, "_id": group_id}
         )
 
+    @write_op
     async def add_emails_to_group(
         self, group_id: PydanticObjectId, emails: List[EmailStr]
     ):
@@ -106,6 +110,7 @@ class ResponderGroupsRepository:
         if new_emails:
             await ResponderGroupMemberDocument.insert_many(new_emails)
 
+    @write_op
     async def remove_emails_from_group(
         self, group_id: PydanticObjectId, emails: List[EmailStr]
     ):
@@ -151,6 +156,7 @@ class ResponderGroupsRepository:
         )
         return responder_groups[0] if len(responder_groups) > 0 else None
 
+    @write_op
     async def remove_responder_group(self, group_id: PydanticObjectId):
         await ResponderGroupDocument.find({"_id": group_id}).delete()
         await ResponderGroupMemberDocument.find({"group_id": group_id}).delete()
@@ -194,6 +200,7 @@ class ResponderGroupsRepository:
             .to_list()
         )
 
+    @write_op
     async def add_group_to_form(self, form_id: str, group_id: PydanticObjectId):
         existing_document = await ResponderGroupFormDocument.find_one(
             {"form_id": form_id, "group_id": group_id}
@@ -204,6 +211,7 @@ class ResponderGroupsRepository:
             )
             return await responder_group_form_document.save()
 
+    @write_op
     async def add_groups_to_form(self, form_id: str, group_ids: List[PydanticObjectId]):
         ids_to_add = group_ids
         existing_groups = await ResponderGroupFormDocument.find(
@@ -260,14 +268,17 @@ class ResponderGroupsRepository:
         # ]
         # ).to_list()
 
+    @write_op
     async def remove_group_from_form(self, form_id: str, group_id: PydanticObjectId):
         await ResponderGroupFormDocument.find_one(
             {"form_id": form_id, "group_id": group_id}
         ).delete()
 
+    @write_op
     async def delete_workspace_form_groups(self, form_id: str):
         await ResponderGroupFormDocument.find({"form_id": form_id}).delete()
 
+    @write_op
     async def delete_responder_groups(self, workspace_ids: List[PydanticObjectId]):
         group_ids_query = ResponderGroupDocument.find(
             {"workspace_id": {"$in": workspace_ids}}

--- a/backend/backend/app/repositories/template.py
+++ b/backend/backend/app/repositories/template.py
@@ -7,6 +7,7 @@ from common.models.user import User
 from backend.app.exceptions import HTTPException
 from backend.app.models.template import StandardFormTemplate, StandardTemplateSetting
 from backend.app.schemas.template import FormTemplateDocument
+from common.db.routing import write_op
 
 
 class FormTemplateRepository:
@@ -83,11 +84,12 @@ class FormTemplateRepository:
 
         raise HTTPException(HTTPStatus.NOT_FOUND, content=MESSAGE_NOT_FOUND)
 
+    @write_op
     async def import_template_to_workspace(
         self, workspace_id: PydanticObjectId, template_id: PydanticObjectId
     ):
         template = await self.get_template_by_id(template_id)
-        imported_template = FormTemplateDocument(**template.model_dump(mode='json'))
+        imported_template = FormTemplateDocument(**template.model_dump(mode="json"))
         imported_template.id = None
         imported_template.imported_from = template.workspace_id
         imported_template.workspace_id = workspace_id
@@ -95,17 +97,19 @@ class FormTemplateRepository:
         imported_template = await imported_template.save()
         return imported_template
 
+    @write_op
     async def create_new_template(
         self,
         workspace_id: PydanticObjectId,
         template_body: StandardFormTemplate,
         user: User,
     ):
-        template = FormTemplateDocument(**template_body.model_dump(mode='json'))
+        template = FormTemplateDocument(**template_body.model_dump(mode="json"))
         template.workspace_id = workspace_id
         template.created_by = user.id
         return await template.save()
 
+    @write_op
     async def update_template(
         self, template_id: PydanticObjectId, template_body: StandardFormTemplate
     ):
@@ -119,9 +123,11 @@ class FormTemplateRepository:
         template.cover_image = template_body.cover_image
         return await template.save()
 
+    @write_op
     async def save(self, template: FormTemplateDocument) -> FormTemplateDocument:
         return await template.save()
 
+    @write_op
     async def delete_template(self, template_id: PydanticObjectId):
         template = await FormTemplateDocument.find_one({"_id": template_id})
         if not template:

--- a/backend/backend/app/repositories/user_feedback.py
+++ b/backend/backend/app/repositories/user_feedback.py
@@ -1,6 +1,8 @@
 from backend.app.schemas.user_feedback import UserFeedbackDocument
+from common.db.routing import write_op
 
 
 class UserFeedbackRepo:
+    @write_op
     async def save_user_feedback(self, user_feedback: UserFeedbackDocument):
         return await user_feedback.save()

--- a/backend/backend/app/repositories/user_tags_repository.py
+++ b/backend/backend/app/repositories/user_tags_repository.py
@@ -7,6 +7,7 @@ from backend.app.models.enum.user_tag_enum import UserTagType
 from backend.app.schemas.user_tags import UserTagsDocument
 from common.base.repo import BaseRepository, U, T
 from common.enums.form_provider import FormProvider
+from common.db.routing import write_op
 
 
 class UserTagsRepository(BaseRepository):
@@ -28,6 +29,7 @@ class UserTagsRepository(BaseRepository):
     async def list(self, **kwargs) -> List[UserTagsDocument]:
         return await UserTagsDocument.find().to_list()
 
+    @write_op
     async def insert_user_tag(self, user_id: str, tag: UserTagType):
         user_id = PydanticObjectId(user_id)
         await UserTagsDocument.find_one(UserTagsDocument.user_id == user_id).upsert(

--- a/backend/backend/app/repositories/workspace_ai_profile_repository.py
+++ b/backend/backend/app/repositories/workspace_ai_profile_repository.py
@@ -3,6 +3,7 @@ from typing import Optional
 from beanie import PydanticObjectId
 
 from backend.app.schemas.workspace_ai_profile import WorkspaceAIProfileDocument
+from common.db.routing import write_op
 
 
 class WorkspaceAIProfileRepository:
@@ -11,6 +12,7 @@ class WorkspaceAIProfileRepository:
     ) -> Optional[WorkspaceAIProfileDocument]:
         return await WorkspaceAIProfileDocument.find_one({"workspace_id": workspace_id})
 
+    @write_op
     async def save(
         self, document: WorkspaceAIProfileDocument
     ) -> WorkspaceAIProfileDocument:

--- a/backend/backend/app/repositories/workspace_api_key_repository.py
+++ b/backend/backend/app/repositories/workspace_api_key_repository.py
@@ -3,9 +3,11 @@ from typing import List, Optional
 from beanie import PydanticObjectId
 
 from backend.app.schemas.workspace_api_key import WorkspaceAPIKeyDocument
+from common.db.routing import write_op
 
 
 class WorkspaceAPIKeyRepository:
+    @write_op
     async def save(self, document: WorkspaceAPIKeyDocument) -> WorkspaceAPIKeyDocument:
         return await document.save()
 

--- a/backend/backend/app/repositories/workspace_consent_repo.py
+++ b/backend/backend/app/repositories/workspace_consent_repo.py
@@ -2,6 +2,7 @@ from beanie import PydanticObjectId
 
 from backend.app.models.dtos.consent import ConsentCamelModel
 from backend.app.schemas.consent import WorkspaceConsentDocument
+from common.db.routing import write_op
 
 
 class WorkspaceConsentRepo:
@@ -10,9 +11,10 @@ class WorkspaceConsentRepo:
             {"workspace_id": workspace_id}
         ).to_list()
 
+    @write_op
     async def create_workspace_consent(
         self, workspace_id: PydanticObjectId, consent: ConsentCamelModel
     ):
-        consent_document = WorkspaceConsentDocument(**consent.model_dump(mode='json'))
+        consent_document = WorkspaceConsentDocument(**consent.model_dump(mode="json"))
         consent_document.workspace_id = workspace_id
         return await consent_document.save()

--- a/backend/backend/app/repositories/workspace_form_repository.py
+++ b/backend/backend/app/repositories/workspace_form_repository.py
@@ -15,6 +15,7 @@ from pymongo.errors import (
 from backend.app.exceptions import HTTPException
 from backend.app.models.workspace import WorkspaceFormSettings
 from backend.app.schemas.workspace_form import WorkspaceFormDocument
+from common.db.routing import write_op
 
 
 class WorkspaceFormRepository:
@@ -38,11 +39,13 @@ class WorkspaceFormRepository:
             {"workspace_id": workspace_id}
         ).to_list()
 
+    @write_op
     async def save(
         self, workspace_form: WorkspaceFormDocument
     ) -> WorkspaceFormDocument:
         return await workspace_form.save()
 
+    @write_op
     async def update(
         self, item_id: str, item: WorkspaceFormDocument
     ) -> WorkspaceFormDocument:
@@ -53,6 +56,7 @@ class WorkspaceFormRepository:
             raise HTTPException(HTTPStatus.NOT_FOUND, "Form not found in ")
         return await item.save()
 
+    @write_op
     async def save_workspace_form(
         self,
         workspace_id: PydanticObjectId,
@@ -264,6 +268,7 @@ class WorkspaceFormRepository:
         ).to_list()
         return [workspace_form.workspace_id for workspace_form in workspace_forms]
 
+    @write_op
     async def delete_form_in_workspace(
         self, workspace_id: PydanticObjectId, form_id: str
     ):
@@ -308,6 +313,7 @@ class WorkspaceFormRepository:
         ).to_list()
         return [form.form_id for form in forms]
 
+    @write_op
     async def delete_forms(self, form_ids):
         return await WorkspaceFormDocument.find({"form_id": {"$in": form_ids}}).delete()
 

--- a/backend/backend/app/repositories/workspace_invitation_repo.py
+++ b/backend/backend/app/repositories/workspace_invitation_repo.py
@@ -13,14 +13,17 @@ from backend.app.schemas.workspace_invitation import WorkspaceUserInvitesDocumen
 from backend.app.services.auth_cookie_service import get_expiry_epoch_after
 from common.constants import MESSAGE_NOT_FOUND
 from common.enums.workspace_invitation_status import InvitationStatus
+from common.db.routing import write_op
 
 
 class WorkspaceInvitationRepo:
+    @write_op
     async def save(
         self, invitation: WorkspaceUserInvitesDocument
     ) -> WorkspaceUserInvitesDocument:
         return await invitation.save()
 
+    @write_op
     async def create_workspace_invitation(
         self, workspace_id: PydanticObjectId, invitation: InvitationRequest
     ):
@@ -69,6 +72,7 @@ class WorkspaceInvitationRepo:
 
         return invitation_request
 
+    @write_op
     async def delete_invitation_by_token_if_pending_state(self, invitation_token):
         invitation_request = await WorkspaceUserInvitesDocument.find_one(
             {"invitation_token": invitation_token}
@@ -82,6 +86,7 @@ class WorkspaceInvitationRepo:
                 HTTPStatus.UNPROCESSABLE_ENTITY, "Invitation not in pending state"
             )
 
+    @write_op
     async def update_status_to_removed(
         self, workspace_id: PydanticObjectId, email: str
     ):

--- a/backend/backend/app/repositories/workspace_repository.py
+++ b/backend/backend/app/repositories/workspace_repository.py
@@ -7,6 +7,7 @@ from backend.app.exceptions import HTTPException
 from backend.app.schemas.workspace import WorkspaceDocument
 from common.base.repo import BaseRepository, T, U
 from common.enums.form_provider import FormProvider
+from common.db.routing import write_op
 
 
 class WorkspaceRepository(BaseRepository):
@@ -22,6 +23,7 @@ class WorkspaceRepository(BaseRepository):
     async def delete(self, item_id: str, provider: FormProvider):
         pass
 
+    @write_op
     async def update(
         self, item_id: PydanticObjectId, item: WorkspaceDocument
     ) -> WorkspaceDocument:
@@ -41,23 +43,31 @@ class WorkspaceRepository(BaseRepository):
             raise HTTPException(HTTPStatus.NOT_FOUND)
         return workspace
 
-    async def find_by_id(self, workspace_id: PydanticObjectId) -> Optional[WorkspaceDocument]:
+    async def find_by_id(
+        self, workspace_id: PydanticObjectId
+    ) -> Optional[WorkspaceDocument]:
         return await WorkspaceDocument.find_one({"_id": workspace_id})
 
     async def find_by_name(self, workspace_name: str) -> Optional[WorkspaceDocument]:
         return await WorkspaceDocument.find_one({"workspace_name": workspace_name})
 
-    async def find_by_custom_domain(self, custom_domain: str) -> Optional[WorkspaceDocument]:
+    async def find_by_custom_domain(
+        self, custom_domain: str
+    ) -> Optional[WorkspaceDocument]:
         return await WorkspaceDocument.find_one({"custom_domain": custom_domain})
 
     async def get_or_404(self, workspace_id: PydanticObjectId) -> WorkspaceDocument:
         """Like ``find_by_id`` but raises the document layer's NotFoundError when missing."""
         return await WorkspaceDocument.get(workspace_id)
 
+    @write_op
     async def save(self, workspace: WorkspaceDocument) -> WorkspaceDocument:
         return await workspace.save()
 
-    async def set_fields(self, workspace: WorkspaceDocument, fields: Dict[str, Any]) -> None:
+    @write_op
+    async def set_fields(
+        self, workspace: WorkspaceDocument, fields: Dict[str, Any]
+    ) -> None:
         await workspace.update({"$set": fields})
 
     async def get_workspace_by_query(self, query: str):
@@ -97,6 +107,7 @@ class WorkspaceRepository(BaseRepository):
     ) -> WorkspaceDocument:
         return await WorkspaceDocument.find_one({"owner_id": owner_id, "default": True})
 
+    @write_op
     async def delete_workspaces_with_ids(self, workspace_ids: List[PydanticObjectId]):
         return await WorkspaceDocument.find({"_id": {"$in": workspace_ids}}).delete()
 

--- a/backend/backend/app/repositories/workspace_responders_repository.py
+++ b/backend/backend/app/repositories/workspace_responders_repository.py
@@ -4,9 +4,11 @@ from backend.app.schemas.workspace_responder import (
     WorkspaceTags,
     WorkspaceResponderDocument,
 )
+from common.db.routing import write_op
 
 
 class WorkspaceRespondersRepository:
+    @write_op
     async def create_workspace_tag(self, workspace_id: PydanticObjectId, title: str):
         workspace_tag = await WorkspaceTags.find_one(
             {"workspace_id": workspace_id, "title": title}
@@ -18,6 +20,7 @@ class WorkspaceRespondersRepository:
     async def get_workspace_tags(self, workspace_id: PydanticObjectId):
         return await WorkspaceTags.find({"workspace_id": workspace_id}).to_list()
 
+    @write_op
     async def get_responder_by_email_and_workspace_id(
         self, workspace_id: PydanticObjectId, email: str
     ):

--- a/backend/backend/app/repositories/workspace_user_repository.py
+++ b/backend/backend/app/repositories/workspace_user_repository.py
@@ -8,6 +8,7 @@ from backend.app.models.enum.workspace_roles import WorkspaceRoles
 from backend.app.schemas.workspace import WorkspaceDocument
 from backend.app.schemas.workspace_user import WorkspaceUserDocument
 from common.models.user import User
+from common.db.routing import write_op
 
 
 class WorkspaceUserRepository:
@@ -58,9 +59,11 @@ class WorkspaceUserRepository:
             {"workspace_id": workspace_id, "user_id": user_id}
         )
 
+    @write_op
     async def save(self, workspace_user: WorkspaceUserDocument):
         return await workspace_user.save()
 
+    @write_op
     async def disable_other_users_in_workspace(
         self, workspace_id: PydanticObjectId, user_id: PydanticObjectId
     ):
@@ -72,11 +75,13 @@ class WorkspaceUserRepository:
                 workspace_user.disabled = True
                 await workspace_user.save()
 
+    @write_op
     async def enable_all_user_in_workspace(self, workspace_id: PydanticObjectId):
         return await WorkspaceUserDocument.find(
             {"workspace_id": workspace_id}
         ).update_many({"$set": {"disabled": False}})
 
+    @write_op
     async def delete(self, workspace_id, user_id):
         workspace_user = await WorkspaceUserDocument.find_one(
             {
@@ -95,11 +100,13 @@ class WorkspaceUserRepository:
             {"user_id": PydanticObjectId(user_id)}
         ).to_list()
 
+    @write_op
     async def delete_user_form_all_workspaces(self, user):
         return await WorkspaceUserDocument.find(
             {"user_id": PydanticObjectId(user.id)}
         ).delete()
 
+    @write_op
     async def delete_all_workspaces_users(self, workspaces_ids: List[PydanticObjectId]):
         return await WorkspaceUserDocument.find(
             {"workspace_id": {"$in": workspaces_ids}}

--- a/backend/tests/app/repositories/test_write_markers.py
+++ b/backend/tests/app/repositories/test_write_markers.py
@@ -1,0 +1,124 @@
+"""Shared by the marker script and the guard test: which repository methods write?
+
+A method writes if its body awaits a Beanie write call (save/insert/delete/
+update/... on a document or query), or if it calls another write method of the
+same repository via ``self.`` — that inner call runs on the concrete Mongo
+instance and would never reach the mirror, so the outer method must be routed
+as a write itself.
+"""
+
+import ast, pathlib
+
+WRITE_CALLS = {
+    "save",
+    "insert",
+    "insert_many",
+    "insert_one",
+    "replace",
+    "replace_one",
+    "delete",
+    "delete_all",
+    "delete_many",
+    "delete_one",
+    "update",
+    "update_many",
+    "update_all",
+    "update_one",
+    "upsert",
+    "set",
+    "inc",
+    "save_changes",
+    "find_one_and_update",
+    "create",
+}
+
+
+def classify(repositories_dir):
+    """-> {(file, class, method): (is_write, reasons)} for public methods."""
+    out = {}
+    for p in sorted(pathlib.Path(repositories_dir).glob("*.py")):
+        if p.name == "__init__.py":
+            continue
+        tree = ast.parse(p.read_text())
+        for cls in [n for n in tree.body if isinstance(n, ast.ClassDef)]:
+            methods = {
+                n.name: n
+                for n in cls.body
+                if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef))
+            }
+            direct, self_calls = {}, {}
+            for name, fn in methods.items():
+                writes, calls = set(), set()
+                for node in ast.walk(fn):
+                    if (
+                        isinstance(node, ast.Await)
+                        and isinstance(node.value, ast.Call)
+                        and isinstance(node.value.func, ast.Attribute)
+                    ):
+                        if node.value.func.attr in WRITE_CALLS:
+                            writes.add(node.value.func.attr)
+                    if (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Attribute)
+                        and isinstance(node.func.value, ast.Name)
+                        and node.func.value.id == "self"
+                    ):
+                        calls.add(node.func.attr)
+                direct[name], self_calls[name] = writes, calls
+            # transitive closure over self-calls
+            is_write = {n: bool(w) for n, w in direct.items()}
+            changed = True
+            while changed:
+                changed = False
+                for n, cs in self_calls.items():
+                    if not is_write[n] and any(is_write.get(c) for c in cs):
+                        is_write[n] = True
+                        changed = True
+            for name, fn in methods.items():
+                if name.startswith("_"):
+                    continue
+                reasons = sorted(direct[name]) + [
+                    f"self.{c}" for c in sorted(self_calls[name]) if is_write.get(c)
+                ]
+                out[(p.name, cls.name, name)] = (
+                    is_write[name],
+                    reasons,
+                    fn.lineno,
+                    [ast.unparse(d) for d in fn.decorator_list],
+                )
+    return out
+
+
+from pathlib import Path
+
+REPOSITORIES = Path(__file__).resolve().parents[3] / "backend" / "app" / "repositories"
+
+
+def test_every_repository_method_that_writes_is_marked_write_op():
+    """The RoutingRepository mirrors only methods marked @write_op. A write that
+    is not marked runs on the primary store alone and silently drifts the
+    mirror — so this is checked from the source, not from convention."""
+    result = classify(REPOSITORIES)
+    unmarked = sorted(
+        f"{cls}.{method} (writes via {', '.join(reasons)})"
+        for (file, cls, method), (is_write, reasons, _, decorators) in result.items()
+        if is_write and not any("write_op" in d for d in decorators)
+    )
+    assert unmarked == [], "mark these with @write_op:\n  " + "\n  ".join(unmarked)
+
+
+def test_reads_are_not_marked_write_op():
+    result = classify(REPOSITORIES)
+    over_marked = sorted(
+        f"{cls}.{method}"
+        for (file, cls, method), (is_write, reasons, _, decorators) in result.items()
+        if not is_write and any("write_op" in d for d in decorators)
+    )
+    assert over_marked == [], "these are reads; drop @write_op:\n  " + "\n  ".join(
+        over_marked
+    )
+
+
+def test_the_classifier_sees_the_whole_repository_layer():
+    result = classify(REPOSITORIES)
+    assert len(result) > 150 and sum(1 for v in result.values() if v[0]) > 60

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -23,6 +23,15 @@ from common.db.canonical import (
 )
 from common.db.engine import DatabaseSettings, make_engine, make_sessionmaker, ping
 from common.db.flags import DbFlags, JobsBackend, ReadSource, WriteMode, load_flags
+from common.db.routing import (
+    MirrorFailure,
+    RoutingError,
+    RoutingMetrics,
+    RoutingRepository,
+    ShadowDiff,
+    is_write_op,
+    write_op,
+)
 from common.db.spine import SpineColumns
 from common.db.outbox import (
     MIRROR_OPS,

--- a/common/common/db/routing.py
+++ b/common/common/db/routing.py
@@ -1,0 +1,288 @@
+"""The seam between the application and its stores (plans/postgres-consolidation.md §6).
+
+Every repository the container hands out is a :class:`RoutingRepository`: a
+proxy over the Mongo implementation and, once it exists, the Postgres one.
+Method calls are dispatched by the flags for the repository's group:
+
+* **writes** (methods marked with :func:`write_op`) go to the primary store;
+  the same call is then replayed on the mirror store, bounded by a timeout
+  and never allowed to fail the request — a failure is counted, logged
+  (redacted) and handed to ``on_mirror_failure`` for the outbox;
+* **reads** go to the read source; with ``DB_SHADOW_READ_SAMPLE`` > 0 a
+  sample is also issued to the other store and the results compared.
+
+With only a Mongo implementation registered and the default flags this is a
+transparent pass-through, which is how R1 ships before the first Postgres
+repository lands.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, Callable, Optional
+
+from pydantic import BaseModel
+
+from common.db.flags import DbFlags, ReadSource
+
+logger = logging.getLogger(__name__)
+
+WRITE_MARKER = "__bc_write__"
+
+
+def write_op(fn):
+    """Mark a repository method as a write. Unmarked methods are reads."""
+    setattr(fn, WRITE_MARKER, True)
+    return fn
+
+
+def is_write_op(fn) -> bool:
+    return bool(getattr(fn, WRITE_MARKER, False))
+
+
+class RoutingError(RuntimeError):
+    """The flags ask for a store this repository has no implementation of."""
+
+
+@dataclass
+class MirrorFailure:
+    group: str
+    repository: str
+    method: str
+    store: ReadSource
+    args: tuple
+    kwargs: dict
+    error: BaseException
+
+
+@dataclass
+class ShadowDiff:
+    group: str
+    repository: str
+    method: str
+    source: ReadSource
+    other: ReadSource
+    args: tuple
+    kwargs: dict
+
+
+@dataclass
+class RoutingMetrics:
+    calls: Counter = field(default_factory=Counter)
+    mirror_failures: Counter = field(default_factory=Counter)
+    shadow_reads: Counter = field(default_factory=Counter)
+    shadow_diffs: Counter = field(default_factory=Counter)
+    shadow_errors: Counter = field(default_factory=Counter)
+
+
+def normalise_result(value: Any) -> Any:
+    """Shape a repository result for comparison: models to plain JSON data."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, dict):
+        return {str(k): normalise_result(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [normalise_result(v) for v in value]
+    return value
+
+
+def results_equal(a: Any, b: Any) -> bool:
+    return normalise_result(a) == normalise_result(b)
+
+
+class RoutingRepository:
+    def __init__(
+        self,
+        *,
+        group: str,
+        flags: DbFlags,
+        mongo: Any = None,
+        postgres: Any = None,
+        mirror_timeout_s: float = 2.0,
+        on_mirror_failure: Optional[Callable[[MirrorFailure], Any]] = None,
+        on_shadow_diff: Optional[Callable[[ShadowDiff], Any]] = None,
+        comparator: Callable[[Any, Any], bool] = results_equal,
+        metrics: Optional[RoutingMetrics] = None,
+    ):
+        if mongo is None and postgres is None:
+            raise RoutingError(f"{group}: no store implementation given")
+        self._group = group
+        self._flags = flags
+        self._stores = {ReadSource.MONGO: mongo, ReadSource.POSTGRES: postgres}
+        self._mirror_timeout_s = mirror_timeout_s
+        self._on_mirror_failure = on_mirror_failure
+        self._on_shadow_diff = on_shadow_diff
+        self._comparator = comparator
+        self._metrics = metrics or RoutingMetrics()
+        self._surface = mongo if mongo is not None else postgres
+        self._repository = type(self._surface).__name__
+        self._check_configuration()
+
+    # -- configuration ---------------------------------------------------
+    def _check_configuration(self) -> None:
+        needed = set()
+        needed.add(self._flags.read_source(self._group))
+        needed.add(self._flags.primary_store(self._group))
+        mirror = self._flags.mirror_store(self._group)
+        if mirror is not None:
+            needed.add(mirror)
+        missing = [s.value for s in needed if self._stores[s] is None]
+        if missing:
+            raise RoutingError(
+                f"group {self._group!r} ({self._repository}): flags require the "
+                f"{', '.join(missing)} store but no implementation is registered"
+            )
+
+    @property
+    def group(self) -> str:
+        return self._group
+
+    @property
+    def metrics(self) -> RoutingMetrics:
+        return self._metrics
+
+    def store(self, source: ReadSource) -> Any:
+        return self._stores[source]
+
+    # -- dispatch ----------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        attr = getattr(self._surface, name)
+        if not callable(attr):
+            return attr
+        if inspect.iscoroutinefunction(attr):
+            return self._write(name) if is_write_op(attr) else self._read(name)
+        return self._sync(name)
+
+    def _impl(self, source: ReadSource, name: str):
+        return getattr(self._stores[source], name)
+
+    def _sync(self, name: str):
+        def method(*args, **kwargs):
+            self._metrics.calls[(self._group, name)] += 1
+            return self._impl(self._flags.read_source(self._group), name)(
+                *args, **kwargs
+            )
+
+        return method
+
+    def _read(self, name: str):
+        async def method(*args, **kwargs):
+            self._metrics.calls[(self._group, name)] += 1
+            source = self._flags.read_source(self._group)
+            result = await self._impl(source, name)(*args, **kwargs)
+            other = (
+                ReadSource.POSTGRES if source is ReadSource.MONGO else ReadSource.MONGO
+            )
+            if self._stores[other] is not None and self._flags.should_shadow_read():
+                await self._shadow(name, source, other, result, args, kwargs)
+            return result
+
+        return method
+
+    def _write(self, name: str):
+        async def method(*args, **kwargs):
+            self._metrics.calls[(self._group, name)] += 1
+            primary = self._flags.primary_store(self._group)
+            result = await self._impl(primary, name)(*args, **kwargs)
+            mirror = self._flags.mirror_store(self._group)
+            if mirror is not None and self._stores[mirror] is not None:
+                await self._mirror(name, mirror, args, kwargs)
+            return result
+
+        return method
+
+    async def _mirror(self, name: str, store: ReadSource, args, kwargs) -> None:
+        try:
+            await asyncio.wait_for(
+                self._impl(store, name)(*args, **kwargs), timeout=self._mirror_timeout_s
+            )
+        except (
+            BaseException
+        ) as exc:  # noqa: BLE001 — the mirror must never fail the request
+            if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                raise
+            self._metrics.mirror_failures[(self._group, name)] += 1
+            logger.warning(
+                "mirror write failed: group=%s repository=%s method=%s store=%s error=%s",
+                self._group,
+                self._repository,
+                name,
+                store.value,
+                type(exc).__name__,
+            )
+            if self._on_mirror_failure is not None:
+                try:
+                    maybe = self._on_mirror_failure(
+                        MirrorFailure(
+                            self._group,
+                            self._repository,
+                            name,
+                            store,
+                            args,
+                            kwargs,
+                            exc,
+                        )
+                    )
+                    if inspect.isawaitable(maybe):
+                        await maybe
+                except Exception as hook_exc:  # noqa: BLE001
+                    logger.warning(
+                        "mirror failure hook raised: {}", type(hook_exc).__name__
+                    )
+
+    async def _shadow(self, name, source, other, result, args, kwargs) -> None:
+        self._metrics.shadow_reads[(self._group, name)] += 1
+        try:
+            other_result = await asyncio.wait_for(
+                self._impl(other, name)(*args, **kwargs), timeout=self._mirror_timeout_s
+            )
+        except Exception as exc:  # noqa: BLE001
+            self._metrics.shadow_errors[(self._group, name)] += 1
+            logger.warning(
+                "shadow read failed: group=%s repository=%s method=%s store=%s error=%s",
+                self._group,
+                self._repository,
+                name,
+                other.value,
+                type(exc).__name__,
+            )
+            return
+        try:
+            equal = self._comparator(result, other_result)
+        except Exception:  # noqa: BLE001 — an uncomparable result counts as a diff
+            equal = False
+        if not equal:
+            self._metrics.shadow_diffs[(self._group, name)] += 1
+            logger.warning(
+                "shadow read differs: group=%s repository=%s method=%s source=%s other=%s",
+                self._group,
+                self._repository,
+                name,
+                source.value,
+                other.value,
+            )
+            if self._on_shadow_diff is not None:
+                try:
+                    maybe = self._on_shadow_diff(
+                        ShadowDiff(
+                            self._group,
+                            self._repository,
+                            name,
+                            source,
+                            other,
+                            args,
+                            kwargs,
+                        )
+                    )
+                    if inspect.isawaitable(maybe):
+                        await maybe
+                except Exception as hook_exc:  # noqa: BLE001
+                    logger.warning(
+                        "shadow diff hook raised: {}", type(hook_exc).__name__
+                    )

--- a/common/tests/test_routing.py
+++ b/common/tests/test_routing.py
@@ -1,0 +1,167 @@
+import asyncio
+
+import pytest
+
+from common.db import ReadSource, RoutingError, RoutingRepository, load_flags, write_op
+
+
+class FakeStore:
+    """A repository double: records calls, can fail or stall, returns tagged results."""
+
+    def __init__(self, tag, fail_on=(), slow=()):
+        self.tag, self.calls, self.fail_on, self.slow = tag, [], set(fail_on), set(slow)
+
+    async def _go(self, name, *args, **kwargs):
+        self.calls.append((name, args, kwargs))
+        if name in self.slow:
+            await asyncio.sleep(5)
+        if name in self.fail_on:
+            raise RuntimeError(f"{self.tag} {name} failed")
+        return f"{self.tag}:{name}"
+
+    async def find(self, key):
+        return await self._go("find", key)
+
+    @write_op
+    async def save(self, doc):
+        return await self._go("save", doc)
+
+    @write_op
+    async def delete(self, key):
+        return await self._go("delete", key)
+
+    def query(self, key):  # a sync method that returns a query object
+        self.calls.append(("query", (key,), {}))
+        return f"{self.tag}:query"
+
+    plain_attribute = "value"
+
+
+def repo(env, mongo=None, postgres=None, **kw):
+    return RoutingRepository(
+        group="forms", flags=load_flags(env), mongo=mongo, postgres=postgres, **kw
+    )
+
+
+async def test_mongo_only_is_a_pass_through():
+    m = FakeStore("mongo")
+    r = repo({}, mongo=m)
+    assert await r.find("a") == "mongo:find"
+    assert await r.save("d") == "mongo:save"
+    assert r.query("q") == "mongo:query"
+    assert r.plain_attribute == "value"
+    assert [c[0] for c in m.calls] == ["find", "save", "query"]
+
+
+async def test_dual_write_mirrors_writes_to_postgres_and_returns_the_primary_result():
+    m, p = FakeStore("mongo"), FakeStore("postgres")
+    r = repo({"DB_WRITE_MODE": "dual"}, mongo=m, postgres=p)
+    assert await r.save("doc") == "mongo:save"
+    assert m.calls == [("save", ("doc",), {})]
+    assert p.calls == [("save", ("doc",), {})]
+    # reads stay on the read source (mongo) and do not touch postgres without sampling
+    assert await r.find("k") == "mongo:find"
+    assert len(p.calls) == 1
+
+
+async def test_mirror_failure_never_reaches_the_caller_and_is_reported():
+    seen = []
+    m, p = FakeStore("mongo"), FakeStore("postgres", fail_on={"save"})
+    r = repo(
+        {"DB_WRITE_MODE": "dual"}, mongo=m, postgres=p, on_mirror_failure=seen.append
+    )
+    assert await r.save("doc") == "mongo:save"
+    assert r.metrics.mirror_failures[("forms", "save")] == 1
+    assert (
+        len(seen) == 1
+        and seen[0].method == "save"
+        and seen[0].store is ReadSource.POSTGRES
+    )
+    assert isinstance(seen[0].error, RuntimeError)
+
+
+async def test_mirror_is_bounded_by_the_timeout():
+    m, p = FakeStore("mongo"), FakeStore("postgres", slow={"delete"})
+    r = repo({"DB_WRITE_MODE": "dual"}, mongo=m, postgres=p, mirror_timeout_s=0.05)
+    result = await asyncio.wait_for(r.delete("k"), timeout=1.0)
+    assert result == "mongo:delete"
+    assert r.metrics.mirror_failures[("forms", "delete")] == 1
+
+
+async def test_postgres_primary_dual_writes_postgres_first_and_mirrors_to_mongo():
+    m, p = FakeStore("mongo"), FakeStore("postgres")
+    r = repo(
+        {"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres_primary_dual"},
+        mongo=m,
+        postgres=p,
+    )
+    assert await r.save("doc") == "postgres:save"
+    assert p.calls == [("save", ("doc",), {})] and m.calls == [("save", ("doc",), {})]
+    assert await r.find("k") == "postgres:find"
+
+
+async def test_shadow_reads_compare_and_report_differences():
+    diffs = []
+    m, p = FakeStore("mongo"), FakeStore("postgres")
+    r = repo(
+        {"DB_WRITE_MODE": "dual", "DB_SHADOW_READ_SAMPLE": "1.0"},
+        mongo=m,
+        postgres=p,
+        on_shadow_diff=diffs.append,
+    )
+    assert await r.find("k") == "mongo:find"  # results are tagged differently -> a diff
+    assert r.metrics.shadow_reads[("forms", "find")] == 1
+    assert r.metrics.shadow_diffs[("forms", "find")] == 1
+    assert diffs[0].method == "find" and diffs[0].other is ReadSource.POSTGRES
+
+
+async def test_shadow_read_agreement_is_not_a_diff_and_errors_are_swallowed():
+    class Same(FakeStore):
+        async def find(self, key):
+            self.calls.append(("find", (key,), {}))
+            return {"id": key}
+
+    m, p = Same("mongo"), Same("postgres")
+    r = repo(
+        {"DB_WRITE_MODE": "dual", "DB_SHADOW_READ_SAMPLE": "1.0"}, mongo=m, postgres=p
+    )
+    assert await r.find("k") == {"id": "k"}
+    assert r.metrics.shadow_diffs[("forms", "find")] == 0
+    broken = FakeStore("postgres", fail_on={"find"})
+    r2 = repo(
+        {"DB_WRITE_MODE": "dual", "DB_SHADOW_READ_SAMPLE": "1.0"},
+        mongo=m,
+        postgres=broken,
+    )
+    assert await r2.find("k") == {"id": "k"}
+    assert r2.metrics.shadow_errors[("forms", "find")] == 1
+
+
+def test_flags_that_need_a_missing_store_fail_at_construction():
+    with pytest.raises(RoutingError, match="postgres store"):
+        repo({"DB_WRITE_MODE": "dual"}, mongo=FakeStore("mongo"))
+    with pytest.raises(RoutingError, match="mongo store"):
+        repo(
+            {"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres_primary_dual"},
+            postgres=FakeStore("postgres"),
+        )
+    with pytest.raises(RoutingError):
+        repo({})
+    repo(
+        {"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres"},
+        postgres=FakeStore("postgres"),
+    )  # mongo gone: fine
+
+
+async def test_per_group_flags_apply_to_the_repository_group():
+    m, p = FakeStore("mongo"), FakeStore("postgres")
+    r = RoutingRepository(
+        group="forms",
+        flags=load_flags({"DB_WRITE_MODE": "dual", "DB_WRITE_MODE__forms": "mongo"}),
+        mongo=m,
+        postgres=p,
+    )
+    await r.save("doc")
+    assert (
+        p.calls == []
+    )  # the forms group is mongo-only even though the default is dual


### PR DESCRIPTION
Phase 0, **PR 4e** — the last of the step-4 slices (#663 → #664 → #665 → #666 → this). It installs the seam the Mongo/Postgres switch lives on. **No behaviour change**: with only the Mongo implementation registered and default flags, the proxy is a pass-through. Backend **236 passed**, common **57 passed**, live smoke unchanged.

## `RoutingRepository` ([common/db/routing.py](common/common/db/routing.py))

One proxy per repository over the Mongo implementation and — from the next PRs — the Postgres one. Dispatch follows the `DbFlags` for the repository's **group** (`refdata`, `identity`, `forms`, `responses`, `actions`, `ai`, `analytics`):

| call | behaviour |
|---|---|
| method marked `@write_op` | primary store first; the same call replayed on the mirror store, **bounded by a timeout and never allowed to fail the request** — failures are counted, logged without payloads, and passed to `on_mirror_failure` (the outbox, wired in the next PR) |
| unmarked (read) | served by the read source; with `DB_SHADOW_READ_SAMPLE` > 0 a sample is also issued to the other store and compared, diffs reported via `on_shadow_diff` |
| sync method | pass-through to the read source (two `FormRepository` methods still return Beanie query objects; reshaped when their Postgres implementation lands) |
| flags need a store with no implementation | **fails at construction**, not at first use in production |

Nine tests cover pass-through, dual-write mirroring and primary-result return, mirror failure and timeout isolation, `postgres_primary_dual`, shadow-read diff/agreement/error paths, misconfiguration, and per-group overrides.

## Markers and the guard that keeps them honest

`@write_op` on the **80 methods that write** — classified from the source, not by hand: a method writes when it awaits a Beanie `save/insert/delete/update/…`, or calls a sibling write method through `self` (that inner call runs on the concrete Mongo instance and would never reach the mirror; `ResponderGroupsRepository.add_groups_to_form` is the one such case). `update`/`set` count only when awaited, which separates Beanie's from `dict.update()`.

[test_write_markers.py](backend/tests/app/repositories/test_write_markers.py) re-derives the classification from the AST on every run and fails if a writing method is unmarked **or** a read is marked. New repository code cannot drift the mirror silently.

## Container

A validated `flags` provider (`load_flags` — a bad combination refuses to boot) and **all 25 repository providers** wrapped as `RoutingRepository(group=…, flags=flags, mongo=<the existing provider>)`. `DeletionRequestsRepository` is only ever called statically from inside `FormResponseRepository`, so it isn't wired.

## Verified

- backend pytest 236 (233 + 3 guard); common pytest 57 (48 + 9 routing); black clean.
- Live, on the routed container: CORS allowed/rejected origins, workspace lookup, public form fetch, `/auth/status` 401, the #655 guard 401, docs.
- Every repository provider resolves to a `RoutingRepository` (checked programmatically: 25/25, 7 groups).

## Next: PR 5

First Postgres implementations (`refdata` + `identity` groups) with the outbox hook and the CI matrix running the backend suite against both backends — the point where `DB_WRITE_MODE=dual` starts doing something.
