### PR TITLE
feat(backend): Postgres runtime, outbox, and the first Postgres repositories (refdata)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,35 @@ jobs:
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
               run: uv run pytest
 
+            - name: Run backend tests (refdata mirrored to Postgres)
+              env:
+                  VIRTUAL_ENV: ""
+                  MONGO_URI: mongodb://localhost:27017
+                  DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/bettercollected_test
+                  AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
+                  AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
+                  SCHEDULAR_ENABLED: "False"
+                  API_ENABLE_FORM_CREATION: "True"
+                  UNSPLASH_ACCESS_KEY: ""
+                  MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
+                  DB_WRITE_MODE__refdata: dual
+              run: uv run pytest
+
+            - name: Run backend tests (refdata served from Postgres)
+              env:
+                  VIRTUAL_ENV: ""
+                  MONGO_URI: mongodb://localhost:27017
+                  DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/bettercollected_test
+                  AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
+                  AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
+                  SCHEDULAR_ENABLED: "False"
+                  API_ENABLE_FORM_CREATION: "True"
+                  UNSPLASH_ACCESS_KEY: ""
+                  MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
+                  DB_READ_SOURCE__refdata: postgres
+                  DB_WRITE_MODE__refdata: postgres
+              run: uv run pytest
+
     auth-tests:
         name: Auth tests (pytest)
         needs: select-runner

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,11 @@ MONGO_URI=mongodb://<USER>:<PASSWORD>@localhost:27017
 # (plans/postgres-consolidation.md). One role per service; the local compose
 # stack (docker-compose.local.yml, service app-postgres) creates these on first start.
 DATABASE_URL=postgresql+asyncpg://bc_app:bc_app@localhost:5432/bettercollected
+# Mongo/Postgres switching, per repository group (refdata, identity, forms, responses,
+# actions, ai, analytics) — see plans/postgres-consolidation.md D5. Defaults = Mongo only.
+#   DB_READ_SOURCE=mongo|postgres            DB_WRITE_MODE=mongo|dual|postgres_primary_dual|postgres
+#   DB_READ_SOURCE__<group>=... / DB_WRITE_MODE__<group>=...   DB_SHADOW_READ_SAMPLE=0.0..1.0
+# e.g. mirror the refdata group to Postgres:  DB_WRITE_MODE__refdata=dual
 # Schedular
 SCHEDULAR_INTERVAL_MINUTES=10
 # Export csv

--- a/backend/backend/app/asgi.py
+++ b/backend/backend/app/asgi.py
@@ -21,6 +21,7 @@ from backend.app.container import container
 from backend.app.exceptions import HTTPException, http_exception_handler
 from backend.app.handlers import init_logging
 from backend.app.handlers.database import close_db, init_db
+from backend.db.startup import check_postgres_at_startup, dispose_postgres
 from backend.app.mcp.server import build_mcp_asgi_app, mcp
 from backend.app.middlewares import DynamicCORSMiddleware, include_middlewares
 from backend.app.router import root_api_router
@@ -46,6 +47,7 @@ async def lifespan(app: FastAPI):
         client = AsyncMongoClient(settings.mongo_settings.URI)
         container.database_client.override(providers.Object(client))
     await init_db(settings.mongo_settings.DB, client)
+    await check_postgres_at_startup(container)
 
     # Auto-provision the Umami website (find-or-create by UMAMI_WEBSITE_NAME)
     # when UMAMI_WEBSITE_ID isn't already set — lets self-hosters skip creating
@@ -53,7 +55,10 @@ async def lifespan(app: FastAPI):
     # PASSWORD; never blocks startup on failure (Umami may not be up yet on a
     # fresh deploy — analytics endpoints just stay unavailable until it is and
     # the backend is restarted). See backend/AGENTS.md "Analytics (Umami)".
-    if settings.umami_settings.has_credentials and not settings.umami_settings.WEBSITE_ID:
+    if (
+        settings.umami_settings.has_credentials
+        and not settings.umami_settings.WEBSITE_ID
+    ):
         try:
             settings.umami_settings.WEBSITE_ID = await provision_umami_website()
             logger.info(
@@ -61,7 +66,9 @@ async def lifespan(app: FastAPI):
                 f"(name={settings.umami_settings.WEBSITE_NAME!r})"
             )
         except Exception:
-            logger.exception("Umami website auto-provisioning failed; continuing startup.")
+            logger.exception(
+                "Umami website auto-provisioning failed; continuing startup."
+            )
 
     # Auto-seed the flow-native template gallery (idempotent — skips templates
     # that already exist). Gated by DEFAULT_SEED_FLOW_TEMPLATES (default on) and
@@ -104,6 +111,7 @@ async def lifespan(app: FastAPI):
     mcp_stop.set()
     await mcp_task
     await close_db(client)
+    await dispose_postgres(container)
     await AiohttpClient.close_aiohttp_client()
     await container.http_client().aclose()
 

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -14,8 +14,17 @@ from pymongo import AsyncMongoClient
 from backend.app.repositories.ai_preference_memory_repository import (
     AIPreferenceMemoryRepository,
 )
-from common.db import load_flags
+from common.db import DatabaseSettings, load_flags
 from common.db.routing import RoutingRepository
+
+from backend.db.outbox import OutboxRecorder
+from backend.db.session import build_engine, build_sessionmaker, postgres_repository
+from backend.app.repositories.postgres.refdata import (
+    PostgresAllowedOriginsRepository,
+    PostgresCouponRepository,
+    PostgresFormPluginProviderRepository,
+    PostgresUserFeedbackRepo,
+)
 
 from backend.app.repositories.action_repository import ActionRepository
 from backend.app.repositories.form_ai_insight_repository import FormAIInsightRepository
@@ -104,11 +113,23 @@ class AppContainer(containers.DeclarativeContainer):
     # Mongo/Postgres switching (plans/postgres-consolidation.md D5): read once at boot,
     # validated; a bad combination refuses to start.
     flags = providers.Singleton(load_flags)
+    # Postgres: engine and sessions exist only when DATABASE_URL is set; the
+    # routing layer treats the store as absent otherwise. Mirror-write failures
+    # land in the primary store's outbox (backend/db/outbox.py).
+    db_settings = providers.Singleton(DatabaseSettings.from_env)
+    pg_engine = providers.Singleton(build_engine, db_settings)
+    pg_sessionmaker = providers.Singleton(build_sessionmaker, pg_engine)
+    outbox_recorder = providers.Singleton(OutboxRecorder, pg_sessionmaker)
+    mirror_timeout_s = providers.Callable(
+        lambda s: s.mirror_timeout_ms / 1000, db_settings
+    )
 
     user_tags_repo = providers.Singleton(
         RoutingRepository,
         group="identity",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(UserTagsRepository),
     )
     user_tags_service = providers.Singleton(
@@ -122,24 +143,38 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="refdata",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        postgres=providers.Singleton(
+            postgres_repository, PostgresCouponRepository, pg_sessionmaker
+        ),
         mongo=providers.Singleton(CouponRepository),
     )
     workspace_user_repo: WorkspaceUserRepository = providers.Singleton(
         RoutingRepository,
         group="identity",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceUserRepository),
     )
     workspace_repo: WorkspaceRepository = providers.Singleton(
         RoutingRepository,
         group="identity",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceRepository),
     )
     allowed_origins_repo: AllowedOriginsRepository = providers.Singleton(
         RoutingRepository,
         group="refdata",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        postgres=providers.Singleton(
+            postgres_repository, PostgresAllowedOriginsRepository, pg_sessionmaker
+        ),
         mongo=providers.Singleton(AllowedOriginsRepository),
     )
     blacklisted_refresh_token_repo: BlacklistedRefreshTokenRepository = (
@@ -147,6 +182,8 @@ class AppContainer(containers.DeclarativeContainer):
             RoutingRepository,
             group="identity",
             flags=flags,
+            on_mirror_failure=outbox_recorder,
+            mirror_timeout_s=mirror_timeout_s,
             mongo=providers.Singleton(BlacklistedRefreshTokenRepository),
         )
     )
@@ -155,54 +192,72 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="forms",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormRepository),
     )
     form_response_repo: FormResponseRepository = providers.Singleton(
         RoutingRepository,
         group="responses",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormResponseRepository, crypto=crypto),
     )
     flow_event_repo: FlowEventRepository = providers.Singleton(
         RoutingRepository,
         group="analytics",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FlowEventRepository),
     )
     form_ai_insight_repo = providers.Singleton(
         RoutingRepository,
         group="ai",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormAIInsightRepository),
     )
     form_ai_session_repo = providers.Singleton(
         RoutingRepository,
         group="ai",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormAISessionRepository),
     )
     workspace_ai_profile_repo = providers.Singleton(
         RoutingRepository,
         group="ai",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceAIProfileRepository),
     )
     workspace_api_key_repo = providers.Singleton(
         RoutingRepository,
         group="identity",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceAPIKeyRepository),
     )
     ai_preference_memory_repo = providers.Singleton(
         RoutingRepository,
         group="ai",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(AIPreferenceMemoryRepository),
     )
     workspace_form_repo: WorkspaceFormRepository = providers.Singleton(
         RoutingRepository,
         group="forms",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceFormRepository),
     )
 
@@ -210,6 +265,11 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="refdata",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        postgres=providers.Singleton(
+            postgres_repository, PostgresFormPluginProviderRepository, pg_sessionmaker
+        ),
         mongo=providers.Singleton(FormPluginProviderRepository),
     )
 
@@ -217,6 +277,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="responses",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(ResponderGroupsRepository),
     )
 
@@ -224,6 +286,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="actions",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(ActionRepository, crypto=crypto),
     )
 
@@ -234,6 +298,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="ai",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(McpAuditLogRepository),
     )
 
@@ -446,6 +512,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="identity",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceInvitationRepo),
     )
 
@@ -471,6 +539,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="responses",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceRespondersRepository),
     )
     workspace_responders_service = providers.Singleton(
@@ -483,6 +553,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="forms",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceConsentRepo),
     )
 
@@ -496,6 +568,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="forms",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormTemplateRepository),
     )
 
@@ -512,6 +586,11 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="refdata",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        postgres=providers.Singleton(
+            postgres_repository, PostgresUserFeedbackRepo, pg_sessionmaker
+        ),
         mongo=providers.Singleton(UserFeedbackRepo),
     )
 
@@ -536,6 +615,8 @@ class AppContainer(containers.DeclarativeContainer):
         RoutingRepository,
         group="forms",
         flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(MediaLibraryRepository),
     )
 

--- a/backend/backend/app/handlers/database.py
+++ b/backend/backend/app/handlers/database.py
@@ -31,6 +31,7 @@ from backend.app.schemas.workspace_user import (
     WorkspaceUserDocument,
 )
 from backend.app.schemas.flow_event import FlowEventDocument
+from common.db import MirrorWriteFailureDocument
 
 document_models = []
 
@@ -70,6 +71,7 @@ async def init_db(db: str, client: AsyncMongoClient):
             ResponderGroupMemberDocument,
             ResponderGroupDocument,
             FlowEventDocument,
+            MirrorWriteFailureDocument,
         ]
     )
     await init_beanie(

--- a/backend/backend/app/repositories/postgres/__init__.py
+++ b/backend/backend/app/repositories/postgres/__init__.py
@@ -1,0 +1,6 @@
+"""Postgres twins of the Mongo repositories, one module per plan group.
+
+Each class carries the same public methods as its Mongo counterpart and is
+registered on the RoutingRepository as ``postgres=``. The Mongo class stays the
+source of the method surface (and of the ``@write_op`` markers) until R3.
+"""

--- a/backend/backend/app/repositories/postgres/refdata.py
+++ b/backend/backend/app/repositories/postgres/refdata.py
@@ -1,0 +1,100 @@
+from typing import List, Optional
+
+from backend.app.models.form_plugin_config import FormProviderConfigDto
+from backend.app.models.types.coupon_code import CouponCode
+from backend.app.repositories.form_plugin_provider_repository import (
+    FormPluginProviderRepository,
+)
+from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+from backend.app.schemas.coupon_codes import CouponCodeDocument
+from backend.app.schemas.form_plugin_config import FormPluginConfigDocument
+from backend.app.schemas.user_feedback import UserFeedbackDocument
+from backend.db.models import (
+    AllowedOriginRow,
+    CouponCodeRow,
+    FormPluginConfigRow,
+    UserFeedbackRow,
+)
+from common.db import PostgresRepositoryBase
+
+
+class PostgresAllowedOriginsRepository(PostgresRepositoryBase):
+    row = AllowedOriginRow
+    document = AllowedOriginsDocument
+
+    async def list_origins(self) -> List[str]:
+        return [doc.origin for doc in await self.many()]
+
+    async def find_by_origin(self, origin: str) -> Optional[AllowedOriginsDocument]:
+        return await self.one(AllowedOriginRow.origin == origin)
+
+    async def add(self, origin: str) -> AllowedOriginsDocument:
+        return await self.upsert(AllowedOriginsDocument(origin=origin))
+
+    async def delete_by_origin(self, origin: str) -> None:
+        # Mongo's find_one(...).delete() removes a single document; match it.
+        await self.delete_one_where(AllowedOriginRow.origin == origin)
+
+
+class PostgresFormPluginProviderRepository(PostgresRepositoryBase):
+    row = FormPluginConfigRow
+    document = FormPluginConfigDocument
+
+    async def list(self) -> List[FormProviderConfigDto]:
+        return [
+            FormProviderConfigDto(**provider.model_dump(mode="json"))
+            for provider in await self.many()
+        ]
+
+    async def get(self, provider_name: str) -> FormPluginConfigDocument | None:
+        return await self.one(FormPluginConfigRow.provider_name == provider_name)
+
+    async def get_provider_url(
+        self, provider_name
+    ) -> Optional[FormPluginProviderRepository.ProviderUrlProject]:
+        document = await self.get(provider_name)
+        if document is None:
+            return None
+        return FormPluginProviderRepository.ProviderUrlProject(
+            provider_url=document.provider_url
+        )
+
+    async def add(self, item: FormPluginConfigDocument) -> FormPluginConfigDocument:
+        return await self.upsert(item)
+
+    async def update(
+        self, provider_name: str, item: FormPluginConfigDocument
+    ) -> FormPluginConfigDocument:
+        existing = await self.get(provider_name)
+        if existing:
+            item.id = existing.id
+        return await self.upsert(item)
+
+    async def delete(self, provider_name: str, provider: FormPluginConfigDocument):
+        pass  # the Mongo implementation is a no-op too
+
+
+class PostgresCouponRepository(PostgresRepositoryBase):
+    row = CouponCodeRow
+    document = CouponCodeDocument
+
+    async def create_coupons(self, coupons: List[CouponCodeDocument]):
+        await self.upsert_many(coupons)
+        return "Created"
+
+    async def save(self, coupon: CouponCodeDocument) -> CouponCodeDocument:
+        return await self.upsert(coupon)
+
+    async def get_all_coupons(self):
+        return await self.many()
+
+    async def get_coupon_by_code(self, coupon_code: CouponCode):
+        return await self.one(CouponCodeRow.code == str(coupon_code))
+
+
+class PostgresUserFeedbackRepo(PostgresRepositoryBase):
+    row = UserFeedbackRow
+    document = UserFeedbackDocument
+
+    async def save_user_feedback(self, user_feedback: UserFeedbackDocument):
+        return await self.upsert(user_feedback)

--- a/backend/backend/db/outbox.py
+++ b/backend/backend/db/outbox.py
@@ -1,0 +1,77 @@
+"""Record mirror-write failures in the *primary* store (plans/postgres-consolidation.md §6).
+
+The routing layer calls this when replaying a write on the mirror store fails.
+While Mongo is primary the record is a ``MirrorWriteFailureDocument``; once
+Postgres is primary it is a row in ``app.mirror_write_failures``. The
+reconciler (migration CLI) drains both.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from beanie import Document
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from backend.db.models import MirrorWriteFailure
+from common.db import MirrorFailure, MirrorWriteFailureDocument, ReadSource
+
+MAX_IDS = 20
+
+
+def _ids(args: tuple, kwargs: dict) -> str:
+    """Best-effort: the ids a call touched, from document / id-like arguments."""
+    found: list[str] = []
+    for value in list(args) + list(kwargs.values()):
+        if isinstance(value, Document):
+            if value.id is not None:
+                found.append(str(value.id))
+        elif type(value).__name__ in ("ObjectId", "PydanticObjectId"):
+            found.append(str(value))
+        elif isinstance(value, str) and len(value) <= 64:
+            found.append(value)
+        elif isinstance(value, (list, tuple)):
+            for item in list(value)[:MAX_IDS]:
+                if isinstance(item, Document) and item.id is not None:
+                    found.append(str(item.id))
+                elif isinstance(item, str) and len(item) <= 64:
+                    found.append(item)
+    return ",".join(found[:MAX_IDS]) or "-"
+
+
+def _error(exc: BaseException) -> str:
+    return f"{type(exc).__name__}: {str(exc)[:200]}"
+
+
+class OutboxRecorder:
+    def __init__(self, session_factory: Optional[async_sessionmaker[AsyncSession]]):
+        self._sessions = session_factory
+
+    async def __call__(self, failure: MirrorFailure) -> None:
+        row_id = _ids(failure.args, failure.kwargs)
+        if failure.store is ReadSource.POSTGRES:
+            # the mirror was Postgres, so Mongo is primary: record there
+            await MirrorWriteFailureDocument(
+                table_name=failure.repository,
+                row_id=row_id,
+                op=failure.method,
+                error=_error(failure.error),
+            ).insert()
+            return
+        if self._sessions is None:
+            logger.error(
+                "mirror to Mongo failed and Postgres is not configured to record it: {} {}",
+                failure.repository,
+                failure.method,
+            )
+            return
+        async with self._sessions() as session, session.begin():
+            session.add(
+                MirrorWriteFailure(
+                    table_name=failure.repository,
+                    row_id=row_id,
+                    op=failure.method,
+                    error=_error(failure.error),
+                )
+            )

--- a/backend/backend/db/session.py
+++ b/backend/backend/db/session.py
@@ -1,0 +1,35 @@
+"""Postgres engine/session providers for the backend container.
+
+Everything here is a no-op when ``DATABASE_URL`` is unset: the engine provider
+yields ``None``, Postgres repositories are not registered, and the routing
+layer treats the store as absent (plans/postgres-consolidation.md §6).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Type
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from common.db import DatabaseSettings, make_engine, make_sessionmaker
+
+APPLICATION_NAME = "bettercollected-backend"
+
+
+def build_engine(settings: DatabaseSettings) -> Optional[AsyncEngine]:
+    if not settings.configured:
+        return None
+    return make_engine(settings, application_name=APPLICATION_NAME)
+
+
+def build_sessionmaker(
+    engine: Optional[AsyncEngine],
+) -> Optional[async_sessionmaker[AsyncSession]]:
+    return None if engine is None else make_sessionmaker(engine)
+
+
+def postgres_repository(
+    cls: Type[Any], session_factory: Optional[async_sessionmaker[AsyncSession]]
+) -> Optional[Any]:
+    """The Postgres twin of a repository, or ``None`` when Postgres is not configured."""
+    return None if session_factory is None else cls(session_factory)

--- a/backend/backend/db/startup.py
+++ b/backend/backend/db/startup.py
@@ -1,0 +1,42 @@
+"""Postgres startup/shutdown for the backend (plans/postgres-consolidation.md §4, R1).
+
+Reachability is checked at boot only when the flags involve Postgres at all,
+and it is fatal only when a group *serves* from Postgres. A mirror-only
+configuration logs and continues: the mirror failing must never take the
+application down.
+"""
+
+from __future__ import annotations
+
+from loguru import logger
+
+from common.db import ping
+
+
+async def check_postgres_at_startup(container) -> None:
+    flags = container.flags()
+    if not flags.requires_postgres():
+        return
+    engine = container.pg_engine()
+    if engine is None:
+        raise RuntimeError(
+            "DB_*/JOBS_* flags require Postgres but DATABASE_URL is not set"
+        )
+    try:
+        await ping(engine)
+        logger.info("Postgres reachable (application database)")
+    except Exception as exc:  # noqa: BLE001
+        if flags.serves_from_postgres():
+            raise RuntimeError(
+                "Postgres is unreachable and a repository group serves from it"
+            ) from exc
+        logger.error(
+            "Postgres unreachable at startup; it is only a mirror, continuing: {}",
+            type(exc).__name__,
+        )
+
+
+async def dispose_postgres(container) -> None:
+    engine = container.pg_engine()
+    if engine is not None:
+        await engine.dispose()

--- a/backend/tests/app/db/test_beanie_bridge.py
+++ b/backend/tests/app/db/test_beanie_bridge.py
@@ -1,0 +1,44 @@
+import datetime as dt
+
+from bson import ObjectId
+
+from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+from backend.app.schemas.standard_form_response import FormResponseDocument
+from common.db import document_checksum, from_row_doc, row_values, to_bson_dict
+
+
+async def test_row_values_mirror_what_beanie_would_store(_initialized_app):
+    doc = AllowedOriginsDocument(origin="https://x.example")
+    assert doc.id is None
+    values = row_values(doc)
+    assert doc.id is not None and values["id"] == str(
+        doc.id
+    )  # id assigned client-side, like Beanie
+    assert values["doc"]["_id"] == {"$oid": str(doc.id)}
+    assert values["doc"]["origin"] == "https://x.example"
+    assert values["bc_source"] == "app"
+    assert values["bc_checksum"] == document_checksum(to_bson_dict(doc))
+    assert values["created_at"].tzinfo is not None
+
+
+async def test_iso_string_timestamps_from_bson_encoders_become_aware_datetimes(
+    _initialized_app,
+):
+    when = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    doc = FormResponseDocument(
+        form_id="f", response_id="r", created_at=when, updated_at=when
+    )
+    doc.id = ObjectId()
+    bson = to_bson_dict(doc)
+    assert isinstance(bson["created_at"], str)  # the bson_encoders quirk
+    values = row_values(doc)
+    assert values["created_at"] == when and values["updated_at"] == when
+
+
+async def test_from_row_doc_round_trips_the_document(_initialized_app):
+    when = dt.datetime(2026, 1, 1, 12, 0, 0, tzinfo=dt.timezone.utc)
+    doc = FormResponseDocument(form_id="f", response_id="r", created_at=when)
+    doc.id = ObjectId()
+    back = from_row_doc(FormResponseDocument, row_values(doc)["doc"])
+    assert back.id == doc.id and back.form_id == "f" and back.created_at == when
+    assert document_checksum(to_bson_dict(back)) == document_checksum(to_bson_dict(doc))

--- a/backend/tests/app/db/test_outbox.py
+++ b/backend/tests/app/db/test_outbox.py
@@ -1,0 +1,31 @@
+from backend.app.container import container
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
+from common.db import MirrorWriteFailureDocument, RoutingRepository, load_flags
+
+
+class BrokenPostgres:
+    async def add(self, origin):
+        raise ConnectionError("postgres is down")
+
+
+async def test_a_failed_mirror_write_lands_in_the_mongo_outbox_and_the_request_succeeds(
+    _initialized_app,
+):
+    routed = RoutingRepository(
+        group="refdata",
+        flags=load_flags({"DB_WRITE_MODE__refdata": "dual"}),
+        mongo=AllowedOriginsRepository(),
+        postgres=BrokenPostgres(),
+        on_mirror_failure=container.outbox_recorder(),
+    )
+    saved = await routed.add("https://mirror-fails.example")
+    assert saved.origin == "https://mirror-fails.example"  # the primary write succeeded
+
+    records = await MirrorWriteFailureDocument.find().to_list()
+    assert len(records) == 1
+    record = records[0]
+    assert record.table_name == "AllowedOriginsRepository"
+    assert record.op == "add"
+    assert record.row_id == "https://mirror-fails.example"
+    assert record.error.startswith("ConnectionError")
+    assert record.attempts == 0 and record.resolved_at is None

--- a/backend/tests/app/repositories/test_refdata_parity.py
+++ b/backend/tests/app/repositories/test_refdata_parity.py
@@ -1,0 +1,156 @@
+"""The Postgres twin of each refdata repository behaves like the Mongo original.
+
+Every step runs on both implementations; results are compared after stripping
+the fields that legitimately differ (ids minted independently, timestamps).
+Skipped unless DATABASE_URL points at a *_test database.
+"""
+
+from typing import Any
+
+import pytest
+
+from backend.app.container import container
+from backend.app.models.types.coupon_code import CouponCode
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
+from backend.app.repositories.coupon_repository import CouponRepository
+from backend.app.repositories.form_plugin_provider_repository import (
+    FormPluginProviderRepository,
+)
+from backend.app.repositories.postgres.refdata import (
+    PostgresAllowedOriginsRepository,
+    PostgresCouponRepository,
+    PostgresFormPluginProviderRepository,
+    PostgresUserFeedbackRepo,
+)
+from backend.app.repositories.user_feedback import UserFeedbackRepo
+from backend.app.schemas.coupon_codes import CouponCodeDocument, CouponStatus
+from backend.app.schemas.form_plugin_config import FormPluginConfigDocument
+from backend.app.schemas.user_feedback import UserFeedbackDocument
+from common.db.routing import normalise_result
+
+VOLATILE = {"id", "_id", "created_at", "updated_at", "revision_id"}
+
+
+def strip(value: Any) -> Any:
+    value = normalise_result(value)
+    if isinstance(value, dict):
+        return {k: strip(v) for k, v in value.items() if k not in VOLATILE}
+    if isinstance(value, list):
+        return [strip(v) for v in value]
+    return value
+
+
+async def parity(mongo, postgres, steps):
+    for name, args in steps:
+        m = await getattr(mongo, name)(*args())
+        p = await getattr(postgres, name)(*args())
+        assert strip(m) == strip(p), f"{type(mongo).__name__}.{name} differs"
+
+
+@pytest.fixture
+def sessions(clean_postgres):
+    return container.pg_sessionmaker()
+
+
+async def test_allowed_origins(sessions):
+    await parity(
+        AllowedOriginsRepository(),
+        PostgresAllowedOriginsRepository(sessions),
+        [
+            ("list_origins", lambda: ()),
+            ("add", lambda: ("https://a.example",)),
+            ("add", lambda: ("https://b.example",)),
+            ("list_origins", lambda: ()),
+            ("find_by_origin", lambda: ("https://a.example",)),
+            ("find_by_origin", lambda: ("https://nope.example",)),
+            ("delete_by_origin", lambda: ("https://a.example",)),
+            ("list_origins", lambda: ()),
+        ],
+    )
+
+
+async def test_form_plugin_providers(sessions):
+    def cfg(name, url):
+        return FormPluginConfigDocument(
+            enabled=True,
+            provider_name=name,
+            provider_url=url,
+            auth_callback_url=f"{url}/cb",
+        )
+
+    await parity(
+        FormPluginProviderRepository(),
+        PostgresFormPluginProviderRepository(sessions),
+        [
+            ("list", lambda: ()),
+            ("add", lambda: (cfg("google", "http://g"),)),
+            ("add", lambda: (cfg("typeform", "http://t"),)),
+            ("list", lambda: ()),
+            ("get", lambda: ("google",)),
+            ("get", lambda: ("missing",)),
+            ("get_provider_url", lambda: ("google",)),
+            ("update", lambda: ("google", cfg("google", "http://g2"))),
+            ("get", lambda: ("google",)),
+            ("list", lambda: ()),
+        ],
+    )
+
+
+async def test_coupons(sessions):
+    codes = [CouponCode(), CouponCode(), CouponCode()]
+
+    def coupon(code):
+        return CouponCodeDocument(code=code)
+
+    async def redeem(repo, code):
+        doc = await repo.get_coupon_by_code(code)
+        doc.status = (
+            CouponStatus.EXPIRED
+            if hasattr(CouponStatus, "EXPIRED")
+            else list(CouponStatus)[-1]
+        )
+        return await repo.save(doc)
+
+    mongo, postgres = CouponRepository(), PostgresCouponRepository(sessions)
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("create_coupons", lambda: ([coupon(c) for c in codes],)),
+            ("get_all_coupons", lambda: ()),
+            ("get_coupon_by_code", lambda: (codes[0],)),
+            ("get_coupon_by_code", lambda: (CouponCode(),)),
+        ],
+    )
+    assert strip(await redeem(mongo, codes[1])) == strip(
+        await redeem(postgres, codes[1])
+    )
+    assert strip(await mongo.get_coupon_by_code(codes[1])) == strip(
+        await postgres.get_coupon_by_code(codes[1])
+    )
+
+
+async def test_user_feedback(sessions):
+    def feedback():
+        return UserFeedbackDocument(reason_for_deletion="testing", feedback="fine")
+
+    await parity(
+        UserFeedbackRepo(),
+        PostgresUserFeedbackRepo(sessions),
+        [("save_user_feedback", lambda: (feedback(),))],
+    )
+
+
+async def test_allowed_origins_delete_removes_one_of_duplicates_like_mongo(sessions):
+    """allowed_origins has no unique index; find_one().delete() removes one document."""
+    mongo, postgres = AllowedOriginsRepository(), PostgresAllowedOriginsRepository(
+        sessions
+    )
+    for repo in (mongo, postgres):
+        await repo.add("https://dup.example")
+        await repo.add("https://dup.example")
+    await parity(
+        mongo, postgres, [("delete_by_origin", lambda: ("https://dup.example",))]
+    )
+    assert await mongo.list_origins() == ["https://dup.example"]
+    assert await postgres.list_origins() == ["https://dup.example"]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,5 @@
+import asyncio
+from pathlib import Path
 import os
 from typing import Any, Coroutine
 from unittest.mock import patch
@@ -38,6 +40,57 @@ TEST_MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost")
 TEST_MONGO_DB = os.getenv("MONGO_TEST_DB", "bettercollected_test")
 
 
+TEST_DATABASE_URL = os.getenv("DATABASE_URL", "")
+
+
+def _postgres_configured() -> bool:
+    """A Postgres test database is available. Guarded: only databases whose name
+    contains "test" are ever migrated or truncated by the suite."""
+    if not TEST_DATABASE_URL:
+        return False
+    name = TEST_DATABASE_URL.rsplit("/", 1)[-1].split("?")[0]
+    return "test" in name
+
+
+def _alembic_upgrade_head() -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    backend_dir = Path(__file__).resolve().parents[1]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option(
+        "script_location", str(backend_dir / "backend" / "migrations")
+    )
+    config.set_main_option("sqlalchemy.url", TEST_DATABASE_URL)
+    command.upgrade(config, "head")
+
+
+async def _truncate_postgres() -> None:
+    """Reset the Postgres test tables between tests.
+
+    TRUNCATE has a fixed per-table cost (locks, relfilenode swap, WAL) that
+    across 35 tables ran to ~1.3 s per test and dominated the suite; deleting
+    from every table was not much better. So: one round trip asks which tables
+    hold rows at all, and only those are cleared. Typically a handful.
+    """
+    from sqlalchemy import text
+
+    import backend.db.models  # noqa: F401
+    from backend.db.base import Base
+
+    engine = container.pg_engine()
+    if engine is None:
+        return
+    tables = [f'"{t.schema}"."{t.name}"' for t in Base.metadata.sorted_tables]
+    probe = " UNION ALL ".join(
+        f"SELECT '{name}' AS t WHERE EXISTS (SELECT 1 FROM {name})" for name in tables
+    )
+    async with engine.begin() as conn:
+        non_empty = [row[0] for row in await conn.execute(text(probe))]
+        for name in non_empty:
+            await conn.execute(text(f"DELETE FROM {name}"))
+
+
 def _drop_test_db() -> None:
     """Drop the test database using a synchronous pymongo client.
 
@@ -66,6 +119,15 @@ async def _initialized_app():
 
     _drop_test_db()
 
+    if _postgres_configured():
+        # Alembic drives its own event loop; keep it off the session loop.
+        await asyncio.to_thread(_alembic_upgrade_head)
+    elif container.flags().requires_postgres():
+        raise RuntimeError(
+            "DB_*/JOBS_* flags require Postgres but DATABASE_URL is unset or does not "
+            "point at a database whose name contains 'test'"
+        )
+
     app = get_application(is_test_mode=True)
     async with lifespan(app):
         yield app
@@ -86,6 +148,17 @@ async def _clean_db(_initialized_app):
     db = container.database_client()[TEST_MONGO_DB]
     for name in await db.list_collection_names():
         await db[name].delete_many({})
+    if _postgres_configured() and container.flags().requires_postgres():
+        await _truncate_postgres()
+    yield
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def clean_postgres(_initialized_app):
+    """For tests that drive the Postgres repositories directly, whatever the flags say."""
+    if not _postgres_configured():
+        pytest.skip("DATABASE_URL not set to a *_test database")
+    await _truncate_postgres()
     yield
 
 

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -9,6 +9,7 @@ Mongo except the Mongo-side outbox document.
 """
 
 from common.db.base import BaseRow, NAMING_CONVENTION, OBJECT_ID_PATTERN, make_base
+from common.db.beanie_bridge import ensure_id, from_row_doc, row_values, to_bson_dict
 from common.db.ddl import (
     HELPER_FUNCTIONS,
     drop_helper_function_ddl,
@@ -33,6 +34,7 @@ from common.db.routing import (
     write_op,
 )
 from common.db.spine import SpineColumns
+from common.db.pg_repository import PostgresNotConfigured, PostgresRepositoryBase
 from common.db.outbox import (
     MIRROR_OPS,
     MirrorWriteFailureDocument,

--- a/common/common/db/alembic_support.py
+++ b/common/common/db/alembic_support.py
@@ -61,10 +61,19 @@ def resolve_url(config) -> str:
     return normalise_url(url)
 
 
+def create_schema_if_missing_sql(schema: str) -> str:
+    """CREATE SCHEMA only when absent. Plain ``CREATE SCHEMA IF NOT EXISTS`` still
+    demands CREATE on the *database*, which the per-service roles (bc_app, ...)
+    deliberately lack; they own their schema, which the init script created.
+    CI and scratch databases run as a superuser and create it here."""
+    return (
+        "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = "
+        f"'{schema}') THEN EXECUTE 'CREATE SCHEMA \"{schema}\"'; END IF; END $$"
+    )
+
+
 def _run_sync(connection: Connection, context, metadata: MetaData, schema: str) -> None:
-    # The schema exists already in deployments (postgres/init/01-roles-schemas.sh);
-    # CI service containers and fresh test databases get it here.
-    connection.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+    connection.execute(text(create_schema_if_missing_sql(schema)))
     context.configure(connection=connection, **context_options(metadata, schema))
     with context.begin_transaction():
         context.run_migrations()
@@ -98,7 +107,7 @@ def run_migrations(context, metadata: MetaData, schema: str) -> None:
 
 # -- helpers for revision files ---------------------------------------------
 def ensure_schema(op, schema: str) -> None:
-    op.execute(f'CREATE SCHEMA IF NOT EXISTS "{schema}"')
+    op.execute(create_schema_if_missing_sql(schema))
 
 
 def create_helper_functions(op, schema: str) -> None:

--- a/common/common/db/beanie_bridge.py
+++ b/common/common/db/beanie_bridge.py
@@ -1,0 +1,82 @@
+"""Beanie document <-> Postgres row values, the shared shape every Postgres repository uses.
+
+A Postgres repository speaks the same language as its Mongo twin: it accepts and
+returns the Beanie ``Document`` classes the services already use. This module is
+the only place that knows how a document becomes a row (and back):
+
+* :func:`to_bson_dict` encodes exactly as ``Document.save()`` would - through
+  Beanie's ``Encoder`` with the document's own ``bson_encoders`` - so the
+  ``doc`` a Postgres row stores is byte-for-byte what Mongo would have stored,
+  and :func:`common.db.canonical.document_checksum` agrees across both stores.
+* :func:`row_values` produces the column values for an upsert (``id``, ``doc``,
+  timestamps, source and checksum).
+* :func:`from_row_doc` rebuilds the document from a row's ``doc``.
+
+Documents can only be instantiated while Beanie is initialised (its
+``Document.__init__`` asks for the collection); that holds for the whole
+dual-run period. Removing Mongo (R3) turns these classes into plain pydantic
+models.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional, Type, TypeVar
+
+from beanie import Document, PydanticObjectId
+from beanie.odm.utils.encoder import Encoder
+
+from common.db.base import SOURCE_APP
+from common.db.canonical import canonical_document, checksum, from_canonical_document
+
+D = TypeVar("D", bound=Document)
+
+
+def ensure_id(document: Document) -> Document:
+    """Beanie assigns ``_id`` client-side on insert; do the same before an upsert."""
+    if document.id is None:
+        document.id = PydanticObjectId()
+    return document
+
+
+def to_bson_dict(document: Document) -> dict[str, Any]:
+    encoders = type(document).get_settings().bson_encoders
+    return Encoder(custom_encoders=encoders).encode(document)
+
+
+def _timestamp(value: Any) -> Optional[datetime]:
+    """created_at/updated_at as stored: a datetime, or the ISO string bson_encoders produce."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def row_values(document: Document, *, source: str = SOURCE_APP) -> dict[str, Any]:
+    """Column values for upserting ``document`` into its table."""
+    ensure_id(document)
+    bson = to_bson_dict(document)
+    doc = canonical_document(bson)
+    now = datetime.now(timezone.utc)
+    return {
+        "id": str(document.id),
+        "doc": doc,
+        "created_at": _timestamp(bson.get("created_at")) or now,
+        "updated_at": _timestamp(bson.get("updated_at")) or now,
+        "bc_source": source,
+        "bc_checksum": checksum(doc),
+    }
+
+
+def from_row_doc(document_cls: Type[D], doc: Mapping[str, Any]) -> D:
+    return document_cls.model_validate(from_canonical_document(doc))

--- a/common/common/db/flags.py
+++ b/common/common/db/flags.py
@@ -126,6 +126,20 @@ class DbFlags:
             return False
         return (rng or random).random() < self.shadow_read_sample
 
+    def serves_from_postgres(self) -> bool:
+        """Whether any group reads from or writes primarily to Postgres — i.e. an
+        unreachable Postgres would break requests, not just the mirror."""
+        groups = {"*"} | set(self.read_overrides) | set(self.write_overrides)
+        for group in groups:
+            read = self.default_read if group == "*" else self.read_source(group)
+            mode = self.default_write if group == "*" else self.write_mode(group)
+            if read is ReadSource.POSTGRES or mode in (
+                WriteMode.POSTGRES_PRIMARY_DUAL,
+                WriteMode.POSTGRES,
+            ):
+                return True
+        return False
+
     def requires_postgres(self) -> bool:
         """Whether the process needs a working DATABASE_URL at all."""
         if (

--- a/common/common/db/pg_repository.py
+++ b/common/common/db/pg_repository.py
@@ -1,0 +1,139 @@
+"""Base for the Postgres twin of a repository.
+
+Subclasses set ``row`` (the BaseRow model) and ``document`` (the Beanie class)
+and express their queries against the row's spine columns; everything crosses
+the boundary as documents, through :mod:`common.db.beanie_bridge`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional, Sequence, Type
+
+from sqlalchemy import delete, func, select
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from common.db.beanie_bridge import from_row_doc, row_values
+
+
+class PostgresNotConfigured(RuntimeError):
+    pass
+
+
+class PostgresRepositoryBase:
+    row: Type[Any]
+    document: Type[Any]
+
+    def __init__(self, session_factory: Optional[async_sessionmaker[AsyncSession]]):
+        self._sessions = session_factory
+
+    # -- sessions --------------------------------------------------------------
+    def _session(self) -> AsyncSession:
+        if self._sessions is None:
+            raise PostgresNotConfigured(
+                "DATABASE_URL is not set; the Postgres store is unavailable"
+            )
+        return self._sessions()
+
+    # -- reads -----------------------------------------------------------------
+    def _order(self) -> Sequence[Any]:
+        # Mongo's natural order is insertion order; created_at then id reproduces it.
+        return (self.row.created_at, self.row.id)
+
+    async def one(self, *where: Any) -> Optional[Any]:
+        async with self._session() as session:
+            stmt = select(self.row.doc).where(*where).order_by(*self._order()).limit(1)
+            doc = (await session.execute(stmt)).scalar_one_or_none()
+        return None if doc is None else from_row_doc(self.document, doc)
+
+    async def many(
+        self,
+        *where: Any,
+        order_by: Optional[Sequence[Any]] = None,
+        limit: Optional[int] = None,
+    ) -> List[Any]:
+        async with self._session() as session:
+            stmt = (
+                select(self.row.doc)
+                .where(*where)
+                .order_by(*(order_by or self._order()))
+            )
+            if limit is not None:
+                stmt = stmt.limit(limit)
+            docs = (await session.execute(stmt)).scalars().all()
+        return [from_row_doc(self.document, d) for d in docs]
+
+    async def count(self, *where: Any) -> int:
+        async with self._session() as session:
+            return (
+                await session.execute(
+                    select(func.count()).select_from(self.row).where(*where)
+                )
+            ).scalar_one()
+
+    # -- writes ----------------------------------------------------------------
+    def _column_names(self) -> dict[str, str]:
+        """attribute -> column name (``bc_source`` is stored as ``_bc_source``)."""
+        mapper = sa_inspect(self.row).mapper
+        return {
+            attr: mapper.attrs[attr].columns[0].name
+            for attr in (
+                "id",
+                "doc",
+                "created_at",
+                "updated_at",
+                "bc_source",
+                "bc_checksum",
+            )
+        }
+
+    def _upsert_statement(self, values: dict[str, Any]):
+        names = self._column_names()
+        stmt = pg_insert(self.row).values({names[k]: v for k, v in values.items()})
+        excluded = stmt.excluded
+        return stmt.on_conflict_do_update(
+            index_elements=[names["id"]],
+            set_={
+                names["doc"]: excluded[names["doc"]],
+                names["updated_at"]: excluded[names["updated_at"]],
+                names["bc_source"]: excluded[names["bc_source"]],
+                names["bc_checksum"]: excluded[names["bc_checksum"]],
+            },
+        )
+
+    async def upsert(self, document: Any) -> Any:
+        values = row_values(document)
+        async with self._session() as session, session.begin():
+            await session.execute(self._upsert_statement(values))
+        return document
+
+    async def upsert_many(self, documents: Iterable[Any]) -> None:
+        async with self._session() as session, session.begin():
+            for document in documents:
+                await session.execute(self._upsert_statement(row_values(document)))
+
+    async def delete_where(self, *where: Any) -> int:
+        async with self._session() as session, session.begin():
+            result = await session.execute(delete(self.row).where(*where))
+        return result.rowcount or 0
+
+    async def delete_one_where(self, *where: Any) -> int:
+        """Delete the first matching row in Mongo's natural order — the twin of
+        ``find_one(...).delete()``. Mongo's semantics, even where odd, are what
+        verification compares against."""
+        async with self._session() as session, session.begin():
+            target = (
+                select(self.row.id)
+                .where(*where)
+                .order_by(*self._order())
+                .limit(1)
+                .scalar_subquery()
+            )
+            result = await session.execute(
+                delete(self.row).where(self.row.id == target)
+            )
+        return result.rowcount or 0
+
+    async def delete_by_id(self, document_id: Any) -> int:
+        return await self.delete_where(self.row.id == str(document_id))

--- a/common/tests/test_flags.py
+++ b/common/tests/test_flags.py
@@ -104,3 +104,23 @@ def test_jobs_backend_per_job():
         load_flags({"JOBS_BACKEND": "postgres"}).jobs_backend("anything")
         is JobsBackend.POSTGRES
     )
+
+
+def test_serves_from_postgres_distinguishes_mirror_only_from_serving():
+    assert load_flags({}).serves_from_postgres() is False
+    assert (
+        load_flags({"DB_WRITE_MODE": "dual"}).serves_from_postgres() is False
+    )  # mirror only
+    assert (
+        load_flags({"DB_WRITE_MODE__refdata": "dual"}).serves_from_postgres() is False
+    )
+    assert (
+        load_flags(
+            {"DB_READ_SOURCE__refdata": "postgres", "DB_WRITE_MODE__refdata": "dual"}
+        ).serves_from_postgres()
+        is True
+    )
+    assert (
+        load_flags({"DB_WRITE_MODE": "postgres_primary_dual"}).serves_from_postgres()
+        is True
+    )


### PR DESCRIPTION
Phase 0, **PR 5a** of the Postgres consolidation — the point where `DB_WRITE_MODE=dual` starts doing real work. It adds the Postgres runtime to the backend, the outbox for mirror failures, and the **first Postgres repositories: the `refdata` group** (allowed origins, plugin provider configs, coupons, user feedback). With default flags nothing changes; with `DB_WRITE_MODE__refdata=dual` every refdata write is mirrored to Postgres; with `DB_READ_SOURCE__refdata=postgres` the group is served from it. **The backend suite is green in all three modes** — that matrix now runs in CI.

## How a document becomes a row — [common/db/beanie_bridge.py](common/common/db/beanie_bridge.py)

The Postgres repositories speak the same language as their Mongo twins: they accept and return the Beanie document classes the services already use. A document is encoded through **Beanie's own `Encoder` with the document's `bson_encoders`**, so the `doc` a row stores is byte-for-byte what Mongo would have stored — the ISO-string timestamps some documents use included — and `document_checksum()` agrees across the two stores. Ids are minted client-side exactly as Beanie does. Rows come back through `model_validate` on the Extended-JSON `doc`.

Documents can only be instantiated while Beanie is initialised (`Document.__init__` asks for its collection), which holds for the whole dual-run period; R3 turns these classes into plain pydantic models when Mongo goes.

## Runtime

| piece | behaviour |
|---|---|
| `backend/db/session.py` | engine, sessionmaker and Postgres-twin providers; **all `None` when `DATABASE_URL` is unset** — the routing layer then treats the store as absent |
| `backend/db/startup.py` | at boot, ping Postgres only if the flags involve it; **fatal only when a group serves from it**, logged-and-continue when it's merely a mirror (a failing mirror must never take the app down); engine disposed at shutdown |
| `backend/db/outbox.py` | `OutboxRecorder` — on a mirror failure writes a `MirrorWriteFailure` record into the **primary** store (Mongo document while Mongo is primary; a row in `app.mirror_write_failures` once Postgres is): repository, method, the ids the call touched, error class |
| container | all 25 `RoutingRepository` providers get `on_mirror_failure` + the mirror timeout; the four refdata ones get their Postgres twin |

`PostgresRepositoryBase` ([common/db/pg_repository.py](common/common/db/pg_repository.py)) gives each twin `one/many/count` over spine columns and Core upserts (`ON CONFLICT (id) DO UPDATE`) that set the checksum explicitly. Lists order by `(created_at, id)`, which reproduces Mongo's insertion order so shadow-read comparisons don't flag ordering.

## Tests

- **Parity**: each refdata repository runs the same operation sequence on the Mongo and Postgres twins and compares results (ids and timestamps stripped). Skipped unless `DATABASE_URL` names a `*_test` database.
- **Outbox**: a routed repository with a broken Postgres twin — the request succeeds, and the Mongo outbox holds exactly one record with repository, method, id and error class.
- **Bridge**: row values match what Beanie stores, ISO-string timestamps become aware datetimes, round trip is lossless with a stable checksum.
- **conftest**: when `DATABASE_URL` points at a database whose name contains `test`, the session runs `alembic upgrade head` once and resets Postgres between tests; it refuses flag combinations that need Postgres without such a database, so the suite can never touch a dev/prod database.
- **CI** ([ci.yml](.github/workflows/ci.yml)): the backend suite runs three ways — default, `DB_WRITE_MODE__refdata=dual`, `DB_READ_SOURCE__refdata=postgres` + `DB_WRITE_MODE__refdata=postgres`.

One performance finding worth knowing: resetting Postgres with `TRUNCATE` across the 35 tables cost **~1.3 s per test** (a fixed per-table cost — locks, relfilenode swap, WAL) and made the dual-mode suite 15× slower. The reset now probes which tables hold rows in one round trip and deletes only from those.

## Verified locally

| run | result |
|---|---|
| backend suite, default flags | **244 passed**, 17 s |
| backend suite, `DB_WRITE_MODE__refdata=dual` | **244 passed**, 54 s (was 410 s before the reset fix) |
| backend suite, `DB_READ_SOURCE__refdata=postgres` + `DB_WRITE_MODE__refdata=postgres` | **244 passed**, 16 s |
| common suite | 58 passed |
| `alembic upgrade head` on the local dev database **as `bc_app`** | 36 tables, all owned by `bc_app` |
| backend booted with `DB_WRITE_MODE__refdata=dual` | "Postgres reachable", endpoints unchanged; an `allowed_origins` write through the routed repository landed in **both** stores with the same id and no mirror failures |

That last row found a real bug tests couldn't: `CREATE SCHEMA IF NOT EXISTS` requires `CREATE` on the *database* even when the schema exists, so migrations as the per-service role failed — CI never saw it because CI runs as superuser. Schema creation is now a conditional `DO` block ([alembic_support.py](common/common/db/alembic_support.py)). It also showed that Mongo's `find_one().delete()` removes **one** of duplicate documents; the Postgres twin now does the same (`delete_one_where`), with a parity test — verification compares against Mongo's behaviour, odd or not.

Next: **5b** — the `identity` group (workspaces, workspace users, invites, API keys, token blacklist, user tags).
