### PR TITLE
refactor(backend): make the responses and actions repositories twin-able; precise cutover rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
                   DB_READ_SOURCE__refdata: postgres
                   DB_WRITE_MODE__refdata: postgres
                   DB_READ_SOURCE__identity: postgres
-                  DB_WRITE_MODE__identity: postgres
+                  DB_WRITE_MODE__identity: postgres_primary_dual
               run: uv run pytest
 
     auth-tests:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,8 +29,9 @@ DATABASE_URL=postgresql+asyncpg://bc_app:bc_app@localhost:5432/bettercollected
 #   DB_READ_SOURCE=mongo|postgres            DB_WRITE_MODE=mongo|dual|postgres_primary_dual|postgres
 #   DB_READ_SOURCE__<group>=... / DB_WRITE_MODE__<group>=...   DB_SHADOW_READ_SAMPLE=0.0..1.0
 # e.g. mirror the refdata group to Postgres:  DB_WRITE_MODE__refdata=dual
-# Cutover order is enforced at boot: `forms` may only be served from Postgres once
-# `responses` is (its Mongo repositories join into forms/workspace_forms).
+# Cutover order is enforced at boot (backend/db/groups.py): a group whose Mongo
+# repositories join into another group's collections must be served from Postgres
+# before that other group stops writing Mongo (DB_WRITE_MODE=postgres).
 # Schedular
 SCHEDULAR_INTERVAL_MINUTES=10
 # Export csv

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -18,7 +18,7 @@ from common.db import DatabaseSettings, load_flags
 from common.db.routing import RoutingRepository
 
 from backend.db.outbox import OutboxRecorder
-from backend.db.groups import READ_DEPENDENCIES
+from backend.db.groups import MONGO_JOINS
 from backend.db.session import build_engine, build_sessionmaker, postgres_repository
 from backend.app.repositories.postgres.forms import (
     PostgresFormRepository,
@@ -128,7 +128,7 @@ class AppContainer(containers.DeclarativeContainer):
     database_client: AsyncMongoClient = providers.Object(None)
     # Mongo/Postgres switching (plans/postgres-consolidation.md D5): read once at boot,
     # validated; a bad combination refuses to start.
-    flags = providers.Singleton(load_flags, read_dependencies=READ_DEPENDENCIES)
+    flags = providers.Singleton(load_flags, mongo_joins=MONGO_JOINS)
     # Postgres: engine and sessions exist only when DATABASE_URL is set; the
     # routing layer treats the store as absent otherwise. Mirror-write failures
     # land in the primary store's outbox (backend/db/outbox.py).
@@ -437,6 +437,7 @@ class AppContainer(containers.DeclarativeContainer):
     action_service = providers.Singleton(
         ActionService,
         action_repository=action_repository,
+        form_repo=form_repo,
         temporal_service=temporal_service,
         workspace_user_service=workspace_user_service,
         http_client=http_client,

--- a/backend/backend/app/repositories/action_repository.py
+++ b/backend/backend/app/repositories/action_repository.py
@@ -6,7 +6,6 @@ from common.models.user import User
 
 from backend.app.models.dtos.action_dto import ActionDto, ActionResponse
 from backend.app.schemas.action_document import ActionDocument, WorkspaceActionsDocument
-from backend.app.schemas.standard_form import FormDocument
 from common.db.routing import write_op
 
 
@@ -14,10 +13,10 @@ class ActionRepository:
     def __init__(self, crypto: Crypto):
         self.crypto = crypto
 
-    @write_op
+    @write_op(replay=True)
     async def create_action(
         self, workspace_id: PydanticObjectId, action: ActionDto, user: User
-    ):
+    ) -> ActionDocument:
         if action.secrets is not None:
             for secret in action.secrets:
                 secret.value = self.crypto.encrypt(secret.value)
@@ -26,8 +25,7 @@ class ActionRepository:
             created_by=PydanticObjectId(user.id),
             workspace_id=workspace_id,
         )
-        new_action = await new_action.save()
-        return ActionResponse(**new_action.model_dump(mode="json"))
+        return await new_action.save()
 
     @write_op
     async def delete_action(self, action_id: PydanticObjectId):
@@ -110,26 +108,8 @@ class ActionRepository:
         # return [ActionResponse(**action, id=action["_id"]) for action in actions]
 
     # TODO resolve circular deps with action_service and workspace_form_service and update in workspace form repo
-    @write_op
-    async def remove_action_form_all_forms(self, action_id: PydanticObjectId):
-        await FormDocument.find(
-            {
-                "$or": [
-                    {"actions.on_submit": {"$in": [action_id]}},
-                    {"actions.on_open": {"$in": [action_id]}},
-                ]
-            }
-        ).update(
-            {
-                "$pull": {"actions.on_submit": action_id},
-                "$unset": {
-                    f"parameters.{str(action_id)}": "",
-                    f"secrets.{str(action_id)}": "",
-                },
-            }
-        )
 
-    @write_op
+    @write_op(replay=True)
     async def create_action_in_workspace_from_action(
         self,
         workspace_id: PydanticObjectId,
@@ -151,7 +131,7 @@ class ActionRepository:
         await workspace_action.save()
         return workspace_action
 
-    @write_op
+    @write_op(replay=True)
     async def create_global_action(self, action: ActionDto, user: User):
         if action.secrets is not None:
             for secret in action.secrets:

--- a/backend/backend/app/repositories/deletion_requests_repository.py
+++ b/backend/backend/app/repositories/deletion_requests_repository.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Optional
 
 from fastapi_pagination.ext.beanie import paginate
 
@@ -14,13 +14,15 @@ class DeletionRequestsRepository:
     @staticmethod
     async def get_deletion_requests(
         form_ids,
-        extra_find_query: Dict[str, Any] = None,
+        data_owner_identifier: Optional[str] = None,
         filter_query: FormResponseFilterQuery = None,
         sort: SortRequest = None,
     ):
+        """Deletion requests for ``form_ids`` (optionally one responder's), each
+        carrying its form's title and importer and the response's submission uuid."""
         find_query = {"form_id": {"$in": form_ids}}
-        if extra_find_query is not None:
-            find_query.update(extra_find_query)
+        if data_owner_identifier is not None:
+            find_query["dataOwnerIdentifier"] = data_owner_identifier
         aggregate_query = [
             {
                 "$lookup": {

--- a/backend/backend/app/repositories/flow_event_repository.py
+++ b/backend/backend/app/repositories/flow_event_repository.py
@@ -5,7 +5,7 @@ from common.db.routing import write_op
 
 
 class FlowEventRepository:
-    @write_op
+    @write_op(replay=True)
     async def add(
         self, form_id: str, session_id: str, from_page: str, to_page: str
     ) -> FlowEventDocument:

--- a/backend/backend/app/repositories/form_repository.py
+++ b/backend/backend/app/repositories/form_repository.py
@@ -435,6 +435,28 @@ class FormRepository:
         return await FormDocument.find_one({"form_id": str(form_id)})
 
     @write_op
+    async def remove_action_from_all_forms(self, action_id: PydanticObjectId):
+        """Detach a deleted action from every form: drop it from the on_submit
+        triggers and forget its parameters and secrets (moved here from the
+        actions repository — it writes forms, so it belongs to the forms group)."""
+        await FormDocument.find(
+            {
+                "$or": [
+                    {"actions.on_submit": {"$in": [action_id]}},
+                    {"actions.on_open": {"$in": [action_id]}},
+                ]
+            }
+        ).update(
+            {
+                "$pull": {"actions.on_submit": action_id},
+                "$unset": {
+                    f"parameters.{str(action_id)}": "",
+                    f"secrets.{str(action_id)}": "",
+                },
+            }
+        )
+
+    @write_op
     async def update_form_actions(
         self,
         form_id: PydanticObjectId,

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -35,16 +35,18 @@ class FormResponseRepository(BaseRepository):
         super().__init__()
         self.crypto = crypto
 
-    @staticmethod
     async def get_form_responses(
+        self,
         form_ids,
-        extra_find_query: Dict[str, Any] = None,
+        data_owner_identifier: Optional[str] = None,
         filter_query: FormResponseFilterQuery = None,
         sort: SortRequest = None,
     ) -> Page[StandardFormResponseCamelModel]:
+        """Responses with answers to ``form_ids`` (optionally one responder's),
+        each carrying its form's title and any deletion request's status."""
         find_query = {"form_id": {"$in": form_ids}, "answers": {"$exists": True}}
-        if extra_find_query is not None:
-            find_query.update(extra_find_query)
+        if data_owner_identifier is not None:
+            find_query["dataOwnerIdentifier"] = data_owner_identifier
         aggregate_query = [
             {
                 "$lookup": {
@@ -191,13 +193,14 @@ class FormResponseRepository(BaseRepository):
         # signed-in account listing must not link anonymous submissions back to
         # the account. The submission number (receipt) is the only key to an
         # anonymous response — which is exactly what the portal promises.
-        extra_find_query = {"dataOwnerIdentifier": user.sub}
         if request_for_deletion:
             return await DeletionRequestsRepository.get_deletion_requests(
-                form_ids=form_ids, extra_find_query=extra_find_query
+                form_ids=form_ids, data_owner_identifier=user.sub
             )
         else:
-            return await self.get_form_responses(form_ids, extra_find_query)
+            return await self.get_form_responses(
+                form_ids, data_owner_identifier=user.sub
+            )
 
     async def count_responses_with_answers_by_form_ids(
         self, form_ids: List[str]
@@ -300,6 +303,19 @@ class FormResponseRepository(BaseRepository):
     ) -> Optional[FormResponseDeletionRequest]:
         return await FormResponseDeletionRequest.find_one({"response_id": response_id})
 
+    @write_op(replay=True)
+    async def add_deletion_request(
+        self, response: FormResponseDocument, response_id: str
+    ) -> FormResponseDeletionRequest:
+        return await FormResponseDeletionRequest(
+            form_id=response.form_id,
+            response_id=response_id,
+            dataOwnerIdentifier=response.dataOwnerIdentifier,
+            anonymous_identity=response.anonymous_identity,
+            provider=response.provider,
+            deleted_at=None,
+        ).save()
+
     @write_op
     async def delete_by_form_id_except(
         self, form_id: str, keep_response_ids: List[str]
@@ -342,7 +358,7 @@ class FormResponseRepository(BaseRepository):
             {"form_id": {"$in": form_ids}}
         ).delete()
 
-    @write_op
+    @write_op(replay=True)
     async def save_form_response(
         self,
         form_id: PydanticObjectId,

--- a/backend/backend/app/repositories/mcp_audit_log_repository.py
+++ b/backend/backend/app/repositories/mcp_audit_log_repository.py
@@ -3,6 +3,6 @@ from common.db.routing import write_op
 
 
 class McpAuditLogRepository:
-    @write_op
+    @write_op(replay=True)
     async def add(self, **fields) -> MCPAuditLogDocument:
         return await MCPAuditLogDocument(**fields).save()

--- a/backend/backend/app/repositories/postgres/forms.py
+++ b/backend/backend/app/repositories/postgres/forms.py
@@ -429,6 +429,27 @@ class PostgresFormRepository(PostgresRepositoryBase):
     async def get_form_by_id(self, form_id: PydanticObjectId):
         return await self.one(FormRow.form_id == _oid(form_id))
 
+    async def remove_action_from_all_forms(self, action_id: PydanticObjectId):
+        # ObjectIds sit in the canonical doc as {"$oid": hex}; @> finds the forms
+        marker = [{"$oid": _oid(action_id)}]
+        actions = FormRow.doc["actions"]
+        forms = await self.many(
+            or_(
+                actions["on_submit"].contains(marker),
+                actions["on_open"].contains(marker),
+            )
+        )
+        for form in forms:
+            if form.actions and form.actions.get("on_submit"):
+                form.actions["on_submit"] = [  # $pull
+                    a for a in form.actions["on_submit"] if str(a) != _oid(action_id)
+                ]
+            for bag in (form.parameters, form.secrets):  # $unset
+                if isinstance(bag, dict):
+                    bag.pop(_oid(action_id), None)
+        if forms:
+            await self.upsert_many(forms)
+
     async def update_form_actions(
         self,
         form_id: PydanticObjectId,

--- a/backend/backend/app/repositories/responder_groups_repository.py
+++ b/backend/backend/app/repositories/responder_groups_repository.py
@@ -10,41 +10,45 @@ from backend.app.schemas.responder_group import (
     ResponderGroupMemberDocument,
     ResponderGroupFormDocument,
 )
-from common.db import to_bson_dict
+from common.db import derived_object_id, to_bson_dict
 from common.db.routing import write_op
 
 
 class ResponderGroupsRepository:
-    @write_op
+    @staticmethod
+    def member(
+        group_id: PydanticObjectId, identifier: str
+    ) -> ResponderGroupMemberDocument:
+        """A member's identity is the (group, identifier) pair; its id follows."""
+        return ResponderGroupMemberDocument(
+            id=derived_object_id("responder_group_member", group_id, identifier),
+            group_id=group_id,
+            identifier=identifier,
+        )
+
+    @staticmethod
+    def link(group_id: PydanticObjectId, form_id: str) -> ResponderGroupFormDocument:
+        return ResponderGroupFormDocument(
+            id=derived_object_id("responder_group_form", group_id, form_id),
+            group_id=group_id,
+            form_id=form_id,
+        )
+
+    @write_op(replay=True)
     async def create_group(
         self,
         workspace_id: PydanticObjectId,
         name: str,
         description: Optional[str] = None,
-        form_id: Optional[str] = None,
-        emails: List[EmailStr] = None,
         regex: Optional[str] = None,
     ):
+        """The group document only; members and forms are added by their own
+        calls (ResponderGroupsService.create_group orchestrates)."""
         if description and len(description) > 280:
             return {"message": "description should be less than 280 characters"}
-        responder_group = ResponderGroupDocument(
+        return await ResponderGroupDocument(
             name=name, workspace_id=workspace_id, description=description, regex=regex
-        )
-        responder_group = await responder_group.save()
-        responder_group_emails = []
-        if emails:
-            for email in emails:
-                responder_group_emails.append(
-                    ResponderGroupMemberDocument(
-                        group_id=responder_group.id, identifier=email
-                    )
-                )
-            await ResponderGroupMemberDocument.insert_many(responder_group_emails)
-        if form_id:
-            await ResponderGroupFormDocument.insert(
-                ResponderGroupFormDocument(group_id=responder_group.id, form_id=form_id)
-            )
-        return responder_group
+        ).save()
 
     @write_op
     async def update_group(
@@ -59,23 +63,12 @@ class ResponderGroupsRepository:
         responder_group = await ResponderGroupDocument.find_one(
             {"workspace_id": workspace_id, "_id": group_id}
         )
-        existing_group_members = await ResponderGroupMemberDocument.find(
-            {"group_id": group_id}
-        ).to_list()
         if emails and len(emails) != 0:
-            for existing_group_member in existing_group_members:
-                for email in existing_group_member:
-                    await ResponderGroupMemberDocument.find(
-                        {"group_id": group_id, "identifier": {"$in": email}}
-                    ).delete()
-            responder_group_emails = []
-            for email in emails:
-                responder_group_emails.append(
-                    ResponderGroupMemberDocument(
-                        group_id=responder_group.id, identifier=email
-                    )
-                )
-            await ResponderGroupMemberDocument.insert_many(responder_group_emails)
+            # replace the membership wholesale
+            await ResponderGroupMemberDocument.find({"group_id": group_id}).delete()
+            await ResponderGroupMemberDocument.insert_many(
+                [self.member(group_id, email) for email in set(emails)]
+            )
 
         if responder_group:
             if name:
@@ -101,14 +94,12 @@ class ResponderGroupsRepository:
             {"group_id": group_id, "identifier": {"$in": emails}}
         ).to_list()
         existing_emails = [
-            ex_document.email for ex_document in existing_email_documents
+            ex_document.identifier for ex_document in existing_email_documents
         ]
         new_emails = []
         for email in emails:
             if email not in existing_emails:
-                new_emails.append(
-                    ResponderGroupMemberDocument(group_id=group_id, identifier=email)
-                )
+                new_emails.append(self.member(group_id, email))
         if new_emails:
             await ResponderGroupMemberDocument.insert_many(new_emails)
 
@@ -256,10 +247,7 @@ class ResponderGroupsRepository:
             {"form_id": form_id, "group_id": group_id}
         )
         if not existing_document:
-            responder_group_form_document = ResponderGroupFormDocument(
-                form_id=form_id, group_id=group_id
-            )
-            return await responder_group_form_document.save()
+            return await self.link(group_id, form_id).save()
 
     @write_op
     async def add_groups_to_form(self, form_id: str, group_ids: List[PydanticObjectId]):

--- a/backend/backend/app/repositories/workspace_responders_repository.py
+++ b/backend/backend/app/repositories/workspace_responders_repository.py
@@ -8,7 +8,7 @@ from common.db.routing import write_op
 
 
 class WorkspaceRespondersRepository:
-    @write_op
+    @write_op(replay=True)
     async def create_workspace_tag(self, workspace_id: PydanticObjectId, title: str):
         workspace_tag = await WorkspaceTags.find_one(
             {"workspace_id": workspace_id, "title": title}
@@ -20,7 +20,7 @@ class WorkspaceRespondersRepository:
     async def get_workspace_tags(self, workspace_id: PydanticObjectId):
         return await WorkspaceTags.find({"workspace_id": workspace_id}).to_list()
 
-    @write_op
+    @write_op(replay=True)
     async def get_responder_by_email_and_workspace_id(
         self, workspace_id: PydanticObjectId, email: str
     ):

--- a/backend/backend/app/services/actions_service.py
+++ b/backend/backend/app/services/actions_service.py
@@ -5,6 +5,7 @@ from common.services.http_client import HttpClient
 from starlette.requests import Request
 
 from backend.app.models.dtos.action_dto import ActionDto, ActionResponse
+from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.action_repository import ActionRepository
 from backend.app.repositories.workspace_repository import WorkspaceRepository
 from backend.app.schemas.standard_form import FormDocument
@@ -19,6 +20,7 @@ class ActionService:
     def __init__(
         self,
         action_repository: ActionRepository,
+        form_repo: FormRepository,
         temporal_service: TemporalService,
         http_client: HttpClient,
         form_provider_service: FormPluginProviderService,
@@ -27,6 +29,7 @@ class ActionService:
         workspace_repo=WorkspaceRepository,
     ):
         self.action_repository = action_repository
+        self.form_repo = form_repo
         self.temporal_service: TemporalService = temporal_service
         self.workspace_user_service = workspace_user_service
         self.http_client = http_client
@@ -43,9 +46,10 @@ class ActionService:
         await self.workspace_user_service.check_is_admin_in_workspace(
             workspace_id=workspace_id, user=user
         )
-        return await self.action_repository.create_action(
+        created = await self.action_repository.create_action(
             workspace_id=workspace_id, action=action, user=user
         )
+        return ActionResponse(**created.model_dump(mode="json"))
 
     async def get_all_actions(self):
         return await self.action_repository.get_all_actions()
@@ -89,7 +93,7 @@ class ActionService:
             )
 
     async def delete_action_from_workspace(self, action_id: PydanticObjectId):
-        await self.action_repository.remove_action_form_all_forms(action_id=action_id)
+        await self.form_repo.remove_action_from_all_forms(action_id=action_id)
         await self.action_repository.delete_action(action_id=action_id)
 
     async def create_action_in_workspace_from_action(

--- a/backend/backend/app/services/form_response_service.py
+++ b/backend/backend/app/services/form_response_service.py
@@ -266,14 +266,7 @@ class FormResponseService:
                 + response_id,
             )
 
-        await FormResponseDeletionRequest(
-            form_id=response.form_id,
-            response_id=response_id,
-            dataOwnerIdentifier=response.dataOwnerIdentifier,
-            anonymous_identity=response.anonymous_identity,
-            provider=response.provider,
-            deleted_at=None,
-        ).save()
+        await self._form_response_repo.add_deletion_request(response, response_id)
 
     async def get_responses_count_in_workspace(self, workspace_form_ids: List[str]):
         return await self._form_response_repo.count_responses_for_form_ids(
@@ -447,14 +440,7 @@ class FormResponseService:
                 + response_id,
             )
 
-        await FormResponseDeletionRequest(
-            form_id=response.form_id,
-            response_id=response_id,
-            dataOwnerIdentifier=response.dataOwnerIdentifier,
-            anonymous_identity=response.anonymous_identity,
-            provider=response.provider,
-            deleted_at=None,
-        ).save()
+        await self._form_response_repo.add_deletion_request(response, response_id)
         pass
 
     def generate_presigned_url_for_each_response(

--- a/backend/backend/app/services/responder_groups_service.py
+++ b/backend/backend/app/services/responder_groups_service.py
@@ -68,7 +68,7 @@ class ResponderGroupsService:
             workspace_id=workspace_id,
             regex=regex,
         )
-        return response.model_dump(mode='json')
+        return response.model_dump(mode="json")
 
     async def create_group(
         self,
@@ -83,14 +83,20 @@ class ResponderGroupsService:
         await self.workspace_user_service.check_is_admin_in_workspace(
             workspace_id=workspace_id, user=user
         )
-        return await self.responder_groups_repo.create_group(
-            workspace_id=workspace_id,
-            name=name,
-            emails=emails,
-            description=description,
-            form_id=form_id,
-            regex=regex,
+        group = await self.responder_groups_repo.create_group(
+            workspace_id=workspace_id, name=name, description=description, regex=regex
         )
+        if isinstance(group, dict):  # validation message from the repository
+            return group
+        if emails:
+            await self.responder_groups_repo.add_emails_to_group(
+                group_id=group.id, emails=emails
+            )
+        if form_id:
+            await self.responder_groups_repo.add_group_to_form(
+                form_id=form_id, group_id=group.id
+            )
+        return group
 
     async def add_emails_to_group(
         self,

--- a/backend/backend/db/groups.py
+++ b/backend/backend/db/groups.py
@@ -1,12 +1,18 @@
-"""Repository groups and the order they may be served from Postgres in.
+"""Repository groups and the order they may leave Mongo in.
 
-A group's Mongo repositories may ``$lookup`` into another group's collections
-(responses → forms, workspace_forms). Once that other group is served from
-Postgres the joins find nothing, so it may only cut over after — or together
-with — the groups that join into it. ``load_flags`` enforces this map at boot.
+A group's Mongo repositories may ``$lookup`` into another group's collections.
+Such a join finds nothing once the joined group stops writing Mongo, so while
+the joining group still reads from Mongo, the joined groups must keep writing
+it (``dual`` / ``postgres_primary_dual``). ``load_flags`` enforces the map at
+boot; the Postgres twins compose over routed repositories instead of joining,
+so a group served from Postgres frees the groups it used to join into.
 """
 
-READ_DEPENDENCIES = {
-    # FormResponseRepository / DeletionRequestsRepository $lookup forms + workspace_forms
-    "forms": ("responses",),
+MONGO_JOINS = {
+    # FormResponseRepository / DeletionRequestsRepository → forms, workspace_forms
+    "responses": ("forms",),
+    # FormTemplateRepository.get_templates_with_creator → workspaces
+    "forms": ("identity",),
+    # WorkspaceRepository.get_workspace_with_action_by_id → workspace_actions
+    "identity": ("actions",),
 }

--- a/backend/tests/app/repositories/test_forms_parity.py
+++ b/backend/tests/app/repositories/test_forms_parity.py
@@ -134,7 +134,8 @@ async def test_form_listings_search_and_versions(sessions):
         version(forms[0], 2),
     )
     # cross-group data, in Mongo only
-    group = await groups.create_group(ws, "Corp", form_id="f1", regex=".*@corp.com")
+    group = await groups.create_group(ws, "Corp", regex=".*@corp.com")
+    await groups.add_group_to_form("f1", group.id)
     await FormResponseDocument(form_id="f1", response_id="r1", answers={}).save()
     await FormResponseDocument(form_id="f1", response_id="r2", answers={}).save()
     await FormResponseDeletionRequest(form_id="f1", response_id="r1").save()
@@ -254,10 +255,11 @@ async def test_workspace_form_visibility(sessions):
         workspace_form(ws, "imported", "u1", 8, provider="google"),
         workspace_form(other, "elsewhere", "u1", 9),
     )
-    await groups.create_group(
-        ws, "Members", form_id="members", emails=["member@example.com"]
-    )
-    await groups.create_group(ws, "Corp", form_id="corp", regex=".*@corp.com")
+    members = await groups.create_group(ws, "Members")
+    await groups.add_emails_to_group(members.id, ["member@example.com"])
+    await groups.add_group_to_form("members", members.id)
+    corp_group = await groups.create_group(ws, "Corp", regex=".*@corp.com")
+    await groups.add_group_to_form("corp", corp_group.id)
 
     def listing(**kwargs):
         return lambda repo: repo.get_workspace_forms_in_workspace(ws, **kwargs)

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -9,7 +9,13 @@ Mongo except the Mongo-side outbox document.
 """
 
 from common.db.base import BaseRow, NAMING_CONVENTION, OBJECT_ID_PATTERN, make_base
-from common.db.beanie_bridge import ensure_id, from_row_doc, row_values, to_bson_dict
+from common.db.beanie_bridge import (
+    derived_object_id,
+    ensure_id,
+    from_row_doc,
+    row_values,
+    to_bson_dict,
+)
 from common.db.ddl import (
     HELPER_FUNCTIONS,
     drop_helper_function_ddl,

--- a/common/common/db/beanie_bridge.py
+++ b/common/common/db/beanie_bridge.py
@@ -20,6 +20,7 @@ models.
 
 from __future__ import annotations
 
+import hashlib
 from datetime import datetime, timezone
 from typing import Any, Mapping, Optional, Type, TypeVar
 
@@ -37,6 +38,14 @@ def ensure_id(document: Document) -> Document:
     if document.id is None:
         document.id = PydanticObjectId()
     return document
+
+
+def derived_object_id(*parts: Any) -> PydanticObjectId:
+    """An ObjectId that is a function of ``parts`` — for documents whose identity
+    *is* a relation (a group member, a group↔form link). Two stores executing
+    the same write then produce the same row, so the mirror needs no replay."""
+    digest = hashlib.sha1("\x00".join(str(p) for p in parts).encode()).digest()
+    return PydanticObjectId(digest[:12])
 
 
 def to_bson_dict(document: Document) -> dict[str, Any]:

--- a/common/common/db/flags.py
+++ b/common/common/db/flags.py
@@ -158,12 +158,14 @@ class DbFlags:
             return True
         return self.shadow_read_sample > 0
 
-    def validate(self, read_dependencies: Mapping[str, Iterable[str]] = {}) -> None:
-        """``read_dependencies``: group -> groups that must be served from Postgres
-        before it may be. A group's *Mongo* repositories may ``$lookup`` into
-        another group's collections; once that other group is served from
-        Postgres those joins find nothing, so it has to cut over first (or
-        together). The application declares the map; the flags enforce it."""
+    def validate(self, mongo_joins: Mapping[str, Iterable[str]] = {}) -> None:
+        """``mongo_joins``: group -> groups whose collections its *Mongo*
+        repositories ``$lookup`` into. Such a join finds nothing once the joined
+        group stops writing Mongo, so while a group still reads from Mongo the
+        groups it joins into must keep writing Mongo (``dual`` or
+        ``postgres_primary_dual`` are fine, ``postgres`` is not). Once the
+        joining group is served from Postgres its twins compose instead and the
+        constraint lifts. The application declares the map; the flags enforce it."""
         groups = {"*"} | set(self.read_overrides) | set(self.write_overrides)
         for group in groups:
             read = self.default_read if group == "*" else self.read_source(group)
@@ -178,29 +180,25 @@ class DbFlags:
             raise FlagError(
                 f"{SAMPLE_KEY} must be between 0 and 1, got {self.shadow_read_sample}"
             )
-        for group, prerequisites in read_dependencies.items():
-            if self.read_source(group) is not ReadSource.POSTGRES:
-                continue
-            lagging = [
-                p
-                for p in prerequisites
-                if self.read_source(p) is not ReadSource.POSTGRES
-            ]
-            if lagging:
+        for group, joined in mongo_joins.items():
+            if self.read_source(group) is ReadSource.POSTGRES:
+                continue  # served by its twins, which compose over the routed repos
+            stopped = [g for g in joined if self.write_mode(g) is WriteMode.POSTGRES]
+            if stopped:
                 raise FlagError(
-                    f"group {group!r} cannot be served from postgres while "
-                    f"{', '.join(repr(p) for p in lagging)} still read from mongo: their "
-                    f"Mongo repositories join into {group!r}'s collections. Cut those "
-                    f"groups over first (or together)."
+                    f"group(s) {', '.join(repr(g) for g in stopped)} cannot stop writing "
+                    f"mongo (DB_WRITE_MODE=postgres) while group {group!r} still reads from "
+                    f"mongo: its Mongo repositories join into their collections. Serve "
+                    f"{group!r} from postgres first, or keep them on postgres_primary_dual."
                 )
 
 
 def load_flags(
     env: Mapping[str, str] = os.environ,
-    read_dependencies: Mapping[str, Iterable[str]] = {},
+    mongo_joins: Mapping[str, Iterable[str]] = {},
 ) -> DbFlags:
     """Parse and validate the flags from ``env``; raises :class:`FlagError` on a bad
-    value. ``read_dependencies`` is the cutover-order map (see ``DbFlags.validate``)."""
+    value. ``mongo_joins`` is the cutover-order map (see ``DbFlags.validate``)."""
     raw_sample = env.get(SAMPLE_KEY, "")
     try:
         sample = float(raw_sample) if raw_sample != "" else 0.0
@@ -221,5 +219,5 @@ def load_flags(
         ),
         jobs_overrides=_overrides(env, JOBS_KEY, JobsBackend),
     )
-    flags.validate(read_dependencies)
+    flags.validate(mongo_joins)
     return flags

--- a/common/tests/test_flags.py
+++ b/common/tests/test_flags.py
@@ -126,16 +126,24 @@ def test_serves_from_postgres_distinguishes_mirror_only_from_serving():
     )
 
 
-def test_read_dependencies_enforce_cutover_order():
-    deps = {"forms": ["responses"]}
-    # responses still on mongo: forms may mirror but not serve
-    load_flags({"DB_WRITE_MODE__forms": "dual"}, deps)
-    with pytest.raises(FlagError, match="'responses' still read from mongo"):
+def test_mongo_joins_enforce_cutover_order():
+    joins = {"responses": ["forms"]}  # Mongo responses repos $lookup forms
+    # forms may mirror or be served from postgres as long as it keeps writing mongo
+    load_flags({"DB_WRITE_MODE__forms": "dual"}, joins)
+    load_flags(
+        {
+            "DB_READ_SOURCE__forms": "postgres",
+            "DB_WRITE_MODE__forms": "postgres_primary_dual",
+        },
+        joins,
+    )
+    # ...but cannot stop writing mongo while responses still reads there
+    with pytest.raises(FlagError, match="'forms' cannot stop writing mongo"):
         load_flags(
             {"DB_READ_SOURCE__forms": "postgres", "DB_WRITE_MODE__forms": "postgres"},
-            deps,
+            joins,
         )
-    # together, or responses first, is fine
+    # once responses is served from postgres the constraint lifts
     load_flags(
         {
             "DB_READ_SOURCE__forms": "postgres",
@@ -143,6 +151,6 @@ def test_read_dependencies_enforce_cutover_order():
             "DB_READ_SOURCE__responses": "postgres",
             "DB_WRITE_MODE__responses": "postgres",
         },
-        deps,
+        joins,
     )
-    load_flags({"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres"}, deps)
+    load_flags({"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres"}, joins)


### PR DESCRIPTION
Plan step 7, part a (`plans/postgres-consolidation.md`). Mongo-side reshape so the responses / actions / ai / analytics groups can get Postgres twins in 7b. Suite passes unmodified in all three CI modes (287 each).

## The cutover rule, made precise

6b's rule ("forms may not be served from Postgres before responses") was the wrong shape. A Mongo `$lookup` into another group's collection breaks when that group **stops writing Mongo** (`DB_WRITE_MODE=postgres`), not when it is read from Postgres. `load_flags(mongo_joins=…)` now enforces exactly that: *while a group still reads from Mongo, the groups its Mongo repositories join into must keep writing Mongo* (`dual` / `postgres_primary_dual` are fine). `backend/db/groups.py` declares all three edges found in the code:

- responses → forms (`FormResponseRepository`, `DeletionRequestsRepository`)
- forms → identity (`FormTemplateRepository.get_templates_with_creator` joins `workspaces`)
- identity → actions (`get_workspace_with_action_by_id` joins `workspace_actions`)

CI's Postgres-served mode therefore keeps identity on `postgres_primary_dual` (forms still reads Mongo there). The forms→identity edge was silently violated by the previous mode 3 — only a template's origin title was affected, which nothing asserted on.

## Repository reshapes

- **`extra_find_query` (raw Mongo filter) → `data_owner_identifier`** on `get_form_responses` and `get_deletion_requests`; the only shape callers passed.
- **Two direct `FormResponseDeletionRequest(...).save()` in `FormResponseService`** — missed by the step-4 scan (multi-line constructor) — go through a new `add_deletion_request`. An AST scan over `backend/app` now finds no direct document access outside repositories.
- **`ResponderGroupsRepository.create_group`** wrote group + members + link in one call, which the mirror cannot replay. It now creates the group only; `ResponderGroupsService.create_group` orchestrates members and the form link through their own routed calls. **Members and group↔form links get ids derived from their relation** (`common.db.derived_object_id`, sha1 of the key pair), so re-executing the call on the mirror yields identical rows — no replay needed for relation documents.
- **`ActionRepository.create_action` returns the document** (the service shapes `ActionResponse`). **`remove_action_form_all_forms` wrote forms from the actions repository** — moved to `FormRepository.remove_action_from_all_forms` (Postgres twin included) and called from `ActionService`.
- `@write_op(replay=True)` on the remaining id-minting writes across the four groups.

## Latent bugs fixed (behaviour change, deliberate)

- `add_emails_to_group` read `.email` off member documents → `AttributeError` whenever an existing address was re-added. Now `.identifier`.
- `update_group`'s member replacement iterated a *document's fields* (`for email in existing_group_member`) — it never removed anyone. Now replaces the membership wholesale when emails are given, as intended.

## Verification

Backend suite ×3: 287 passed, 6 skipped each. Common: 53 passed (rule covered in `test_flags.py`).
