### PR TITLE
feat(backend): Postgres twins for the identity group; replay minted writes on the mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
               run: uv run pytest
 
-            - name: Run backend tests (refdata mirrored to Postgres)
+            - name: Run backend tests (refdata + identity mirrored to Postgres)
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
@@ -116,9 +116,10 @@ jobs:
                   UNSPLASH_ACCESS_KEY: ""
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
                   DB_WRITE_MODE__refdata: dual
+                  DB_WRITE_MODE__identity: dual
               run: uv run pytest
 
-            - name: Run backend tests (refdata served from Postgres)
+            - name: Run backend tests (refdata + identity served from Postgres)
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
@@ -131,6 +132,8 @@ jobs:
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
                   DB_READ_SOURCE__refdata: postgres
                   DB_WRITE_MODE__refdata: postgres
+                  DB_READ_SOURCE__identity: postgres
+                  DB_WRITE_MODE__identity: postgres
               run: uv run pytest
 
     auth-tests:

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -19,6 +19,14 @@ from common.db.routing import RoutingRepository
 
 from backend.db.outbox import OutboxRecorder
 from backend.db.session import build_engine, build_sessionmaker, postgres_repository
+from backend.app.repositories.postgres.identity import (
+    PostgresBlacklistedRefreshTokenRepository,
+    PostgresUserTagsRepository,
+    PostgresWorkspaceAPIKeyRepository,
+    PostgresWorkspaceInvitationRepo,
+    PostgresWorkspaceRepository,
+    PostgresWorkspaceUserRepository,
+)
 from backend.app.repositories.postgres.refdata import (
     PostgresAllowedOriginsRepository,
     PostgresCouponRepository,
@@ -131,11 +139,23 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(UserTagsRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresUserTagsRepository, pg_sessionmaker
+        ),
     )
     user_tags_service = providers.Singleton(
         UserTagsService, user_tags_repo=user_tags_repo
     )
     crypto = providers.Singleton(Crypto, settings.auth_settings.AES_HEX_KEY)
+    # defined early: the workspace twin composes over it (identity → actions)
+    action_repository = providers.Singleton(
+        RoutingRepository,
+        group="actions",
+        flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        mongo=providers.Singleton(ActionRepository, crypto=crypto),
+    )
 
     # Repositories
 
@@ -157,6 +177,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceUserRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceUserRepository, pg_sessionmaker
+        ),
     )
     workspace_repo: WorkspaceRepository = providers.Singleton(
         RoutingRepository,
@@ -165,6 +188,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceRepository, pg_sessionmaker, action_repository
+        ),
     )
     allowed_origins_repo: AllowedOriginsRepository = providers.Singleton(
         RoutingRepository,
@@ -185,6 +211,9 @@ class AppContainer(containers.DeclarativeContainer):
             on_mirror_failure=outbox_recorder,
             mirror_timeout_s=mirror_timeout_s,
             mongo=providers.Singleton(BlacklistedRefreshTokenRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresBlacklistedRefreshTokenRepository, pg_sessionmaker
+        ),
         )
     )
 
@@ -243,6 +272,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceAPIKeyRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceAPIKeyRepository, pg_sessionmaker
+        ),
     )
     ai_preference_memory_repo = providers.Singleton(
         RoutingRepository,
@@ -282,14 +314,6 @@ class AppContainer(containers.DeclarativeContainer):
         mongo=providers.Singleton(ResponderGroupsRepository),
     )
 
-    action_repository = providers.Singleton(
-        RoutingRepository,
-        group="actions",
-        flags=flags,
-        on_mirror_failure=outbox_recorder,
-        mirror_timeout_s=mirror_timeout_s,
-        mongo=providers.Singleton(ActionRepository, crypto=crypto),
-    )
 
     integration_action_service: IntegrationActionService = providers.Singleton(
         IntegrationActionService, form_repo=form_repo
@@ -515,6 +539,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceInvitationRepo),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceInvitationRepo, pg_sessionmaker
+        ),
     )
 
     workspace_members_service: WorkspaceMembersService = providers.Singleton(

--- a/backend/backend/app/repositories/action_repository.py
+++ b/backend/backend/app/repositories/action_repository.py
@@ -40,6 +40,13 @@ class ActionRepository:
     async def get_action_by_id(self, action_id: PydanticObjectId):
         return await ActionDocument.find_one(ActionDocument.id == action_id)
 
+    async def get_workspace_action(
+        self, workspace_id: PydanticObjectId, action_id: PydanticObjectId
+    ) -> WorkspaceActionsDocument | None:
+        return await WorkspaceActionsDocument.find_one(
+            {"workspace_id": workspace_id, "action_id": action_id}
+        )
+
     # query = {
     #     '_id': action_id,
     #     'workspace_id': workspace_id,

--- a/backend/backend/app/repositories/allowed_origins_repository.py
+++ b/backend/backend/app/repositories/allowed_origins_repository.py
@@ -14,7 +14,7 @@ class AllowedOriginsRepository:
     async def find_by_origin(self, origin: str) -> Optional[AllowedOriginsDocument]:
         return await AllowedOriginsDocument.find_one({"origin": origin})
 
-    @write_op
+    @write_op(replay=True)
     async def add(self, origin: str) -> AllowedOriginsDocument:
         return await AllowedOriginsDocument(origin=origin).save()
 

--- a/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
+++ b/backend/backend/app/repositories/blacklisted_refresh_token_repository.py
@@ -8,6 +8,6 @@ class BlacklistedRefreshTokenRepository:
     async def find_by_token(self, token: str) -> Optional[BlackListedRefreshTokens]:
         return await BlackListedRefreshTokens.find_one({"token": token})
 
-    @write_op
+    @write_op(replay=True)
     async def add(self, token: str, expiry) -> BlackListedRefreshTokens:
         return await BlackListedRefreshTokens(token=token, expiry=expiry).save()

--- a/backend/backend/app/repositories/coupon_repository.py
+++ b/backend/backend/app/repositories/coupon_repository.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from beanie import PydanticObjectId
+
 from backend.app.models.types.coupon_code import CouponCode
 from backend.app.schemas.coupon_codes import CouponCodeDocument
 from common.db.routing import write_op
@@ -8,6 +10,11 @@ from common.db.routing import write_op
 class CouponRepository:
     @write_op
     async def create_coupons(self, coupons: List[CouponCodeDocument]):
+        # insert_many does not write ids back; fix them here so the mirror
+        # store (which re-executes this call) gets the same documents.
+        for coupon in coupons:
+            if coupon.id is None:
+                coupon.id = PydanticObjectId()
         await CouponCodeDocument.insert_many(coupons)
         return "Created"
 

--- a/backend/backend/app/repositories/postgres/identity.py
+++ b/backend/backend/app/repositories/postgres/identity.py
@@ -1,0 +1,446 @@
+"""Postgres twins of the identity-group repositories.
+
+Each class mirrors the public surface of its Mongo original method for method,
+including its quirks (404 vs None, the document layer's NotFoundError), so the
+RoutingRepository can serve either store. Queries use the spine columns of the
+rows in :mod:`backend.db.models`; documents cross the boundary unchanged.
+
+One method crosses a group boundary: ``get_workspace_with_action_by_id`` is a
+``$lookup`` from workspaces (identity) into workspace_actions (actions) in
+Mongo. Groups cut over independently, so the twin composes the two reads
+through the *routed* actions repository instead of a SQL join — whichever
+store currently serves actions is the one consulted. Joins stay SQL only
+within a group; R3 can collapse this one once both groups live in Postgres.
+"""
+
+import datetime
+import secrets
+from datetime import timedelta, timezone
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional
+
+from beanie import PydanticObjectId
+from fastapi_pagination.ext.sqlalchemy import apaginate
+from sqlalchemy import and_, func, not_, or_, select
+
+from backend.app.exceptions import HTTPException
+from backend.app.models.enum.user_tag_enum import UserTagType
+from backend.app.models.enum.workspace_roles import WorkspaceRoles
+from backend.app.models.invitation_request import InvitationRequest
+from backend.app.schemas.blacklisted_refresh_tokens import BlackListedRefreshTokens
+from backend.app.schemas.user_tags import UserTagsDocument
+from backend.app.schemas.workspace import WorkspaceDocument
+from backend.app.schemas.workspace_api_key import WorkspaceAPIKeyDocument
+from backend.app.schemas.workspace_invitation import WorkspaceUserInvitesDocument
+from backend.app.schemas.workspace_user import WorkspaceUserDocument
+from backend.app.services.auth_cookie_service import get_expiry_epoch_after
+from backend.db.base import SCHEMA
+from backend.db.models import (
+    BlacklistedRefreshTokenRow,
+    UserTagsRow,
+    WorkspaceApiKeyRow,
+    WorkspaceInviteRow,
+    WorkspaceRow,
+    WorkspaceUserRow,
+)
+from common.constants import MESSAGE_NOT_FOUND
+from common.db import (
+    PostgresRepositoryBase,
+    from_canonical_document,
+    from_row_doc,
+    to_bson_dict,
+)
+from common.enums.workspace_invitation_status import InvitationStatus
+from common.models.user import User
+
+
+def _oid(value: Any) -> str:
+    """Spine ids are ObjectId hex strings; accept whatever the callers pass."""
+    return str(value)
+
+
+class PostgresWorkspaceRepository(PostgresRepositoryBase):
+    row = WorkspaceRow
+    document = WorkspaceDocument
+
+    def __init__(self, session_factory, action_repository):
+        super().__init__(session_factory)
+        self._actions = action_repository
+
+    # BaseRepository stubs, unused — kept so both stores expose the same surface.
+    async def list(self):
+        pass
+
+    async def get(self, item_id, provider):
+        pass
+
+    async def add(self, item):
+        pass
+
+    async def delete(self, item_id, provider):
+        pass
+
+    async def update(
+        self, item_id: PydanticObjectId, item: WorkspaceDocument
+    ) -> WorkspaceDocument:
+        if await self.one(WorkspaceRow.id == _oid(item_id)) is None:
+            raise HTTPException(HTTPStatus.NOT_FOUND, "Workspace not found")
+        return await self.upsert(item)
+
+    async def get_workspace_by_id(
+        self, workspace_id: PydanticObjectId
+    ) -> WorkspaceDocument:
+        workspace = await self.one(WorkspaceRow.id == _oid(workspace_id))
+        if not workspace:
+            raise HTTPException(HTTPStatus.NOT_FOUND)
+        return workspace
+
+    async def find_by_id(
+        self, workspace_id: PydanticObjectId
+    ) -> Optional[WorkspaceDocument]:
+        return await self.one(WorkspaceRow.id == _oid(workspace_id))
+
+    async def find_by_name(self, workspace_name: str) -> Optional[WorkspaceDocument]:
+        return await self.one(WorkspaceRow.workspace_name == workspace_name)
+
+    async def find_by_custom_domain(
+        self, custom_domain: str
+    ) -> Optional[WorkspaceDocument]:
+        return await self.one(WorkspaceRow.custom_domain == custom_domain)
+
+    async def get_or_404(self, workspace_id: PydanticObjectId) -> WorkspaceDocument:
+        return await self.get_or_raise(workspace_id)
+
+    async def save(self, workspace: WorkspaceDocument) -> WorkspaceDocument:
+        return await self.upsert(workspace)
+
+    async def set_fields(
+        self, workspace: WorkspaceDocument, fields: Dict[str, Any]
+    ) -> None:
+        # Beanie's document.update({"$set": ...}) also refreshes the instance.
+        for path, value in fields.items():
+            *parents, leaf = path.split(".")
+            target: Any = workspace
+            for part in parents:
+                target = (
+                    target[part] if isinstance(target, dict) else getattr(target, part)
+                )
+            if isinstance(target, dict):
+                target[leaf] = value
+            else:
+                setattr(target, leaf, value)
+        await self.upsert(workspace)
+
+    async def get_workspace_by_query(self, query: str):
+        disabled = WorkspaceRow.doc["custom_domain_disabled"]
+        workspace = await self.one(
+            or_(
+                WorkspaceRow.workspace_name == query,
+                and_(
+                    WorkspaceRow.custom_domain == query,
+                    or_(
+                        not_(WorkspaceRow.doc.has_key("custom_domain_disabled")),
+                        getattr(func, SCHEMA).bc_bool(disabled).is_(False),
+                    ),
+                ),
+            )
+        )
+        if not workspace:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                content="The page you are looking is unavailable.",
+            )
+        return workspace
+
+    async def get_user_workspaces(self, owner_id: str):
+        return await self.many(WorkspaceRow.owner_id == owner_id)
+
+    async def get_workspace_by_ids(self, workspace_ids: List[PydanticObjectId]):
+        return await self.many(WorkspaceRow.id.in_([_oid(i) for i in workspace_ids]))
+
+    async def get_default_workspace_by_owner_id(
+        self, owner_id: str
+    ) -> WorkspaceDocument:
+        return await self.one(
+            WorkspaceRow.owner_id == owner_id, WorkspaceRow.is_default.is_(True)
+        )
+
+    async def delete_workspaces_with_ids(self, workspace_ids: List[PydanticObjectId]):
+        return await self.delete_where(
+            WorkspaceRow.id.in_([_oid(i) for i in workspace_ids])
+        )
+
+    async def get_workspace_with_action_by_id(
+        self, workspace_id: PydanticObjectId, action_id: PydanticObjectId
+    ):
+        """The raw-document shape of the Mongo aggregation: the workspace with
+        ``parameters.<action_id>`` / ``secrets.<action_id>`` from its
+        workspace_actions entry and ``id`` set. See the module docstring for
+        why the second read goes through the routed actions repository."""
+        async with self._session() as session:
+            raw = (
+                await session.execute(
+                    select(WorkspaceRow.doc).where(
+                        WorkspaceRow.id == _oid(workspace_id)
+                    )
+                )
+            ).scalar_one_or_none()
+        workspace_action = (
+            None
+            if raw is None
+            else await self._actions.get_workspace_action(
+                workspace_id=PydanticObjectId(_oid(workspace_id)),
+                action_id=PydanticObjectId(_oid(action_id)),
+            )
+        )
+        if raw is None or workspace_action is None:
+            raise HTTPException(status_code=404, content="Workspace not found")
+        workspace = from_canonical_document(raw)
+        action = to_bson_dict(workspace_action)
+        for key in ("parameters", "secrets"):
+            if key in action:  # $set of a missing path adds nothing
+                workspace.setdefault(key, {})[str(action_id)] = action[key]
+        workspace["id"] = PydanticObjectId(_oid(workspace_id))
+        return workspace
+
+
+class PostgresWorkspaceUserRepository(PostgresRepositoryBase):
+    row = WorkspaceUserRow
+    document = WorkspaceUserDocument
+
+    async def has_user_access_in_workspace(
+        self, workspace_id: PydanticObjectId, user: User
+    ) -> bool:
+        if not user or not workspace_id:
+            return False
+        workspace_user = await self.find_workspace_user(workspace_id, user.id)
+        return True if workspace_user and not workspace_user.disabled else False
+
+    async def is_user_admin_in_workspace(
+        self, workspace_id: PydanticObjectId, user: User
+    ) -> bool:
+        if not user or not workspace_id:
+            return False
+        workspace_user = await self.find_workspace_user(workspace_id, user.id)
+        # The original calls WorkspaceDocument.get unconditionally: a missing
+        # workspace raises NotFoundError even when the user is not a member.
+        workspace = WorkspaceDocument.verify_doc_exists(
+            await self.one_of(
+                WorkspaceRow, WorkspaceDocument, WorkspaceRow.id == _oid(workspace_id)
+            ),
+            {"id": workspace_id},
+        )
+        return (
+            True
+            if workspace_user
+            and (
+                WorkspaceRoles.ADMIN in workspace_user.roles
+                or workspace.owner_id == user.id
+            )
+            else False
+        )
+
+    async def get_workspace_users(self, workspace_id: PydanticObjectId):
+        return await self.many(WorkspaceUserRow.workspace_id == _oid(workspace_id))
+
+    async def find_workspace_user(
+        self, workspace_id: PydanticObjectId, user_id: PydanticObjectId
+    ) -> Optional[WorkspaceUserDocument]:
+        return await self.one(
+            WorkspaceUserRow.workspace_id == _oid(workspace_id),
+            WorkspaceUserRow.user_id == _oid(user_id),
+        )
+
+    async def save(self, workspace_user: WorkspaceUserDocument):
+        return await self.upsert(workspace_user)
+
+    async def disable_other_users_in_workspace(
+        self, workspace_id: PydanticObjectId, user_id: PydanticObjectId
+    ):
+        for workspace_user in await self.get_workspace_users(workspace_id):
+            if workspace_user.user_id != user_id:
+                workspace_user.disabled = True
+                await self.upsert(workspace_user)
+
+    async def enable_all_user_in_workspace(self, workspace_id: PydanticObjectId):
+        workspace_users = await self.get_workspace_users(workspace_id)
+        for workspace_user in workspace_users:
+            workspace_user.disabled = False
+        await self.upsert_many(workspace_users)
+        return len(workspace_users)
+
+    async def delete(self, workspace_id, user_id):
+        workspace_user = await self.find_workspace_user(workspace_id, user_id)
+        if not workspace_user:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND, content="Resource doesn't exist"
+            )
+        return await self.delete_by_id(workspace_user.id)
+
+    async def get_mine_workspaces(self, user_id: str):
+        return await self.many(WorkspaceUserRow.user_id == _oid(user_id))
+
+    async def delete_user_form_all_workspaces(self, user):
+        return await self.delete_where(WorkspaceUserRow.user_id == _oid(user.id))
+
+    async def delete_all_workspaces_users(self, workspaces_ids: List[PydanticObjectId]):
+        return await self.delete_where(
+            WorkspaceUserRow.workspace_id.in_([_oid(i) for i in workspaces_ids])
+        )
+
+
+class PostgresWorkspaceInvitationRepo(PostgresRepositoryBase):
+    row = WorkspaceInviteRow
+    document = WorkspaceUserInvitesDocument
+
+    async def save(
+        self, invitation: WorkspaceUserInvitesDocument
+    ) -> WorkspaceUserInvitesDocument:
+        return await self.upsert(invitation)
+
+    async def _find(
+        self, workspace_id, email
+    ) -> Optional[WorkspaceUserInvitesDocument]:
+        return await self.one(
+            WorkspaceInviteRow.workspace_id == _oid(workspace_id),
+            WorkspaceInviteRow.email == email,
+        )
+
+    async def create_workspace_invitation(
+        self, workspace_id: PydanticObjectId, invitation: InvitationRequest
+    ):
+        existing_invitation = await self._find(workspace_id, invitation.email)
+        if existing_invitation:
+            existing_invitation.invitation_status = InvitationStatus.PENDING
+            existing_invitation.expiry = get_expiry_epoch_after(
+                time_delta=timedelta(days=7)
+            )
+            existing_invitation.created_at = datetime.datetime.now(timezone.utc)
+            existing_invitation.invitation_token = secrets.token_hex(16)
+        else:
+            existing_invitation = WorkspaceUserInvitesDocument(
+                workspace_id=workspace_id,
+                email=invitation.email,
+                role=invitation.role,
+                invitation_token=secrets.token_hex(16),
+                expiry=get_expiry_epoch_after(time_delta=timedelta(days=7)),
+            )
+        return await self.upsert(existing_invitation)
+
+    async def get_workspace_invitations(self, workspace_id: PydanticObjectId):
+        statuses = [InvitationStatus.PENDING.value, InvitationStatus.EXPIRED.value]
+        stmt = (
+            select(WorkspaceInviteRow.doc)
+            .where(
+                WorkspaceInviteRow.workspace_id == _oid(workspace_id),
+                WorkspaceInviteRow.invitation_status.in_(statuses),
+            )
+            .order_by(*self._order())
+        )
+        async with self._session() as session:
+            return await apaginate(
+                session,
+                stmt,
+                transformer=lambda docs: [from_row_doc(self.document, d) for d in docs],
+                unwrap_mode="unwrap",  # hand the transformer the doc column itself
+                unique=False,  # JSONB rows are not hashable; the id is unique anyway
+            )
+
+    async def get_workspace_invitation_by_token(
+        self, workspace_id: PydanticObjectId, invitation_token: str
+    ) -> WorkspaceUserInvitesDocument | None:
+        invitation_request = await self.one(
+            WorkspaceInviteRow.invitation_token == invitation_token,
+            WorkspaceInviteRow.workspace_id == _oid(workspace_id),
+        )
+        if not invitation_request:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND, content=MESSAGE_NOT_FOUND
+            )
+        return invitation_request
+
+    async def delete_invitation_by_token_if_pending_state(self, invitation_token):
+        invitation_request = await self.one(
+            WorkspaceInviteRow.invitation_token == invitation_token
+        )
+        if not invitation_request:
+            raise HTTPException(HTTPStatus.NOT_FOUND, "Invitation not found")
+        elif invitation_request.invitation_status == InvitationStatus.PENDING:
+            await self.delete_by_id(invitation_request.id)
+        else:
+            raise HTTPException(
+                HTTPStatus.UNPROCESSABLE_ENTITY, "Invitation not in pending state"
+            )
+
+    async def update_status_to_removed(
+        self, workspace_id: PydanticObjectId, email: str
+    ):
+        invitation = await self._find(workspace_id, email)
+        if invitation is not None:  # find_one(...).update() on no match is a no-op
+            invitation.invitation_status = InvitationStatus.REMOVED
+            await self.upsert(invitation)
+
+
+class PostgresWorkspaceAPIKeyRepository(PostgresRepositoryBase):
+    row = WorkspaceApiKeyRow
+    document = WorkspaceAPIKeyDocument
+
+    async def save(self, document: WorkspaceAPIKeyDocument) -> WorkspaceAPIKeyDocument:
+        return await self.upsert(document)
+
+    async def list_by_workspace(
+        self, workspace_id: PydanticObjectId
+    ) -> List[WorkspaceAPIKeyDocument]:
+        return await self.many(WorkspaceApiKeyRow.workspace_id == _oid(workspace_id))
+
+    async def get_or_404(self, key_id: PydanticObjectId) -> WorkspaceAPIKeyDocument:
+        return await self.get_or_raise(key_id)
+
+    async def find_by_key_hash(
+        self, key_hash: str
+    ) -> Optional[WorkspaceAPIKeyDocument]:
+        return await self.one(WorkspaceApiKeyRow.key_hash == key_hash)
+
+
+class PostgresBlacklistedRefreshTokenRepository(PostgresRepositoryBase):
+    row = BlacklistedRefreshTokenRow
+    document = BlackListedRefreshTokens
+
+    async def find_by_token(self, token: str) -> Optional[BlackListedRefreshTokens]:
+        return await self.one(BlacklistedRefreshTokenRow.token == token)
+
+    async def add(self, token: str, expiry) -> BlackListedRefreshTokens:
+        return await self.upsert(BlackListedRefreshTokens(token=token, expiry=expiry))
+
+
+class PostgresUserTagsRepository(PostgresRepositoryBase):
+    row = UserTagsRow
+    document = UserTagsDocument
+
+    # BaseRepository stubs, unused — kept so both stores expose the same surface.
+    async def get(self, item_id, provider):
+        pass
+
+    async def add(self, item):
+        pass
+
+    async def update(self, item_id, item):
+        pass
+
+    async def delete(self, item_id, provider):
+        pass
+
+    async def get_tags_by_id(self, user_id: str):
+        return await self.one(UserTagsRow.user_id == _oid(PydanticObjectId(user_id)))
+
+    async def list(self, **kwargs) -> List[UserTagsDocument]:
+        return await self.many()
+
+    async def insert_user_tag(self, user_id: str, tag: UserTagType) -> UserTagsDocument:
+        user_id = PydanticObjectId(user_id)
+        user_tags = await self.one(UserTagsRow.user_id == _oid(user_id))
+        if user_tags is None:
+            user_tags = UserTagsDocument(user_id=user_id, tags=[tag])
+        elif tag not in user_tags.tags:  # $addToSet
+            user_tags.tags.append(tag)
+        return await self.upsert(user_tags)

--- a/backend/backend/app/repositories/user_tags_repository.py
+++ b/backend/backend/app/repositories/user_tags_repository.py
@@ -29,10 +29,11 @@ class UserTagsRepository(BaseRepository):
     async def list(self, **kwargs) -> List[UserTagsDocument]:
         return await UserTagsDocument.find().to_list()
 
-    @write_op
-    async def insert_user_tag(self, user_id: str, tag: UserTagType):
+    @write_op(replay=True)
+    async def insert_user_tag(self, user_id: str, tag: UserTagType) -> UserTagsDocument:
         user_id = PydanticObjectId(user_id)
         await UserTagsDocument.find_one(UserTagsDocument.user_id == user_id).upsert(
             {"$addToSet": {UserTagsDocument.tags: tag}},
             on_insert=UserTagsDocument(user_id=user_id, tags=[tag]),
         )
+        return await UserTagsDocument.find_one(UserTagsDocument.user_id == user_id)

--- a/backend/backend/app/repositories/workspace_invitation_repo.py
+++ b/backend/backend/app/repositories/workspace_invitation_repo.py
@@ -23,7 +23,7 @@ class WorkspaceInvitationRepo:
     ) -> WorkspaceUserInvitesDocument:
         return await invitation.save()
 
-    @write_op
+    @write_op(replay=True)
     async def create_workspace_invitation(
         self, workspace_id: PydanticObjectId, invitation: InvitationRequest
     ):

--- a/backend/backend/db/outbox.py
+++ b/backend/backend/db/outbox.py
@@ -49,7 +49,7 @@ class OutboxRecorder:
         self._sessions = session_factory
 
     async def __call__(self, failure: MirrorFailure) -> None:
-        row_id = _ids(failure.args, failure.kwargs)
+        row_id = _ids(failure.args + tuple(failure.documents), failure.kwargs)
         if failure.store is ReadSource.POSTGRES:
             # the mirror was Postgres, so Mongo is primary: record there
             await MirrorWriteFailureDocument(

--- a/backend/backend/db/session.py
+++ b/backend/backend/db/session.py
@@ -29,7 +29,10 @@ def build_sessionmaker(
 
 
 def postgres_repository(
-    cls: Type[Any], session_factory: Optional[async_sessionmaker[AsyncSession]]
+    cls: Type[Any],
+    session_factory: Optional[async_sessionmaker[AsyncSession]],
+    *args: Any,
+    **kwargs: Any,
 ) -> Optional[Any]:
     """The Postgres twin of a repository, or ``None`` when Postgres is not configured."""
-    return None if session_factory is None else cls(session_factory)
+    return None if session_factory is None else cls(session_factory, *args, **kwargs)

--- a/backend/tests/app/controllers/test_form_ai_insights.py
+++ b/backend/tests/app/controllers/test_form_ai_insights.py
@@ -217,9 +217,11 @@ class TestAIFormAccessIsWorkspaceScoped:
     ):
         # Make the caller a member of workspace_1 so plain workspace access
         # passes — the form-belongs-to-workspace check must be what stops it.
-        await WorkspaceUserDocument(
-            workspace_id=workspace_1.id, user_id=testUser.id, roles=[WorkspaceRoles.COLLABORATOR]
-        ).save()
+        await container.workspace_user_repo().save(
+            WorkspaceUserDocument(
+                workspace_id=workspace_1.id, user_id=testUser.id, roles=[WorkspaceRoles.COLLABORATOR]
+            )
+        )
         foreign = workspace_form.form_id
         calls = [
             ("post", f"/api/v1/workspaces/{workspace_1.id}/forms/{foreign}/ai/chat", {"message": "hi"}),

--- a/backend/tests/app/controllers/test_workspace.py
+++ b/backend/tests/app/controllers/test_workspace.py
@@ -3,6 +3,7 @@ from typing import Any, Coroutine
 from httpx import AsyncClient
 from common.constants import MESSAGE_FORBIDDEN
 
+from backend.app.container import container
 from backend.app.schemas.standard_form import FormDocument
 from backend.app.schemas.workspace import WorkspaceDocument
 from backend.config import settings
@@ -106,7 +107,7 @@ class TestWorkspaces:
         assert response.json().get("customThemes") == [{**theme, "background": None, "style": None}]
 
         # And it round-trips on the persisted document.
-        saved = await WorkspaceDocument.get(workspace.id)
+        saved = await container.workspace_repo().get_or_404(workspace.id)
         assert [t.title for t in saved.custom_themes] == ["Brand 2026"]
 
     async def test_patch_theme_presets_round_trips_background(

--- a/backend/tests/app/controllers/test_workspace_members.py
+++ b/backend/tests/app/controllers/test_workspace_members.py
@@ -126,8 +126,8 @@ class TestWorkspaceMember:
         expected_form = await WorkspaceFormDocument.find_one(
             {"form_id": workspace_form.form_id, "workspace_id": workspace.id}
         )
-        expected_user = await WorkspaceUserDocument.find_one(
-            {"workspace_id": workspace.id, "user_id": PydanticObjectId(testUser.id)}
+        expected_user = await container.workspace_user_repo().find_workspace_user(
+            workspace.id, PydanticObjectId(testUser.id)
         )
         actual_user_and_form = None
         assert actual_user_and_form == expected_user == expected_form
@@ -297,13 +297,15 @@ class TestWorkspaceMember:
         workspace: Coroutine[Any, Any, WorkspaceDocument],
         test_invited_user_cookies: dict[str, str],
     ):
-        invitation = await WorkspaceUserInvitesDocument(
+        invitation = await container.workspace_invitation_repo().save(
+            WorkspaceUserInvitesDocument(
             workspace_id=workspace.id,
             email="invited_daemon@gmail.com",
             invitation_status="REMOVED",
             invitation_token=secrets.token_hex(16),
             expiry=1720156071,
-        ).save()
+            )
+        )
         invitation_by_token_url = (
             f"{workspace_invitation_url}/{invitation.invitation_token}"
         )
@@ -324,12 +326,14 @@ class TestWorkspaceMember:
         workspace: Coroutine[Any, Any, WorkspaceDocument],
         test_invited_user_cookies: dict[str, str],
     ):
-        invitation = await WorkspaceUserInvitesDocument(
+        invitation = await container.workspace_invitation_repo().save(
+            WorkspaceUserInvitesDocument(
             workspace_id=workspace.id,
             email="invited_daemon@gmail.com",
             expiry=0,
             invitation_token=secrets.token_hex(16),
-        ).save()
+            )
+        )
         invitation_by_token_url = (
             f"{workspace_invitation_url}/{invitation.invitation_token}"
         )
@@ -402,13 +406,15 @@ class TestWorkspaceMember:
         workspace_invitation_url: str,
         test_invited_user_cookies: dict[str, str],
     ):
-        accepted_invitation = await WorkspaceUserInvitesDocument(
+        accepted_invitation = await container.workspace_invitation_repo().save(
+            WorkspaceUserInvitesDocument(
             workspace_id=workspace.id,
             email="invited_daemon@gmail.com",
             invitation_status="ACCEPTED",
             invitation_token=secrets.token_hex(16),
             expiry=1720156071,
-        ).save()
+            )
+        )
         url = f"{workspace_invitation_url}/{accepted_invitation.invitation_token}?response_status=REJECTED"
 
         responded_invitation = await client.post(url, cookies=test_invited_user_cookies)
@@ -425,12 +431,14 @@ class TestWorkspaceMember:
         workspace_invitation_url: str,
         test_invited_user_cookies: dict[str, str],
     ):
-        accepted_invitation = await WorkspaceUserInvitesDocument(
+        accepted_invitation = await container.workspace_invitation_repo().save(
+            WorkspaceUserInvitesDocument(
             workspace_id=workspace.id,
             email="invited_daemon@gmail.com",
             expiry=0,
             invitation_token=secrets.token_hex(16),
-        ).save()
+            )
+        )
         url = f"{workspace_invitation_url}/{accepted_invitation.invitation_token}?response_status=REJECTED"
 
         responded_invitation = await client.post(url, cookies=test_invited_user_cookies)

--- a/backend/tests/app/db/test_outbox.py
+++ b/backend/tests/app/db/test_outbox.py
@@ -4,7 +4,8 @@ from common.db import MirrorWriteFailureDocument, RoutingRepository, load_flags
 
 
 class BrokenPostgres:
-    async def add(self, origin):
+    # add() is @write_op(replay=True): the mirror receives the saved document
+    async def replay_write(self, documents):
         raise ConnectionError("postgres is down")
 
 
@@ -26,6 +27,7 @@ async def test_a_failed_mirror_write_lands_in_the_mongo_outbox_and_the_request_s
     record = records[0]
     assert record.table_name == "AllowedOriginsRepository"
     assert record.op == "add"
-    assert record.row_id == "https://mirror-fails.example"
+    # the call's arguments and the document the replay tried to store
+    assert record.row_id == f"https://mirror-fails.example,{saved.id}"
     assert record.error.startswith("ConnectionError")
     assert record.attempts == 0 and record.resolved_at is None

--- a/backend/tests/app/repositories/test_identity_parity.py
+++ b/backend/tests/app/repositories/test_identity_parity.py
@@ -1,0 +1,384 @@
+"""The Postgres twin of each identity repository behaves like the Mongo original.
+
+Same harness as the refdata parity tests: each step runs on both stores and the
+results are compared after stripping the fields that legitimately differ.
+Skipped unless DATABASE_URL points at a *_test database.
+"""
+
+import datetime as dt
+
+import pytest
+from beanie import PydanticObjectId
+from fastapi_pagination import Page, Params
+from fastapi_pagination.api import set_page, set_params
+
+from backend.app.container import container
+from backend.app.exceptions import HTTPException
+from backend.app.models.enum.user_tag_enum import UserTagType
+from backend.app.models.enum.workspace_roles import WorkspaceRoles
+from backend.app.models.invitation_request import InvitationRequest
+from backend.app.repositories.action_repository import ActionRepository
+from backend.app.repositories.blacklisted_refresh_token_repository import (
+    BlacklistedRefreshTokenRepository,
+)
+from backend.app.repositories.postgres.identity import (
+    PostgresBlacklistedRefreshTokenRepository,
+    PostgresUserTagsRepository,
+    PostgresWorkspaceAPIKeyRepository,
+    PostgresWorkspaceInvitationRepo,
+    PostgresWorkspaceRepository,
+    PostgresWorkspaceUserRepository,
+)
+from backend.app.repositories.user_tags_repository import UserTagsRepository
+from backend.app.repositories.workspace_api_key_repository import (
+    WorkspaceAPIKeyRepository,
+)
+from backend.app.repositories.workspace_invitation_repo import WorkspaceInvitationRepo
+from backend.app.repositories.workspace_repository import WorkspaceRepository
+from backend.app.repositories.workspace_user_repository import WorkspaceUserRepository
+from backend.app.schemas.action_document import WorkspaceActionsDocument
+from backend.app.schemas.workspace import WorkspaceDocument
+from backend.app.schemas.workspace_api_key import WorkspaceAPIKeyDocument
+from backend.app.schemas.workspace_invitation import WorkspaceUserInvitesDocument
+from backend.app.schemas.workspace_user import WorkspaceUserDocument
+from common.enums.workspace_invitation_status import InvitationStatus
+from common.exceptions import NotFoundError
+from common.models.user import User
+from tests.app.repositories.test_refdata_parity import parity, strip
+
+
+@pytest.fixture
+def sessions(clean_postgres):
+    return container.pg_sessionmaker()
+
+
+def workspace(name, owner, **extra):
+    return WorkspaceDocument(
+        id=PydanticObjectId(),
+        title=name,
+        workspace_name=name,
+        owner_id=owner,
+        **extra,
+    )
+
+
+async def both_raise(exc_type, mongo_call, postgres_call):
+    with pytest.raises(exc_type) as m:
+        await mongo_call()
+    with pytest.raises(exc_type) as p:
+        await postgres_call()
+    if exc_type is HTTPException:
+        assert m.value.status_code == p.value.status_code
+    else:
+        assert str(m.value) == str(p.value)
+
+
+async def test_workspaces(sessions):
+    owner = str(PydanticObjectId())
+    default = workspace("acme", owner, default=True)
+    other = workspace("beta", owner, custom_domain="beta.example")
+    hidden = workspace(
+        "gamma", owner, custom_domain="gamma.example", custom_domain_disabled=True
+    )
+    mongo = WorkspaceRepository()
+    postgres = PostgresWorkspaceRepository(sessions, ActionRepository(crypto=None))
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("save", lambda: (default,)),
+            ("save", lambda: (other,)),
+            ("save", lambda: (hidden,)),
+            ("find_by_id", lambda: (default.id,)),
+            ("find_by_id", lambda: (PydanticObjectId(),)),
+            ("find_by_name", lambda: ("beta",)),
+            ("find_by_custom_domain", lambda: ("beta.example",)),
+            ("get_or_404", lambda: (other.id,)),
+            ("get_workspace_by_id", lambda: (other.id,)),
+            ("get_workspace_by_query", lambda: ("acme",)),
+            ("get_workspace_by_query", lambda: ("beta.example",)),
+            ("get_user_workspaces", lambda: (owner,)),
+            ("get_workspace_by_ids", lambda: ([default.id, hidden.id],)),
+            ("get_default_workspace_by_owner_id", lambda: (owner,)),
+            ("get_default_workspace_by_owner_id", lambda: ("nobody",)),
+            ("set_fields", lambda: (other, {"custom_domain_verified": True})),
+            ("find_by_id", lambda: (other.id,)),
+        ],
+    )
+    # a disabled custom domain is not reachable by domain, and a missing one 404s
+    await both_raise(
+        HTTPException,
+        lambda: mongo.get_workspace_by_query("gamma.example"),
+        lambda: postgres.get_workspace_by_query("gamma.example"),
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.get_workspace_by_id(PydanticObjectId()),
+        lambda: postgres.get_workspace_by_id(PydanticObjectId()),
+    )
+    missing = PydanticObjectId()
+    await both_raise(
+        NotFoundError,
+        lambda: mongo.get_or_404(missing),
+        lambda: postgres.get_or_404(missing),
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.update(missing, default),
+        lambda: postgres.update(missing, default),
+    )
+    default.title = "ACME"
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("update", lambda: (default.id, default)),
+            ("delete_workspaces_with_ids", lambda: ([hidden.id],)),
+            ("get_user_workspaces", lambda: (owner,)),
+        ],
+    )
+
+
+async def test_workspace_with_action_composes_over_the_actions_store(sessions):
+    """Mongo joins workspace_actions with $lookup; the twin asks the (routed)
+    actions repository — here the Mongo one, as in a staged cutover."""
+    owner = str(PydanticObjectId())
+    ws = workspace("delta", owner)
+    action_id = PydanticObjectId()
+    await WorkspaceActionsDocument(
+        workspace_id=ws.id,
+        action_id=action_id,
+        parameters=[{"name": "Sheet", "value": "abc"}],
+        secrets=None,
+    ).save()
+    mongo = WorkspaceRepository()
+    postgres = PostgresWorkspaceRepository(sessions, ActionRepository(crypto=None))
+    await mongo.save(ws)
+    await postgres.save(ws)
+    m = await mongo.get_workspace_with_action_by_id(ws.id, action_id)
+    p = await postgres.get_workspace_with_action_by_id(ws.id, action_id)
+    assert strip(m) == strip(p)
+    assert p["parameters"][str(action_id)][0]["value"] == "abc"
+    assert p["id"] == ws.id
+    await both_raise(
+        HTTPException,
+        lambda: mongo.get_workspace_with_action_by_id(ws.id, PydanticObjectId()),
+        lambda: postgres.get_workspace_with_action_by_id(ws.id, PydanticObjectId()),
+    )
+
+
+async def test_workspace_users(sessions):
+    owner = User(id=str(PydanticObjectId()), sub="owner@example.com")
+    member = User(id=str(PydanticObjectId()), sub="member@example.com")
+    ws = workspace("epsilon", owner.id)
+    for repo in (
+        WorkspaceRepository(),
+        PostgresWorkspaceRepository(sessions, ActionRepository(crypto=None)),
+    ):
+        await repo.save(ws)
+
+    def wu(user, roles):
+        return WorkspaceUserDocument(
+            id=PydanticObjectId(),
+            workspace_id=ws.id,
+            user_id=PydanticObjectId(user.id),
+            roles=roles,
+        )
+
+    owner_row, member_row = wu(owner, [WorkspaceRoles.ADMIN]), wu(member, [])
+    mongo, postgres = WorkspaceUserRepository(), PostgresWorkspaceUserRepository(
+        sessions
+    )
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("save", lambda: (owner_row,)),
+            ("save", lambda: (member_row,)),
+            ("has_user_access_in_workspace", lambda: (ws.id, member)),
+            ("has_user_access_in_workspace", lambda: (ws.id, None)),
+            ("is_user_admin_in_workspace", lambda: (ws.id, owner)),
+            ("is_user_admin_in_workspace", lambda: (ws.id, member)),
+            ("get_workspace_users", lambda: (ws.id,)),
+            ("find_workspace_user", lambda: (ws.id, member_row.user_id)),
+            ("get_mine_workspaces", lambda: (member.id,)),
+            ("disable_other_users_in_workspace", lambda: (ws.id, owner_row.user_id)),
+            ("has_user_access_in_workspace", lambda: (ws.id, member)),
+            ("get_workspace_users", lambda: (ws.id,)),
+            ("enable_all_user_in_workspace", lambda: (ws.id,)),
+            ("has_user_access_in_workspace", lambda: (ws.id, member)),
+            ("delete", lambda: (ws.id, member_row.user_id)),
+            ("get_workspace_users", lambda: (ws.id,)),
+            ("delete_user_form_all_workspaces", lambda: (owner,)),
+            ("get_workspace_users", lambda: (ws.id,)),
+        ],
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.delete(ws.id, member_row.user_id),
+        lambda: postgres.delete(ws.id, member_row.user_id),
+    )
+    gone = PydanticObjectId()
+    await both_raise(
+        NotFoundError,
+        lambda: mongo.is_user_admin_in_workspace(gone, owner),
+        lambda: postgres.is_user_admin_in_workspace(gone, owner),
+    )
+
+
+async def test_invitations(sessions):
+    ws_id = PydanticObjectId()
+    mongo, postgres = WorkspaceInvitationRepo(), PostgresWorkspaceInvitationRepo(
+        sessions
+    )
+    request = InvitationRequest(
+        email="new@example.com", role=WorkspaceRoles.COLLABORATOR
+    )
+
+    # tokens are minted inside the call, so results are compared shape-wise
+    m = await mongo.create_workspace_invitation(ws_id, request)
+    p = await postgres.create_workspace_invitation(ws_id, request)
+    assert strip(m) | {"invitation_token": 0, "expiry": 0} == strip(p) | {
+        "invitation_token": 0,
+        "expiry": 0,
+    }
+    # re-inviting the same address renews the existing invitation
+    m2 = await mongo.create_workspace_invitation(ws_id, request)
+    p2 = await postgres.create_workspace_invitation(ws_id, request)
+    assert m2.id == m.id and p2.id == p.id
+
+    seeded = WorkspaceUserInvitesDocument(
+        id=PydanticObjectId(),
+        workspace_id=ws_id,
+        email="seeded@example.com",
+        invitation_token="tok-seeded",
+        expiry=0,
+        invitation_status=InvitationStatus.EXPIRED,
+    )
+    accepted = WorkspaceUserInvitesDocument(
+        id=PydanticObjectId(),
+        workspace_id=ws_id,
+        email="done@example.com",
+        invitation_token="tok-done",
+        expiry=0,
+        invitation_status=InvitationStatus.ACCEPTED,
+    )
+    with set_page(Page), set_params(Params(page=1, size=10)):
+        await parity(
+            mongo,
+            postgres,
+            [
+                ("save", lambda: (seeded,)),
+                ("save", lambda: (accepted,)),
+                ("get_workspace_invitation_by_token", lambda: (ws_id, "tok-seeded")),
+                ("update_status_to_removed", lambda: (ws_id, "seeded@example.com")),
+                ("update_status_to_removed", lambda: (ws_id, "nobody@example.com")),
+                ("get_workspace_invitation_by_token", lambda: (ws_id, "tok-seeded")),
+            ],
+        )
+        m_page = await mongo.get_workspace_invitations(ws_id)
+        p_page = await postgres.get_workspace_invitations(ws_id)
+    assert (
+        m_page.total == p_page.total == 1
+    )  # pending only; removed and accepted excluded
+    assert [i["email"] for i in strip(m_page.items)] == [
+        i["email"] for i in strip(p_page.items)
+    ]
+    await both_raise(
+        HTTPException,
+        lambda: mongo.get_workspace_invitation_by_token(ws_id, "nope"),
+        lambda: postgres.get_workspace_invitation_by_token(ws_id, "nope"),
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.delete_invitation_by_token_if_pending_state("tok-done"),
+        lambda: postgres.delete_invitation_by_token_if_pending_state("tok-done"),
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.delete_invitation_by_token_if_pending_state("nope"),
+        lambda: postgres.delete_invitation_by_token_if_pending_state("nope"),
+    )
+    await mongo.delete_invitation_by_token_if_pending_state(m2.invitation_token)
+    await postgres.delete_invitation_by_token_if_pending_state(p2.invitation_token)
+    await both_raise(
+        HTTPException,
+        lambda: mongo.get_workspace_invitation_by_token(ws_id, m2.invitation_token),
+        lambda: postgres.get_workspace_invitation_by_token(ws_id, p2.invitation_token),
+    )
+
+
+async def test_api_keys(sessions):
+    ws_id = PydanticObjectId()
+
+    def key(name, h):
+        return WorkspaceAPIKeyDocument(
+            id=PydanticObjectId(),
+            workspace_id=ws_id,
+            name=name,
+            key_hash=h,
+            prefix=h[:6],
+            scopes=["forms:read"],
+            created_by="tester",
+        )
+
+    a, b = key("ci", "hash-a"), key("ops", "hash-b")
+    mongo, postgres = WorkspaceAPIKeyRepository(), PostgresWorkspaceAPIKeyRepository(
+        sessions
+    )
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("save", lambda: (a,)),
+            ("save", lambda: (b,)),
+            ("list_by_workspace", lambda: (ws_id,)),
+            ("list_by_workspace", lambda: (PydanticObjectId(),)),
+            ("get_or_404", lambda: (a.id,)),
+            ("find_by_key_hash", lambda: ("hash-b",)),
+            ("find_by_key_hash", lambda: ("hash-z",)),
+        ],
+    )
+    a.revoked = True
+    await parity(
+        mongo, postgres, [("save", lambda: (a,)), ("get_or_404", lambda: (a.id,))]
+    )
+    missing = PydanticObjectId()
+    await both_raise(
+        NotFoundError,
+        lambda: mongo.get_or_404(missing),
+        lambda: postgres.get_or_404(missing),
+    )
+
+
+async def test_blacklisted_tokens(sessions):
+    expiry = dt.datetime(2030, 1, 1, tzinfo=dt.timezone.utc)
+    await parity(
+        BlacklistedRefreshTokenRepository(),
+        PostgresBlacklistedRefreshTokenRepository(sessions),
+        [
+            ("find_by_token", lambda: ("t1",)),
+            ("add", lambda: ("t1", expiry)),
+            ("find_by_token", lambda: ("t1",)),
+            ("find_by_token", lambda: ("t2",)),
+        ],
+    )
+
+
+async def test_user_tags(sessions):
+    user_id = str(PydanticObjectId())
+    await parity(
+        UserTagsRepository(),
+        PostgresUserTagsRepository(sessions),
+        [
+            ("get_tags_by_id", lambda: (user_id,)),
+            ("insert_user_tag", lambda: (user_id, UserTagType.NEW_USER)),
+            ("insert_user_tag", lambda: (user_id, UserTagType.NEW_USER)),  # $addToSet
+            (
+                "insert_user_tag",
+                lambda: (user_id, UserTagType.DELETION_REQUEST_RECEIVED),
+            ),
+            ("get_tags_by_id", lambda: (user_id,)),
+            ("list", lambda: ()),
+        ],
+    )

--- a/backend/tests/app/repositories/test_postgres_surface.py
+++ b/backend/tests/app/repositories/test_postgres_surface.py
@@ -1,0 +1,77 @@
+"""Every Postgres twin exposes at least the public surface of its Mongo original.
+
+The RoutingRepository dispatches by attribute name, so a method missing on
+the twin would surface as a mirror failure (or an AttributeError when the
+group is served from Postgres). No database needed.
+"""
+
+import inspect
+
+import pytest
+
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
+from backend.app.repositories.blacklisted_refresh_token_repository import (
+    BlacklistedRefreshTokenRepository,
+)
+from backend.app.repositories.coupon_repository import CouponRepository
+from backend.app.repositories.form_plugin_provider_repository import (
+    FormPluginProviderRepository,
+)
+from backend.app.repositories.postgres.identity import (
+    PostgresBlacklistedRefreshTokenRepository,
+    PostgresUserTagsRepository,
+    PostgresWorkspaceAPIKeyRepository,
+    PostgresWorkspaceInvitationRepo,
+    PostgresWorkspaceRepository,
+    PostgresWorkspaceUserRepository,
+)
+from backend.app.repositories.postgres.refdata import (
+    PostgresAllowedOriginsRepository,
+    PostgresCouponRepository,
+    PostgresFormPluginProviderRepository,
+    PostgresUserFeedbackRepo,
+)
+from backend.app.repositories.user_feedback import UserFeedbackRepo
+from backend.app.repositories.user_tags_repository import UserTagsRepository
+from backend.app.repositories.workspace_api_key_repository import (
+    WorkspaceAPIKeyRepository,
+)
+from backend.app.repositories.workspace_invitation_repo import WorkspaceInvitationRepo
+from backend.app.repositories.workspace_repository import WorkspaceRepository
+from backend.app.repositories.workspace_user_repository import WorkspaceUserRepository
+from common.db import is_write_op
+
+PAIRS = [
+    (AllowedOriginsRepository, PostgresAllowedOriginsRepository),
+    (FormPluginProviderRepository, PostgresFormPluginProviderRepository),
+    (CouponRepository, PostgresCouponRepository),
+    (UserFeedbackRepo, PostgresUserFeedbackRepo),
+    (WorkspaceRepository, PostgresWorkspaceRepository),
+    (WorkspaceUserRepository, PostgresWorkspaceUserRepository),
+    (WorkspaceInvitationRepo, PostgresWorkspaceInvitationRepo),
+    (WorkspaceAPIKeyRepository, PostgresWorkspaceAPIKeyRepository),
+    (BlacklistedRefreshTokenRepository, PostgresBlacklistedRefreshTokenRepository),
+    (UserTagsRepository, PostgresUserTagsRepository),
+]
+
+
+def public_methods(cls):
+    return {
+        name
+        for name, member in inspect.getmembers(cls, inspect.isfunction)
+        if not name.startswith("_") and name in cls.__dict__
+    }
+
+
+@pytest.mark.parametrize("mongo, postgres", PAIRS, ids=lambda c: c.__name__)
+def test_twin_covers_the_mongo_surface(mongo, postgres):
+    missing = public_methods(mongo) - public_methods(postgres)
+    assert not missing, f"{postgres.__name__} lacks {sorted(missing)}"
+
+
+@pytest.mark.parametrize("mongo, postgres", PAIRS, ids=lambda c: c.__name__)
+def test_twin_methods_are_not_marked_themselves(mongo, postgres):
+    """Routing reads the markers off the Mongo surface; a marker on the twin is
+    a sign the two classes have drifted apart."""
+    marked = [n for n in public_methods(postgres) if is_write_op(getattr(postgres, n))]
+    assert marked == []

--- a/backend/tests/app/repositories/test_refdata_parity.py
+++ b/backend/tests/app/repositories/test_refdata_parity.py
@@ -8,6 +8,7 @@ Skipped unless DATABASE_URL points at a *_test database.
 from typing import Any
 
 import pytest
+from pymongo.results import DeleteResult, UpdateResult
 
 from backend.app.container import container
 from backend.app.models.types.coupon_code import CouponCode
@@ -32,6 +33,11 @@ VOLATILE = {"id", "_id", "created_at", "updated_at", "revision_id"}
 
 
 def strip(value: Any) -> Any:
+    # Mongo write results carry counts the callers ignore; the twins return the count.
+    if isinstance(value, DeleteResult):
+        return value.deleted_count
+    if isinstance(value, UpdateResult):
+        return value.matched_count
     value = normalise_result(value)
     if isinstance(value, dict):
         return {k: strip(v) for k, v in value.items() if k not in VOLATILE}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -173,12 +173,16 @@ async def client(_initialized_app):
 @pytest.fixture()
 async def workspace():
     await workspace_service.create_workspace(testUser)
-    workspace = (await WorkspaceDocument.find().to_list())[0]
-    await WorkspaceUserDocument(
-        workspace_id=workspace.id,
-        user_id=invited_user.id,
-        roles=[WorkspaceRoles.COLLABORATOR],
-    ).save()
+    workspace = await container.workspace_repo().get_default_workspace_by_owner_id(
+        testUser.id
+    )
+    await container.workspace_user_repo().save(
+        WorkspaceUserDocument(
+            workspace_id=workspace.id,
+            user_id=invited_user.id,
+            roles=[WorkspaceRoles.COLLABORATOR],
+        )
+    )
     return workspace
 
 
@@ -186,8 +190,9 @@ async def workspace():
 async def workspace_1():
     await workspace_service.create_workspace(testUser)
     await workspace_service.create_workspace(testUser1)
-    workspace = (await WorkspaceDocument.find().to_list())[1]
-    return workspace
+    return await container.workspace_repo().get_default_workspace_by_owner_id(
+        testUser1.id
+    )
 
 
 @pytest.fixture()
@@ -195,8 +200,7 @@ async def workspace_pro():
     await container.workspace_service().create_non_default_workspace(
         title="Title", description="description", workspace_name="name", user=proUser
     )
-    workspace = (await WorkspaceDocument.find().to_list())[0]
-    return workspace
+    return await container.workspace_repo().find_by_name("name")
 
 
 @pytest.fixture()

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -30,7 +30,9 @@ from common.db.routing import (
     RoutingMetrics,
     RoutingRepository,
     ShadowDiff,
+    is_replayed,
     is_write_op,
+    persisted_documents,
     write_op,
 )
 from common.db.spine import SpineColumns

--- a/common/common/db/pg_repository.py
+++ b/common/common/db/pg_repository.py
@@ -42,10 +42,23 @@ class PostgresRepositoryBase:
         return (self.row.created_at, self.row.id)
 
     async def one(self, *where: Any) -> Optional[Any]:
+        return await self.one_of(self.row, self.document, *where)
+
+    async def one_of(self, row: Type[Any], document: Type[Any], *where: Any):
+        """``one`` against another table of the same group — for the places the
+        Mongo original reads a second collection inside one method."""
         async with self._session() as session:
-            stmt = select(self.row.doc).where(*where).order_by(*self._order()).limit(1)
+            stmt = (
+                select(row.doc).where(*where).order_by(row.created_at, row.id).limit(1)
+            )
             doc = (await session.execute(stmt)).scalar_one_or_none()
-        return None if doc is None else from_row_doc(self.document, doc)
+        return None if doc is None else from_row_doc(document, doc)
+
+    async def get_or_raise(self, document_id: Any) -> Any:
+        """The twin of ``Document.get``: the document, or the document layer's
+        ``NotFoundError`` with the same message."""
+        found = await self.one(self.row.id == str(document_id))
+        return self.document.verify_doc_exists(found, {"id": document_id})
 
     async def many(
         self,
@@ -112,6 +125,17 @@ class PostgresRepositoryBase:
         async with self._session() as session, session.begin():
             for document in documents:
                 await session.execute(self._upsert_statement(row_values(document)))
+
+    async def replay_write(self, documents: Iterable[Any]) -> None:
+        """Store what the primary persisted (``@write_op(replay=True)``)."""
+        documents = list(documents)
+        for document in documents:
+            if not isinstance(document, self.document):
+                raise TypeError(
+                    f"{type(self).__name__} cannot store a "
+                    f"{type(document).__name__}; expected {self.document.__name__}"
+                )
+        await self.upsert_many(documents)
 
     async def delete_where(self, *where: Any) -> int:
         async with self._session() as session, session.begin():

--- a/common/common/db/routing.py
+++ b/common/common/db/routing.py
@@ -5,9 +5,14 @@ proxy over the Mongo implementation and, once it exists, the Postgres one.
 Method calls are dispatched by the flags for the repository's group:
 
 * **writes** (methods marked with :func:`write_op`) go to the primary store;
-  the same call is then replayed on the mirror store, bounded by a timeout
-  and never allowed to fail the request — a failure is counted, logged
-  (redacted) and handed to ``on_mirror_failure`` for the outbox;
+  the mirror store is then brought in line, bounded by a timeout and never
+  allowed to fail the request — a failure is counted, logged (redacted) and
+  handed to ``on_mirror_failure`` for the outbox. By default the mirror
+  re-executes the call with the same arguments, which is only correct when
+  the call is deterministic in them; a write that mints state the caller did
+  not pass in (a new document's id, an invitation token) must be marked
+  ``@write_op(replay=True)`` and return the persisted document(s) — the
+  mirror then stores *those*, so both stores hold the same document;
 * **reads** go to the read source; with ``DB_SHADOW_READ_SAMPLE`` > 0 a
   sample is also issued to the other store and the results compared.
 
@@ -32,16 +37,46 @@ from common.db.flags import DbFlags, ReadSource
 logger = logging.getLogger(__name__)
 
 WRITE_MARKER = "__bc_write__"
+REPLAY_MARKER = "__bc_replay__"
 
 
-def write_op(fn):
-    """Mark a repository method as a write. Unmarked methods are reads."""
-    setattr(fn, WRITE_MARKER, True)
-    return fn
+def write_op(fn=None, *, replay: bool = False):
+    """Mark a repository method as a write. Unmarked methods are reads.
+
+    ``replay=True`` declares that the method returns the document(s) it
+    persisted and that the mirror must store that result rather than re-run
+    the method (see the module docstring). Usable bare or with arguments.
+    """
+
+    def mark(f):
+        setattr(f, WRITE_MARKER, True)
+        setattr(f, REPLAY_MARKER, replay)
+        return f
+
+    return mark if fn is None else mark(fn)
 
 
 def is_write_op(fn) -> bool:
     return bool(getattr(fn, WRITE_MARKER, False))
+
+
+def is_replayed(fn) -> bool:
+    return bool(getattr(fn, REPLAY_MARKER, False))
+
+
+def persisted_documents(result: Any) -> list:
+    """The persisted document(s) in a replayed write's result: a document with
+    an id, or a list/tuple of them. Anything else yields ``[]`` and the mirror
+    falls back to re-executing the call."""
+
+    def is_doc(v: Any) -> bool:
+        return getattr(v, "id", None) is not None and callable(getattr(v, "save", None))
+
+    if is_doc(result):
+        return [result]
+    if isinstance(result, (list, tuple)) and result and all(is_doc(v) for v in result):
+        return list(result)
+    return []
 
 
 class RoutingError(RuntimeError):
@@ -57,6 +92,7 @@ class MirrorFailure:
     args: tuple
     kwargs: dict
     error: BaseException
+    documents: tuple = ()  # what a replayed write tried to store on the mirror
 
 
 @dataclass
@@ -156,7 +192,9 @@ class RoutingRepository:
         if not callable(attr):
             return attr
         if inspect.iscoroutinefunction(attr):
-            return self._write(name) if is_write_op(attr) else self._read(name)
+            if is_write_op(attr):
+                return self._write(name, replay=is_replayed(attr))
+            return self._read(name)
         return self._sync(name)
 
     def _impl(self, source: ReadSource, name: str):
@@ -185,23 +223,37 @@ class RoutingRepository:
 
         return method
 
-    def _write(self, name: str):
+    def _write(self, name: str, *, replay: bool):
         async def method(*args, **kwargs):
             self._metrics.calls[(self._group, name)] += 1
             primary = self._flags.primary_store(self._group)
             result = await self._impl(primary, name)(*args, **kwargs)
             mirror = self._flags.mirror_store(self._group)
             if mirror is not None and self._stores[mirror] is not None:
-                await self._mirror(name, mirror, args, kwargs)
+                documents = persisted_documents(result) if replay else []
+                await self._mirror(name, mirror, args, kwargs, documents)
             return result
 
         return method
 
-    async def _mirror(self, name: str, store: ReadSource, args, kwargs) -> None:
+    async def _replay(self, store: ReadSource, documents: list) -> None:
+        impl = self._stores[store]
+        hook = getattr(impl, "replay_write", None)
+        if hook is not None:
+            await hook(documents)
+            return
+        for document in documents:  # a Beanie repository: save() is an upsert by id
+            await document.save()
+
+    async def _mirror(
+        self, name: str, store: ReadSource, args, kwargs, documents: list = ()
+    ) -> None:
         try:
-            await asyncio.wait_for(
-                self._impl(store, name)(*args, **kwargs), timeout=self._mirror_timeout_s
-            )
+            if documents:
+                coro = self._replay(store, documents)
+            else:
+                coro = self._impl(store, name)(*args, **kwargs)
+            await asyncio.wait_for(coro, timeout=self._mirror_timeout_s)
         except (
             BaseException
         ) as exc:  # noqa: BLE001 — the mirror must never fail the request
@@ -227,6 +279,7 @@ class RoutingRepository:
                             args,
                             kwargs,
                             exc,
+                            tuple(documents),
                         )
                     )
                     if inspect.isawaitable(maybe):

--- a/common/tests/test_routing.py
+++ b/common/tests/test_routing.py
@@ -165,3 +165,106 @@ async def test_per_group_flags_apply_to_the_repository_group():
     assert (
         p.calls == []
     )  # the forms group is mongo-only even though the default is dual
+
+
+class Doc:
+    """Stands in for a Beanie document: has an id and an upserting save()."""
+
+    saved = []
+
+    def __init__(self, id, body):
+        self.id, self.body = id, body
+
+    async def save(self):
+        Doc.saved.append((self.id, self.body))
+        return self
+
+
+class MintingStore(FakeStore):
+    """A repository whose ``create`` mints an id and a token — non-deterministic
+    in its arguments, so the mirror must replay the result, not the call."""
+
+    def __init__(self, tag, **kw):
+        super().__init__(tag, **kw)
+        self.replayed = []
+        self.counter = 0
+
+    @write_op(replay=True)
+    async def create(self, body):
+        await self._go("create", body)
+        self.counter += 1
+        return Doc(f"{self.tag}-{self.counter}", body)
+
+    @write_op(replay=True)
+    async def create_many(self, n):
+        await self._go("create_many", n)
+        return [Doc(f"{self.tag}-{i}", i) for i in range(n)]
+
+    @write_op(replay=True)
+    async def touch(self, key):
+        await self._go("touch", key)
+        return None  # replay-marked but nothing persisted to hand over
+
+    async def replay_write(self, documents):
+        self.replayed.append([d.id for d in documents])
+
+
+class BeanieLikeStore(MintingStore):
+    replay_write = None  # a Mongo repository: no hook, documents save() themselves
+
+
+async def test_replayed_write_stores_the_primary_result_on_the_mirror():
+    m, p = MintingStore("mongo"), MintingStore("postgres")
+    r = repo({"DB_WRITE_MODE": "dual"}, mongo=m, postgres=p)
+    doc = await r.create({"a": 1})
+    assert doc.id == "mongo-1"
+    assert [c[0] for c in p.calls] == []  # the call itself was not re-executed
+    assert p.replayed == [["mongo-1"]]
+    assert (await r.create_many(2))[1].id == "mongo-1"
+    assert p.replayed[-1] == ["mongo-0", "mongo-1"]
+
+
+async def test_replay_falls_back_to_re_execution_when_nothing_was_persisted():
+    m, p = MintingStore("mongo"), MintingStore("postgres")
+    r = repo({"DB_WRITE_MODE": "dual"}, mongo=m, postgres=p)
+    await r.touch("k")
+    assert [c[0] for c in p.calls] == ["touch"]
+    assert p.replayed == []
+
+
+async def test_replay_onto_a_beanie_repository_saves_each_document():
+    Doc.saved.clear()
+    m, p = BeanieLikeStore("mongo"), MintingStore("postgres")
+    r = repo({"DB_WRITE_MODE": "postgres_primary_dual"}, mongo=m, postgres=p)
+    doc = await r.create({"b": 2})
+    assert doc.id == "postgres-1"
+    assert Doc.saved == [("postgres-1", {"b": 2})]
+    assert [c[0] for c in m.calls] == []
+
+
+async def test_replay_failure_is_reported_with_the_documents():
+    class Broken(MintingStore):
+        async def replay_write(self, documents):
+            raise RuntimeError("down")
+
+    failures = []
+    m, p = MintingStore("mongo"), Broken("postgres")
+    r = repo(
+        {"DB_WRITE_MODE": "dual"},
+        mongo=m,
+        postgres=p,
+        on_mirror_failure=failures.append,
+    )
+    doc = await r.create({"c": 3})
+    assert doc.id == "mongo-1"
+    assert len(failures) == 1
+    assert [d.id for d in failures[0].documents] == ["mongo-1"]
+    assert failures[0].method == "create"
+
+
+def test_write_op_marks_replay():
+    from common.db import is_replayed, is_write_op
+
+    assert is_write_op(MintingStore.create) and is_replayed(MintingStore.create)
+    assert is_write_op(FakeStore.save) and not is_replayed(FakeStore.save)
+    assert not is_write_op(FakeStore.find)


### PR DESCRIPTION
Plan step 5b (`plans/postgres-consolidation.md`), stacked on #669. Retarget to `develop` once #669 merges — CI only runs for PRs targeting develop/master.

## What

- **Postgres twins for the identity group** — `PostgresWorkspaceRepository`, `PostgresWorkspaceUserRepository`, `PostgresWorkspaceInvitationRepo`, `PostgresWorkspaceAPIKeyRepository`, `PostgresBlacklistedRefreshTokenRepository`, `PostgresUserTagsRepository` (`backend/app/repositories/postgres/identity.py`), wired as the `postgres=` store of their `RoutingRepository` providers. Method for method, including the originals' quirks (404 vs `None`, the document layer's `NotFoundError`, `find_one().update()` being a no-op on no match, `$addToSet`).
- **CI matrix** now runs the backend suite with `identity` mirrored and served from Postgres alongside `refdata`. Test fixtures create and read identity documents through the repositories, so the suite exercises whichever store the flags select.
- **Parity tests** (`test_identity_parity.py`) run every method on both stores and compare; a **surface test** (`test_postgres_surface.py`, no DB) checks each twin covers its Mongo original's public methods.

## Routing fix: replay, not re-execution, for minting writes

The mirror re-executed a write with the primary's arguments. That is only correct when the call is deterministic in them; a write that mints state the caller did not pass in — a new document's id, an invitation token — left the two stores holding **different documents** (refdata's `add(origin)` already did this silently; the invitation token would have been unusable from the mirror).

- `@write_op(replay=True)` declares a write returns the document(s) it persisted; the mirror stores *that* (`PostgresRepositoryBase.replay_write`, or `document.save()` when Mongo is the mirror). Anything else still re-executes.
- Applied to `allowed_origins.add`, `create_workspace_invitation`, `blacklisted_tokens.add`, `insert_user_tag` (now returns the document). `create_coupons` assigns ids before `insert_many`, which does not write them back.
- Outbox records include the replayed documents' ids. Tests in `common/tests/test_routing.py`.
- Rule recorded for later groups: a write may not return a DTO built from the document (e.g. `ActionRepository.create_action`) — return the document and let the service shape it.

## Cross-group lookups compose, they do not join

`get_workspace_with_action_by_id` is a `$lookup` from workspaces (identity) into workspace_actions (actions). Groups cut over independently, so the twin reads the workspace from Postgres and the action through the **routed** actions repository (new read `ActionRepository.get_workspace_action`) — correct whatever store currently serves actions. Joins stay SQL within a group; R3 can collapse this one.

## Verification

- backend suite ×3 (default / `DB_WRITE_MODE__{refdata,identity}=dual` / `DB_READ_SOURCE__…=postgres DB_WRITE_MODE__…=postgres`): 272 passed, 6 skipped each
- common: 52 passed, 11 skipped (Postgres-only tests without a DB)
- auth and integrations/google still import the changed `common.db`
