### PR TITLE
refactor(backend): make the forms repositories' query API implementable by a second store

### DIFF
--- a/backend/backend/app/repositories/form_repository.py
+++ b/backend/backend/app/repositories/form_repository.py
@@ -3,6 +3,8 @@ from typing import List
 from beanie import PydanticObjectId
 from beanie.odm.enums import SortDirection
 from beanie.odm.queries.aggregation import AggregationQuery
+from fastapi_pagination import Page
+from fastapi_pagination.ext.beanie import apaginate
 from common.models.standard_form import StandardForm
 
 from backend.app.exceptions import HTTPException
@@ -14,9 +16,20 @@ from backend.app.utils.aggregation_query_builder import create_filter_pipeline
 from common.db.routing import write_op
 
 
+# Arrays the $lookups leave behind once their values are folded into the
+# document; nothing reads them and they can be large (every version of a form).
+_LOOKUP_SCAFFOLDING = [
+    "workspace_form",
+    "form",
+    "form_groups",
+    "versions",
+    "responses_deletion_requests",
+]
+
+
 class FormRepository:
-    @staticmethod
-    def get_forms_in_workspace_query(
+    def _forms_in_workspace_query(
+        self,
         workspace_id: PydanticObjectId,
         form_id_list: List[str],
         is_admin: bool,
@@ -110,13 +123,38 @@ class FormRepository:
                     {"$set": {"is_published": {"$gt": [{"$size": "$versions"}, 0]}}},
                 ]
             )
-        forms = FormDocument.find({"form_id": {"$in": form_id_list}}).aggregate(
+        aggregation_pipeline.append({"$unset": _LOOKUP_SCAFFOLDING})
+        return FormDocument.find({"form_id": {"$in": form_id_list}}).aggregate(
             aggregation_pipeline
         )
-        return forms
 
-    @staticmethod
-    def get_published_forms_in_workspace(
+    async def get_forms_in_workspace(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id_list: List[str],
+        is_admin: bool,
+        sort=None,
+    ) -> List[dict]:
+        """Draft forms of a workspace with their workspace settings, importer,
+        responder groups and — for admins — response/deletion counts and publish
+        state. Raw documents, shaped for ``FormDtoCamelModel``."""
+        return await self._forms_in_workspace_query(
+            workspace_id, form_id_list, is_admin, sort
+        ).to_list()
+
+    async def paginate_forms_in_workspace(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id_list: List[str],
+        is_admin: bool,
+        sort=None,
+    ) -> Page:
+        return await apaginate(
+            self._forms_in_workspace_query(workspace_id, form_id_list, is_admin, sort)
+        )
+
+    def _published_forms_in_workspace_query(
+        self,
         workspace_id: PydanticObjectId,
         form_id_list: List[str],
         sort=None,
@@ -204,10 +242,37 @@ class FormRepository:
         if get_actions:
             aggregation_pipeline.extend(get_action_aggregation)
         aggregation_pipeline.extend(create_filter_pipeline(sort=sort))
-        form_versions_query = FormVersionsDocument.find(
+        aggregation_pipeline.append({"$unset": _LOOKUP_SCAFFOLDING})
+        return FormVersionsDocument.find(
             {"form_id": {"$in": form_id_list}}
         ).aggregate(aggregation_pipeline=aggregation_pipeline)
-        return form_versions_query
+
+    async def get_published_forms_in_workspace(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id_list: List[str],
+        sort=None,
+        get_actions=False,
+    ) -> List[dict]:
+        """Latest published version of each form, with workspace settings and
+        response/deletion counts; ``get_actions`` adds the draft's actions,
+        parameters, secrets and responder groups."""
+        return await self._published_forms_in_workspace_query(
+            workspace_id, form_id_list, sort, get_actions
+        ).to_list()
+
+    async def paginate_published_forms_in_workspace(
+        self,
+        workspace_id: PydanticObjectId,
+        form_id_list: List[str],
+        sort=None,
+        get_actions=False,
+    ) -> Page:
+        return await apaginate(
+            self._published_forms_in_workspace_query(
+                workspace_id, form_id_list, sort, get_actions
+            )
+        )
 
     async def search_form_in_workspace(
         self,

--- a/backend/backend/app/repositories/workspace_form_repository.py
+++ b/backend/backend/app/repositories/workspace_form_repository.py
@@ -104,34 +104,51 @@ class WorkspaceFormRepository:
         workspace_id: PydanticObjectId,
         is_not_admin: bool = False,
         user: User = None,
-        match_query: Dict[str, Any] = None,
+        form_id: Optional[str] = None,
+        form_id_or_slug: Optional[str] = None,
         pinned_only: bool = False,
         id_only: bool = False,
         filter_closed=False,
     ) -> List[Dict[str, Any]]:
+        """Workspace-form rows a caller may see, as raw documents (``form_id``
+        only with ``id_only``). ``form_id`` narrows to one form; ``form_id_or_slug``
+        also accepts the form's custom URL. Anonymous visitors see public,
+        unhidden forms; a signed-in non-member additionally sees private forms
+        whose responder groups admit them (membership or the group's regex)."""
         try:
             query = {"workspace_id": workspace_id}
+            if form_id is not None:
+                query["form_id"] = form_id
+            if form_id_or_slug is not None:
+                query["$or"] = [
+                    {"form_id": form_id_or_slug},
+                    {"settings.custom_url": form_id_or_slug},
+                ]
             if pinned_only:
                 query["settings.pinned"] = True
 
             if not is_not_admin and user:
-                query["$or"] = [
+                visible = [
                     {"settings.hidden": False},
                     {"settings.hidden": {"$exists": False}},
                     {"user_id": user.id},
                 ]
+                if "$or" in query:
+                    query["$and"] = [{"$or": query.pop("$or")}, {"$or": visible}]
+                else:
+                    query["$or"] = visible
             if is_not_admin and not user:
-                query["$and"] = [
-                    {
-                        "$or": [
-                            {"settings.hidden": False},
-                            {"settings.hidden": {"$exists": False}},
-                        ]
-                    },
-                    {"settings.private": False},
-                ]
-            if match_query:
-                query.update(match_query)
+                query.setdefault("$and", []).extend(
+                    [
+                        {
+                            "$or": [
+                                {"settings.hidden": False},
+                                {"settings.hidden": {"$exists": False}},
+                            ]
+                        },
+                        {"settings.private": False},
+                    ]
+                )
             aggregation_pipeline = []
 
             if filter_closed:
@@ -225,7 +242,14 @@ class WorkspaceFormRepository:
                 .aggregate(aggregation_pipeline)
                 .to_list()
             )
-            return workspace_forms
+            # the $unwind over group regexes yields one row per matching group
+            seen, unique = set(), []
+            for workspace_form in workspace_forms:
+                key = workspace_form.get("_id", workspace_form.get("form_id"))
+                if key not in seen:
+                    seen.add(key)
+                    unique.append(workspace_form)
+            return unique
         except (InvalidURI, NetworkTimeout, OperationFailure, InvalidOperation):
             raise HTTPException(
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -238,14 +262,16 @@ class WorkspaceFormRepository:
         is_not_admin: bool = False,
         user: User = None,
         pinned_only: bool = False,
-        match_query: Dict[str, Any] = None,
+        form_id: Optional[str] = None,
+        form_id_or_slug: Optional[str] = None,
         filter_closed: bool = False,
     ):
         workspace_forms = await self.get_workspace_forms_in_workspace(
             workspace_id=workspace_id,
             is_not_admin=is_not_admin,
             user=user,
-            match_query=match_query,
+            form_id=form_id,
+            form_id_or_slug=form_id_or_slug,
             pinned_only=pinned_only,
             id_only=True,
             filter_closed=filter_closed,

--- a/backend/backend/app/services/form_service.py
+++ b/backend/backend/app/services/form_service.py
@@ -16,7 +16,6 @@ from common.models.standard_form import (
 from common.models.user import User
 from common.services.http_client import HttpClient
 from fastapi_pagination import Page
-from fastapi_pagination.ext.beanie import paginate, apaginate
 from starlette.requests import Request
 
 from backend.app.constants.consents import default_consents
@@ -91,20 +90,18 @@ class FormService:
             filter_closed=published or pinned_only,
         )
         if published:
-            forms_query = self._form_repo.get_published_forms_in_workspace(
+            forms_page = await self._form_repo.paginate_published_forms_in_workspace(
                 workspace_id=workspace_id,
                 form_id_list=workspace_form_ids,
                 sort=sort,
             )
         else:
-            forms_query = self._form_repo.get_forms_in_workspace_query(
+            forms_page = await self._form_repo.paginate_forms_in_workspace(
                 workspace_id=workspace_id,
                 form_id_list=workspace_form_ids,
                 is_admin=has_access_to_workspace,
                 sort=sort,
             )
-
-        forms_page = await apaginate(forms_query)
 
         if not published:
             user_ids = [form.imported_by for form in forms_page.items]
@@ -203,23 +200,21 @@ class FormService:
             workspace_id=workspace_id,
             is_not_admin=not is_admin,
             user=user,
-            match_query={
-                "$or": [{"form_id": form_id}, {"settings.custom_url": form_id}]
-            },
+            form_id_or_slug=form_id,
         )
         if published:
             authorized_form = await self._form_repo.get_published_forms_in_workspace(
                 workspace_id=workspace_id,
                 form_id_list=workspace_form_ids,
                 get_actions=is_admin,
-            ).to_list()
+            )
             if not authorized_form:
                 if draft:
-                    form = await self._form_repo.get_forms_in_workspace_query(
+                    form = await self._form_repo.get_forms_in_workspace(
                         workspace_id=workspace_id,
                         form_id_list=workspace_form_ids,
                         is_admin=is_admin,
-                    ).to_list()
+                    )
                     if not form:
                         raise HTTPException(
                             status_code=HTTPStatus.NOT_FOUND, content="Form Not Found"
@@ -247,11 +242,11 @@ class FormService:
                 return authorized_form[0]
 
         else:
-            form = await self._form_repo.get_forms_in_workspace_query(
+            form = await self._form_repo.get_forms_in_workspace(
                 workspace_id=workspace_id,
                 form_id_list=workspace_form_ids,
                 is_admin=is_admin,
-            ).to_list()
+            )
         if not form:
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND, content="Form Not Found"
@@ -431,9 +426,7 @@ class FormService:
                 workspace_id=workspace_id,
                 is_not_admin=not is_admin,
                 user=user,
-                match_query={
-                    "$or": [{"form_id": form_id}, {"settings.custom_url": form_id}]
-                },
+                form_id_or_slug=form_id,
             )
         )
 
@@ -443,11 +436,11 @@ class FormService:
             )
         workspace_form = workspace_forms[0]
         if workspace_form["settings"]["provider"] != "self":
-            form = await self._form_repo.get_forms_in_workspace_query(
+            form = await self._form_repo.get_forms_in_workspace(
                 workspace_id=workspace_id,
                 form_id_list=[form_id],
                 is_admin=is_admin,
-            ).to_list()
+            )
 
             if not form:
                 raise HTTPException(

--- a/backend/backend/app/services/workspace_form_service.py
+++ b/backend/backend/app/services/workspace_form_service.py
@@ -479,7 +479,7 @@ class WorkspaceFormService:
                 workspace_id=workspace_id,
                 is_not_admin=True,
                 user=user,
-                match_query={"form_id": str(form_id)},
+                form_id=str(form_id),
             )
         )
 
@@ -529,12 +529,7 @@ class WorkspaceFormService:
                 workspace_id=workspace_id,
                 is_not_admin=True,
                 user=user,
-                match_query={
-                    "$or": [
-                        {"form_id": str(form_id)},
-                        {"settings.custom_url": str(form_id)},
-                    ]
-                },
+                form_id_or_slug=str(form_id),
             )
         )
         if not workspace_form_ids:


### PR DESCRIPTION
Plan step 6, part a (`plans/postgres-consolidation.md`): the forms group is the largest group and its `FormRepository` was the one repository whose public surface a Postgres twin could not implement — two static methods returned Beanie aggregation *queries* for the service to paginate or `.to_list()` itself. This PR reshapes that surface with **no behaviour change** (suite passes unmodified: 272 passed); 6b adds the twins.

## Changes

- **`FormRepository`**: the builders become private; the public API is async and owns pagination — `get_forms_in_workspace` / `paginate_forms_in_workspace` (drafts) and `get_published_forms_in_workspace` / `paginate_published_forms_in_workspace` (latest published version per form). Callers in `FormService` updated.
- **`$unset` of lookup scaffolding**: the aggregations left `workspace_form`, `form`, `form_groups`, `versions`, `responses_deletion_requests` arrays on every returned document. Their values are already folded into the document (`settings`, `imported_by`, `is_published`, counts) and nothing reads them — `versions` carried every version of every listed form. Also gives the twins an exact shape to match.
- **`WorkspaceFormRepository.get_workspace_forms_in_workspace`**: the raw Mongo filter parameter `match_query` (callers passed one of two shapes) becomes explicit `form_id` / `form_id_or_slug` parameters, combined with the visibility filters via `$and` rather than dict-overwriting them.
- The same method **de-duplicates** its rows: the `$unwind` over responder-group regexes returned one row per matching group for a signed-in non-member (callers that needed ids already `set()`-ed them; the raw-row callers did not).

## Verification

Backend suite: 272 passed, 6 skipped, no test changes.
