### PR TITLE
feat(backend): Postgres twins for responses, actions, ai and analytics — every group twinned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
               run: uv run pytest
 
-            - name: Run backend tests (refdata, identity, forms mirrored to Postgres)
+            - name: Run backend tests (every group mirrored to Postgres)
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
@@ -115,12 +115,10 @@ jobs:
                   API_ENABLE_FORM_CREATION: "True"
                   UNSPLASH_ACCESS_KEY: ""
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
-                  DB_WRITE_MODE__refdata: dual
-                  DB_WRITE_MODE__identity: dual
-                  DB_WRITE_MODE__forms: dual
+                  DB_WRITE_MODE: dual
               run: uv run pytest
 
-            - name: Run backend tests (refdata + identity served from Postgres)
+            - name: Run backend tests (every group served from Postgres)
               env:
                   VIRTUAL_ENV: ""
                   MONGO_URI: mongodb://localhost:27017
@@ -131,10 +129,8 @@ jobs:
                   API_ENABLE_FORM_CREATION: "True"
                   UNSPLASH_ACCESS_KEY: ""
                   MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
-                  DB_READ_SOURCE__refdata: postgres
-                  DB_WRITE_MODE__refdata: postgres
-                  DB_READ_SOURCE__identity: postgres
-                  DB_WRITE_MODE__identity: postgres_primary_dual
+                  DB_READ_SOURCE: postgres
+                  DB_WRITE_MODE: postgres
               run: uv run pytest
 
     auth-tests:

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -19,7 +19,26 @@ from common.db.routing import RoutingRepository
 
 from backend.db.outbox import OutboxRecorder
 from backend.db.groups import MONGO_JOINS
-from backend.db.session import build_engine, build_sessionmaker, postgres_repository
+from backend.db.session import (
+    LazyRepository,
+    build_engine,
+    build_sessionmaker,
+    postgres_repository,
+)
+from backend.app.repositories.postgres.actions import PostgresActionRepository
+from backend.app.repositories.postgres.ai import (
+    PostgresAIPreferenceMemoryRepository,
+    PostgresFlowEventRepository,
+    PostgresFormAIInsightRepository,
+    PostgresFormAISessionRepository,
+    PostgresMcpAuditLogRepository,
+    PostgresWorkspaceAIProfileRepository,
+)
+from backend.app.repositories.postgres.responses import (
+    PostgresFormResponseRepository,
+    PostgresResponderGroupsRepository,
+    PostgresWorkspaceRespondersRepository,
+)
 from backend.app.repositories.postgres.forms import (
     PostgresFormRepository,
     PostgresFormTemplateRepository,
@@ -163,6 +182,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(ActionRepository, crypto=crypto),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresActionRepository, pg_sessionmaker, crypto
+        ),
     )
 
     # Repositories
@@ -197,7 +219,10 @@ class AppContainer(containers.DeclarativeContainer):
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceRepository),
         postgres=providers.Singleton(
-            postgres_repository, PostgresWorkspaceRepository, pg_sessionmaker, action_repository
+            postgres_repository,
+            PostgresWorkspaceRepository,
+            pg_sessionmaker,
+            action_repository,
         ),
     )
     allowed_origins_repo: AllowedOriginsRepository = providers.Singleton(
@@ -219,20 +244,14 @@ class AppContainer(containers.DeclarativeContainer):
             on_mirror_failure=outbox_recorder,
             mirror_timeout_s=mirror_timeout_s,
             mongo=providers.Singleton(BlacklistedRefreshTokenRepository),
-        postgres=providers.Singleton(
-            postgres_repository, PostgresBlacklistedRefreshTokenRepository, pg_sessionmaker
-        ),
+            postgres=providers.Singleton(
+                postgres_repository,
+                PostgresBlacklistedRefreshTokenRepository,
+                pg_sessionmaker,
+            ),
         )
     )
 
-    form_response_repo: FormResponseRepository = providers.Singleton(
-        RoutingRepository,
-        group="responses",
-        flags=flags,
-        on_mirror_failure=outbox_recorder,
-        mirror_timeout_s=mirror_timeout_s,
-        mongo=providers.Singleton(FormResponseRepository, crypto=crypto),
-    )
     flow_event_repo: FlowEventRepository = providers.Singleton(
         RoutingRepository,
         group="analytics",
@@ -240,6 +259,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FlowEventRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresFlowEventRepository, pg_sessionmaker
+        ),
     )
     form_ai_insight_repo = providers.Singleton(
         RoutingRepository,
@@ -248,6 +270,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormAIInsightRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresFormAIInsightRepository, pg_sessionmaker
+        ),
     )
     form_ai_session_repo = providers.Singleton(
         RoutingRepository,
@@ -256,6 +281,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormAISessionRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresFormAISessionRepository, pg_sessionmaker
+        ),
     )
     workspace_ai_profile_repo = providers.Singleton(
         RoutingRepository,
@@ -264,6 +292,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceAIProfileRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceAIProfileRepository, pg_sessionmaker
+        ),
     )
     workspace_api_key_repo = providers.Singleton(
         RoutingRepository,
@@ -283,6 +314,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(AIPreferenceMemoryRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresAIPreferenceMemoryRepository, pg_sessionmaker
+        ),
     )
 
     form_provider_repo: FormPluginProviderRepository = providers.Singleton(
@@ -297,6 +331,23 @@ class AppContainer(containers.DeclarativeContainer):
         mongo=providers.Singleton(FormPluginProviderRepository),
     )
 
+    # the forms twins compose over this one and it over theirs: resolved lazily
+    form_response_repo: FormResponseRepository = providers.Singleton(
+        RoutingRepository,
+        group="responses",
+        flags=flags,
+        on_mirror_failure=outbox_recorder,
+        mirror_timeout_s=mirror_timeout_s,
+        mongo=providers.Singleton(FormResponseRepository, crypto=crypto),
+        postgres=providers.Singleton(
+            postgres_repository,
+            PostgresFormResponseRepository,
+            pg_sessionmaker,
+            LazyRepository(lambda: container.form_repo()),
+            LazyRepository(lambda: container.workspace_form_repo()),
+        ),
+    )
+
     responder_groups_repository = providers.Singleton(
         RoutingRepository,
         group="responses",
@@ -304,6 +355,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(ResponderGroupsRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresResponderGroupsRepository, pg_sessionmaker
+        ),
     )
     # after responder_groups_repository / form_response_repo: the forms twins compose over them
     form_repo: FormRepository = providers.Singleton(
@@ -314,7 +368,11 @@ class AppContainer(containers.DeclarativeContainer):
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormRepository),
         postgres=providers.Singleton(
-            postgres_repository, PostgresFormRepository, pg_sessionmaker, responder_groups_repository, form_response_repo
+            postgres_repository,
+            PostgresFormRepository,
+            pg_sessionmaker,
+            responder_groups_repository,
+            form_response_repo,
         ),
     )
     workspace_form_repo: WorkspaceFormRepository = providers.Singleton(
@@ -325,7 +383,10 @@ class AppContainer(containers.DeclarativeContainer):
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceFormRepository),
         postgres=providers.Singleton(
-            postgres_repository, PostgresWorkspaceFormRepository, pg_sessionmaker, responder_groups_repository
+            postgres_repository,
+            PostgresWorkspaceFormRepository,
+            pg_sessionmaker,
+            responder_groups_repository,
         ),
     )
 
@@ -339,6 +400,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(McpAuditLogRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresMcpAuditLogRepository, pg_sessionmaker
+        ),
     )
 
     temporal_service = providers.Singleton(
@@ -464,6 +528,7 @@ class AppContainer(containers.DeclarativeContainer):
         aws_service=aws_service,
         action_service=action_service,
         crypto=crypto,
+        form_template_repo=LazyRepository(lambda: container.form_template_repo()),
     )
 
     workspace_service: WorkspaceService = providers.Singleton(
@@ -584,6 +649,9 @@ class AppContainer(containers.DeclarativeContainer):
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(WorkspaceRespondersRepository),
+        postgres=providers.Singleton(
+            postgres_repository, PostgresWorkspaceRespondersRepository, pg_sessionmaker
+        ),
     )
     workspace_responders_service = providers.Singleton(
         WorkspaceRespondersService,
@@ -617,7 +685,10 @@ class AppContainer(containers.DeclarativeContainer):
         mirror_timeout_s=mirror_timeout_s,
         mongo=providers.Singleton(FormTemplateRepository),
         postgres=providers.Singleton(
-            postgres_repository, PostgresFormTemplateRepository, pg_sessionmaker, workspace_repo
+            postgres_repository,
+            PostgresFormTemplateRepository,
+            pg_sessionmaker,
+            workspace_repo,
         ),
     )
 

--- a/backend/backend/app/repositories/deletion_requests_repository.py
+++ b/backend/backend/app/repositories/deletion_requests_repository.py
@@ -61,7 +61,7 @@ class DeletionRequestsRepository:
                     }
                 }
             },
-            {"$unset": "response_doc"},
+            {"$unset": ["response_doc", "form", "workspace_form"]},
         ]
 
         aggregate_query.extend(

--- a/backend/backend/app/repositories/form_response_repository.py
+++ b/backend/backend/app/repositories/form_response_repository.py
@@ -70,7 +70,7 @@ class FormResponseRepository(BaseRepository):
                 },
             },
             {"$set": {"status": {"$arrayElemAt": ["$deletion_request.status", 0]}}},
-            {"$unset": "deletion_request"},
+            {"$unset": ["deletion_request", "form"]},
             {"$sort": {"created_at": -1}},
         ]
 
@@ -136,6 +136,7 @@ class FormResponseRepository(BaseRepository):
                     "metadata": "$responder.metadata",
                 }
             },
+            {"$unset": "responder"},
             {
                 "$lookup": {
                     "from": "workspace_tags",

--- a/backend/backend/app/repositories/mcp_audit_log_repository.py
+++ b/backend/backend/app/repositories/mcp_audit_log_repository.py
@@ -1,3 +1,7 @@
+from typing import List
+
+from beanie import PydanticObjectId
+
 from backend.app.schemas.mcp_audit_log import MCPAuditLogDocument
 from common.db.routing import write_op
 
@@ -6,3 +10,8 @@ class McpAuditLogRepository:
     @write_op(replay=True)
     async def add(self, **fields) -> MCPAuditLogDocument:
         return await MCPAuditLogDocument(**fields).save()
+
+    async def list_by_workspace(
+        self, workspace_id: PydanticObjectId
+    ) -> List[MCPAuditLogDocument]:
+        return await MCPAuditLogDocument.find({"workspace_id": workspace_id}).to_list()

--- a/backend/backend/app/repositories/postgres/actions.py
+++ b/backend/backend/app/repositories/postgres/actions.py
@@ -1,0 +1,86 @@
+"""Postgres twin of the actions-group repository."""
+
+from typing import List
+
+from beanie import PydanticObjectId
+
+from backend.app.models.dtos.action_dto import ActionDto
+from backend.app.repositories.postgres.forms import _oid
+from backend.app.schemas.action_document import ActionDocument, WorkspaceActionsDocument
+from backend.db.models import ActionRow, WorkspaceActionRow
+from common.configs.crypto import Crypto
+from common.db import PostgresRepositoryBase
+from common.models.user import User
+
+
+class PostgresActionRepository(PostgresRepositoryBase):
+    row = ActionRow
+    document = ActionDocument
+
+    def __init__(self, session_factory, crypto: Crypto):
+        super().__init__(session_factory)
+        self.crypto = crypto
+
+    async def create_action(
+        self, workspace_id: PydanticObjectId, action: ActionDto, user: User
+    ) -> ActionDocument:
+        if action.secrets is not None:
+            for secret in action.secrets:
+                secret.value = self.crypto.encrypt(secret.value)
+        return await self.upsert(
+            ActionDocument(
+                **action.model_dump(mode="json"),
+                created_by=PydanticObjectId(user.id),
+                workspace_id=workspace_id,
+            )
+        )
+
+    async def delete_action(self, action_id: PydanticObjectId):
+        await self.delete_by_id(action_id)
+        return action_id
+
+    async def get_all_actions(self):
+        return await self.many()
+
+    async def get_action_by_id(self, action_id: PydanticObjectId):
+        return await self.one(ActionRow.id == _oid(action_id))
+
+    async def get_workspace_action(
+        self, workspace_id: PydanticObjectId, action_id: PydanticObjectId
+    ) -> WorkspaceActionsDocument | None:
+        return await self.one_of(
+            WorkspaceActionRow,
+            WorkspaceActionsDocument,
+            WorkspaceActionRow.workspace_id == _oid(workspace_id),
+            WorkspaceActionRow.action_id == _oid(action_id),
+        )
+
+    async def get_actions_by_ids(self, action_ids: List[PydanticObjectId]):
+        return await self.many(ActionRow.id.in_([_oid(i) for i in action_ids]))
+
+    async def create_action_in_workspace_from_action(
+        self,
+        workspace_id: PydanticObjectId,
+        action_id: PydanticObjectId,
+        credentials: str = None,
+    ):
+        workspace_action = await self.get_workspace_action(workspace_id, action_id)
+        secrets = None
+        if credentials:
+            secrets = [{"name": "Credentials", "value": credentials}]
+        if workspace_action is None:
+            workspace_action = WorkspaceActionsDocument(
+                workspace_id=workspace_id, action_id=action_id
+            )
+        workspace_action.secrets = secrets
+        return await self.upsert(workspace_action, row=WorkspaceActionRow)
+
+    async def create_global_action(self, action: ActionDto, user: User):
+        if action.secrets is not None:
+            for secret in action.secrets:
+                secret.value = self.crypto.encrypt(secret.value)
+        return await self.upsert(
+            ActionDocument(
+                **action.model_dump(mode="json"), created_by=PydanticObjectId(user.id)
+            )
+        )

--- a/backend/backend/app/repositories/postgres/ai.py
+++ b/backend/backend/app/repositories/postgres/ai.py
@@ -1,0 +1,115 @@
+"""Postgres twins of the ai- and analytics-group repositories."""
+
+from typing import List, Optional
+
+from beanie import PydanticObjectId
+
+from backend.app.repositories.postgres.forms import _oid
+from backend.app.schemas.ai_preference_memory import UserAIPreferenceMemoryDocument
+from backend.app.schemas.flow_event import FlowEventDocument
+from backend.app.schemas.form_ai_insight import FormAIInsightDocument
+from backend.app.schemas.form_ai_session import FormAISessionDocument
+from backend.app.schemas.mcp_audit_log import MCPAuditLogDocument
+from backend.app.schemas.workspace_ai_profile import WorkspaceAIProfileDocument
+from backend.db.models import (
+    AiPreferenceMemoryRow,
+    FormAiInsightRow,
+    FormAiSessionRow,
+    FormFlowEventRow,
+    McpAuditLogRow,
+    WorkspaceAiProfileRow,
+)
+from common.db import PostgresRepositoryBase
+
+
+class PostgresFlowEventRepository(PostgresRepositoryBase):
+    row = FormFlowEventRow
+    document = FlowEventDocument
+
+    async def add(
+        self, form_id: str, session_id: str, from_page: str, to_page: str
+    ) -> FlowEventDocument:
+        return await self.upsert(
+            FlowEventDocument(
+                form_id=form_id,
+                session_id=session_id,
+                from_page=from_page,
+                to_page=to_page,
+            )
+        )
+
+    async def list_by_form_id(self, form_id: str) -> List[FlowEventDocument]:
+        return await self.many(FormFlowEventRow.form_id == form_id)
+
+
+class PostgresFormAIInsightRepository(PostgresRepositoryBase):
+    row = FormAiInsightRow
+    document = FormAIInsightDocument
+
+    async def find(
+        self, workspace_id: PydanticObjectId, form_id: str
+    ) -> Optional[FormAIInsightDocument]:
+        return await self.one(
+            FormAiInsightRow.workspace_id == _oid(workspace_id),
+            FormAiInsightRow.form_id == form_id,
+        )
+
+    async def save(self, document: FormAIInsightDocument) -> FormAIInsightDocument:
+        return await self.upsert(document)
+
+
+class PostgresFormAISessionRepository(PostgresRepositoryBase):
+    row = FormAiSessionRow
+    document = FormAISessionDocument
+
+    async def get_or_404(self, session_id: PydanticObjectId) -> FormAISessionDocument:
+        return await self.get_or_raise(session_id)
+
+    async def save(self, session: FormAISessionDocument) -> FormAISessionDocument:
+        return await self.upsert(session)
+
+
+class PostgresWorkspaceAIProfileRepository(PostgresRepositoryBase):
+    row = WorkspaceAiProfileRow
+    document = WorkspaceAIProfileDocument
+
+    async def find_by_workspace(
+        self, workspace_id: PydanticObjectId
+    ) -> Optional[WorkspaceAIProfileDocument]:
+        return await self.one(WorkspaceAiProfileRow.workspace_id == _oid(workspace_id))
+
+    async def save(
+        self, document: WorkspaceAIProfileDocument
+    ) -> WorkspaceAIProfileDocument:
+        return await self.upsert(document)
+
+
+class PostgresAIPreferenceMemoryRepository(PostgresRepositoryBase):
+    row = AiPreferenceMemoryRow
+    document = UserAIPreferenceMemoryDocument
+
+    async def find(
+        self, workspace_id: PydanticObjectId, user_id: str
+    ) -> Optional[UserAIPreferenceMemoryDocument]:
+        return await self.one(
+            AiPreferenceMemoryRow.workspace_id == _oid(workspace_id),
+            AiPreferenceMemoryRow.user_id == user_id,
+        )
+
+    async def save(
+        self, document: UserAIPreferenceMemoryDocument
+    ) -> UserAIPreferenceMemoryDocument:
+        return await self.upsert(document)
+
+
+class PostgresMcpAuditLogRepository(PostgresRepositoryBase):
+    row = McpAuditLogRow
+    document = MCPAuditLogDocument
+
+    async def add(self, **fields) -> MCPAuditLogDocument:
+        return await self.upsert(MCPAuditLogDocument(**fields))
+
+    async def list_by_workspace(
+        self, workspace_id: PydanticObjectId
+    ) -> List[MCPAuditLogDocument]:
+        return await self.many(McpAuditLogRow.workspace_id == _oid(workspace_id))

--- a/backend/backend/app/repositories/postgres/responses.py
+++ b/backend/backend/app/repositories/postgres/responses.py
@@ -1,0 +1,862 @@
+"""Postgres twins of the responses-group repositories.
+
+Within the group (form_responses ⋈ responses_deletion_requests ⋈
+workspace_responder ⋈ workspace_tags, responder_group ⋈ members ⋈ forms) the
+Mongo ``$lookup``s are SQL joins. Into the forms group (a form's title, the
+workspace that imported it) they *compose* through the routed forms
+repositories — see plans/postgres-consolidation.md §4 — restricted to the
+form ids those repositories know, because the Mongo ``$unwind`` drops
+responses whose form is gone.
+"""
+
+import json
+import re
+from http import HTTPStatus
+from typing import Any, Dict, Iterable, List, Optional, Set
+from uuid import uuid4
+
+from beanie import PydanticObjectId
+from fastapi_pagination import Page
+from fastapi_pagination.ext.sqlalchemy import apaginate
+from pydantic import EmailStr
+from sqlalchemy import and_, func, literal, or_, select
+
+from backend.app.exceptions import HTTPException
+from backend.app.models.dtos.response_group_dto import ResponderGroupDto
+from backend.app.models.filter_queries.form_responses import FormResponseFilterQuery
+from backend.app.models.filter_queries.sort import SortOrder, SortRequest
+from backend.app.repositories.postgres.forms import _fold, _oid, _sort_terms, _text
+from backend.app.schemas.responder_group import (
+    ResponderGroupDocument,
+    ResponderGroupFormDocument,
+    ResponderGroupMemberDocument,
+)
+from backend.app.schemas.standard_form_response import (
+    DeletionRequestStatus,
+    FormResponseDeletionRequest,
+    FormResponseDocument,
+)
+from backend.app.schemas.workspace_responder import (
+    WorkspaceResponderDocument,
+    WorkspaceTags,
+)
+from backend.db.models import (
+    ResponseDeletionRequestRow,
+    FormResponseRow,
+    ResponderGroupFormRow,
+    ResponderGroupMemberRow,
+    ResponderGroupRow,
+    WorkspaceResponderRow,
+    WorkspaceTagRow,
+)
+from common.constants import MESSAGE_FORBIDDEN
+from common.db import (
+    PostgresRepositoryBase,
+    derived_object_id,
+    from_canonical_document,
+    from_row_doc,
+    to_bson_dict,
+)
+from common.models.standard_form import StandardFormResponse, StandardFormResponseAnswer
+from common.models.user import User
+from common.services.crypto_service import crypto_service
+from camel_converter import to_camel, to_snake
+
+
+def _filter_terms(doc, filter_query) -> list:
+    """``create_filter_pipeline(filter_object=...)``: each set field is a
+    case-insensitive regex on its camelCase or snake_case key."""
+    if not filter_query:
+        return []
+    matching = filter_query.model_dump(exclude_unset=True, exclude_none=True)
+    return [
+        or_(
+            _text(doc[to_camel(key)]).op("~*")(value),
+            _text(doc[to_snake(key)]).op("~*")(value),
+        )
+        for key, value in matching.items()
+    ]
+
+
+class PostgresFormResponseRepository(PostgresRepositoryBase):
+    row = FormResponseRow
+    document = FormResponseDocument
+
+    def __init__(self, session_factory, form_repo, workspace_form_repo):
+        super().__init__(session_factory)
+        self._forms = form_repo  # routed FormRepository
+        self._workspace_forms = workspace_form_repo  # routed WorkspaceFormRepository
+
+    # -- composition over the forms group ---------------------------------
+    async def _form_titles(self, form_ids: List[str]) -> Dict[str, Any]:
+        """form_id -> title for the forms that exist (``$lookup forms`` + ``$unwind``)."""
+        forms = await self._forms.get_forms_by_form_ids(list(form_ids))
+        return {form.form_id: form.title for form in forms}
+
+    async def _form_importers(self, form_ids: List[str]) -> Dict[str, str]:
+        """form_id -> importing user (``$lookup workspace_forms`` + ``$unwind``)."""
+        rows = await self._workspace_forms.get_workspace_forms_form_ids(list(form_ids))
+        importers: Dict[str, str] = {}
+        for workspace_form in rows:
+            importers.setdefault(workspace_form.form_id, workspace_form.user_id)
+        return importers
+
+    # -- listings -----------------------------------------------------------
+    async def get_form_responses(
+        self,
+        form_ids,
+        data_owner_identifier: Optional[str] = None,
+        filter_query: FormResponseFilterQuery = None,
+        sort: SortRequest = None,
+    ) -> Page:
+        titles = await self._form_titles(form_ids)
+        dr = ResponseDeletionRequestRow
+        where = [
+            FormResponseRow.form_id.in_(list(titles)),
+            FormResponseRow.doc.has_key("answers"),
+            *_filter_terms(FormResponseRow.doc, filter_query),
+        ]
+        if data_owner_identifier is not None:
+            where.append(FormResponseRow.data_owner_identifier == data_owner_identifier)
+        # $arrayElemAt [deletion_request.status, 0]: the first request, in natural order
+        first_request = (
+            select(dr.doc)
+            .where(dr.response_id == FormResponseRow.response_id)
+            .order_by(dr.created_at, dr.id)
+            .limit(1)
+            .correlate(FormResponseRow)
+            .scalar_subquery()
+        )
+        stmt = (
+            select(FormResponseRow.doc, first_request)
+            .where(*where)
+            .order_by(
+                *_sort_terms(
+                    FormResponseRow.doc,
+                    sort,
+                    (FormResponseRow.created_at.desc(), FormResponseRow.id),
+                )
+            )
+        )
+
+        async def transform(items):
+            responses = []
+            for doc, request_doc in items:
+                response = from_canonical_document(doc)
+                response["form_title"] = titles[response["form_id"]]
+                if request_doc is not None:  # $arrayElemAt: unset without a request
+                    response["status"] = from_canonical_document(request_doc).get(
+                        "status"
+                    )
+                responses.append(response)
+            return responses
+
+        async with self._session() as session:
+            return await apaginate(session, stmt, transformer=transform, unique=False)
+
+    async def get_workspace_responders(
+        self,
+        form_ids: List[str],
+        filter_query: FormResponseFilterQuery = None,
+        sort: SortRequest = None,
+    ):
+        r, dr, wr = FormResponseRow, ResponseDeletionRequestRow, WorkspaceResponderRow
+        grouped = (
+            select(
+                r.data_owner_identifier.label("email"),
+                func.count().label("responses"),
+                func.array_agg(r.response_id).label("response_ids"),
+            )
+            .where(r.form_id.in_(list(form_ids)), r.data_owner_identifier.is_not(None))
+            .group_by(r.data_owner_identifier)
+            .subquery("grouped")
+        )
+        deletion_requests = (
+            select(func.count())
+            .where(dr.response_id == func.any(grouped.c.response_ids))
+            .correlate(grouped)
+            .scalar_subquery()
+        )
+        stmt = (
+            select(
+                grouped.c.email,
+                grouped.c.responses,
+                deletion_requests.label("deletion_requests"),
+                wr.doc,
+            )
+            .outerjoin(wr, wr.email == grouped.c.email)  # any workspace, as the $lookup
+            .order_by(grouped.c.email, wr.created_at, wr.id)
+        )
+        # create_filter_pipeline(..., default_sort=False): filters only, no sort
+        matching = (
+            filter_query.model_dump(exclude_unset=True, exclude_none=True)
+            if filter_query
+            else {}
+        )
+        for key, value in matching.items():
+            keys = {to_camel(key), to_snake(key)}
+            if "email" in keys:
+                stmt = stmt.where(grouped.c.email.op("~*")(value))
+            else:  # the projected document has no such field
+                stmt = stmt.where(literal(False))
+
+        async def transform(items):
+            responders = []
+            tag_ids: Set[str] = set()
+            for email, responses, deletions, responder_doc in items:
+                responder = {
+                    "email": email,
+                    "responses": responses,
+                    "deletion_requests": deletions,
+                }
+                if responder_doc is not None:
+                    raw = from_canonical_document(responder_doc)
+                    _fold(responder, raw, {"tags": "tags", "metadata": "metadata"})
+                responders.append(responder)
+                for tag in responder.get("tags") or []:
+                    tag_ids.add(_oid(tag))
+            tags = {}
+            if tag_ids:
+                async with self._session() as session:
+                    docs = (
+                        (
+                            await session.execute(
+                                select(WorkspaceTagRow.doc).where(
+                                    WorkspaceTagRow.id.in_(tag_ids)
+                                )
+                            )
+                        )
+                        .scalars()
+                        .all()
+                    )
+                for doc in docs:
+                    tag = from_canonical_document(doc)
+                    tags[_oid(tag["_id"])] = tag
+            for responder in responders:  # $lookup workspace_tags: docs, [] when none
+                responder["tags"] = [
+                    tags[_oid(t)]
+                    for t in (responder.get("tags") or [])
+                    if _oid(t) in tags
+                ]
+            return responders
+
+        async with self._session() as session:
+            return await apaginate(session, stmt, transformer=transform, unique=False)
+
+    async def get_deletion_requests(
+        self,
+        form_ids,
+        data_owner_identifier: Optional[str] = None,
+        filter_query: FormResponseFilterQuery = None,
+        sort: SortRequest = None,
+    ):
+        """DeletionRequestsRepository.get_deletion_requests, composed."""
+        titles = await self._form_titles(form_ids)
+        importers = await self._form_importers(list(titles))
+        known = [f for f in titles if f in importers]  # both $unwinds must match
+        dr, r = ResponseDeletionRequestRow, FormResponseRow
+        where = [dr.form_id.in_(known), *_filter_terms(dr.doc, filter_query)]
+        if data_owner_identifier is not None:
+            where.append(dr.data_owner_identifier == data_owner_identifier)
+        response_doc = (
+            select(r.doc)
+            .where(r.response_id == dr.response_id)
+            .order_by(r.created_at, r.id)
+            .limit(1)
+            .correlate(dr)
+            .scalar_subquery()
+        )
+        stmt = (
+            select(dr.doc, response_doc)
+            .where(*where)
+            .order_by(*_sort_terms(dr.doc, sort, (dr.created_at, dr.id)))
+        )
+
+        async def transform(items):
+            requests = []
+            for doc, response in items:
+                request = from_canonical_document(doc)
+                request["form_title"] = titles[request["form_id"]]
+                request["form_imported_by"] = importers[request["form_id"]]
+                if response is not None:  # $arrayElemAt: unset without a response
+                    request["submission_uuid"] = from_canonical_document(response).get(
+                        "submission_uuid"
+                    )
+                requests.append(request)
+            return requests
+
+        async with self._session() as session:
+            return await apaginate(session, stmt, transformer=transform, unique=False)
+
+    async def list(
+        self,
+        form_ids: List[str],
+        request_for_deletion: bool,
+        filter_query: FormResponseFilterQuery = None,
+        sort: SortRequest = None,
+        data_subjects: bool = None,
+    ) -> Page:
+        if data_subjects:
+            return await self.get_workspace_responders(
+                form_ids=form_ids, filter_query=filter_query, sort=sort
+            )
+        elif request_for_deletion:
+            return await self.get_deletion_requests(
+                form_ids, filter_query=filter_query, sort=sort
+            )
+        else:
+            return await self.get_form_responses(
+                form_ids, filter_query=filter_query, sort=sort
+            )
+
+    async def get_user_submissions(
+        self, form_ids, user: User, request_for_deletion: bool = False
+    ):
+        if request_for_deletion:
+            return await self.get_deletion_requests(
+                form_ids=form_ids, data_owner_identifier=user.sub
+            )
+        else:
+            return await self.get_form_responses(
+                form_ids, data_owner_identifier=user.sub
+            )
+
+    # -- counts -------------------------------------------------------------
+    async def _counts_by_form(self, row, *where) -> Dict[str, int]:
+        async with self._session() as session:
+            rows = (
+                await session.execute(
+                    select(row.form_id, func.count())
+                    .where(*where)
+                    .group_by(row.form_id)
+                )
+            ).all()
+        return {form_id: n for form_id, n in rows}
+
+    async def count_responses_with_answers_by_form_ids(
+        self, form_ids: List[str]
+    ) -> Dict[str, int]:
+        return await self._counts_by_form(
+            FormResponseRow,
+            FormResponseRow.form_id.in_(form_ids),
+            FormResponseRow.doc.has_key("answers"),
+        )
+
+    async def count_deletion_requests_by_form_ids(
+        self, form_ids: List[str]
+    ) -> Dict[str, int]:
+        return await self._counts_by_form(
+            ResponseDeletionRequestRow,
+            ResponseDeletionRequestRow.form_id.in_(form_ids),
+        )
+
+    async def count_responses_for_form_ids(self, form_ids: List[str]) -> int:
+        return await self.count(FormResponseRow.form_id.in_(form_ids))
+
+    async def get_deletion_requests_count_in_workspace(self, form_ids: List[str]):
+        dr = ResponseDeletionRequestRow
+        in_forms = dr.form_id.in_(form_ids)
+
+        async def count_where(*where):
+            async with self._session() as session:
+                return (
+                    await session.execute(
+                        select(func.count()).select_from(dr).where(*where)
+                    )
+                ).scalar_one()
+
+        counts = {
+            "success": await count_where(
+                in_forms, dr.status == DeletionRequestStatus.SUCCESS.value
+            ),
+            "pending": await count_where(
+                in_forms, dr.status == DeletionRequestStatus.PENDING.value
+            ),
+            "total": await count_where(in_forms),
+        }
+        # $count emits no document for zero matches; $arrayElemAt then unsets the field
+        return {k: v for k, v in counts.items() if v}
+
+    # -- BaseRepository stubs ---------------------------------------------
+    async def get(self, form_id: str, response_id: str):
+        pass
+
+    async def add(self, item: FormResponseDocument):
+        pass
+
+    async def update(self, item_id: str, item: FormResponseDocument):
+        pass
+
+    async def delete(self, item_id: str, provider):
+        pass
+
+    # -- plain reads and writes ------------------------------------------------
+    async def list_recent_by_form_id(
+        self, form_id: str, limit: int
+    ) -> List[FormResponseDocument]:
+        return await self.many(
+            FormResponseRow.form_id == form_id,
+            order_by=(FormResponseRow.created_at.desc(), FormResponseRow.id),
+            limit=limit,
+        )
+
+    async def list_deletion_requests_for_form_ids(
+        self, form_ids: List[str]
+    ) -> List[FormResponseDeletionRequest]:
+        return await self.many(
+            ResponseDeletionRequestRow.form_id.in_(form_ids),
+            row=ResponseDeletionRequestRow,
+            document=FormResponseDeletionRequest,
+        )
+
+    async def list_by_form_id(self, form_id: str) -> List[FormResponseDocument]:
+        return await self.many(FormResponseRow.form_id == form_id)
+
+    async def save(self, response: FormResponseDocument) -> FormResponseDocument:
+        return await self.upsert(response)
+
+    async def find_deletion_request_by_response_id(
+        self, response_id: str
+    ) -> Optional[FormResponseDeletionRequest]:
+        return await self.one_of(
+            ResponseDeletionRequestRow,
+            FormResponseDeletionRequest,
+            ResponseDeletionRequestRow.response_id == response_id,
+        )
+
+    async def add_deletion_request(
+        self, response: FormResponseDocument, response_id: str
+    ) -> FormResponseDeletionRequest:
+        return await self.upsert(
+            FormResponseDeletionRequest(
+                form_id=response.form_id,
+                response_id=response_id,
+                dataOwnerIdentifier=response.dataOwnerIdentifier,
+                anonymous_identity=response.anonymous_identity,
+                provider=response.provider,
+                deleted_at=None,
+            ),
+            row=ResponseDeletionRequestRow,
+        )
+
+    async def delete_by_form_id_except(
+        self, form_id: str, keep_response_ids: List[str]
+    ):
+        return await self.delete_where(
+            FormResponseRow.form_id == form_id,
+            FormResponseRow.response_id.not_in(list(keep_response_ids)),
+        )
+
+    async def mark_deletion_requests_success_except(
+        self, form_id: str, provider: str, keep_response_ids: List[str], now
+    ) -> int:
+        dr = ResponseDeletionRequestRow
+        requests = await self.many(
+            dr.form_id == form_id,
+            dr.provider == provider,
+            dr.response_id.not_in(list(keep_response_ids)),
+            row=dr,
+            document=FormResponseDeletionRequest,
+        )
+        modified = 0
+        for request in requests:
+            if (
+                request.status != DeletionRequestStatus.SUCCESS
+                or request.updated_at != now
+            ):
+                modified += 1
+            request.status = DeletionRequestStatus.SUCCESS
+            request.updated_at = now
+        await self.upsert_many(requests, row=dr)
+        return modified
+
+    async def delete_by_form_id(self, form_id):
+        return await self.delete_where(FormResponseRow.form_id == form_id)
+
+    async def delete_deletion_requests(self, form_id: str):
+        return await self.delete_where(
+            ResponseDeletionRequestRow.form_id == form_id,
+            row=ResponseDeletionRequestRow,
+        )
+
+    async def delete_by_form_ids(self, form_ids):
+        return await self.delete_where(FormResponseRow.form_id.in_(list(form_ids)))
+
+    async def delete_deletion_requests_by_form_ids(self, form_ids):
+        return await self.delete_where(
+            ResponseDeletionRequestRow.form_id.in_(list(form_ids)),
+            row=ResponseDeletionRequestRow,
+        )
+
+    async def save_form_response(
+        self,
+        form_id: PydanticObjectId,
+        response: StandardFormResponse,
+        workspace_id: PydanticObjectId,
+    ):
+        response_document = FormResponseDocument(**response.model_dump(mode="json"))
+        response_document.submission_uuid = str(uuid4())
+        if workspace_id:
+            for k, v in response_document.answers.items():
+                if type(v) == StandardFormResponseAnswer:
+                    response_document.answers[k] = v.model_dump(mode="json")
+            response_document.answers = crypto_service.encrypt(
+                workspace_id=workspace_id,
+                form_id=form_id,
+                data=json.dumps(response_document.answers),
+            )
+            if isinstance(response_document.hidden_fields, dict):
+                response_document.hidden_fields = crypto_service.encrypt(
+                    workspace_id=workspace_id,
+                    form_id=form_id,
+                    data=json.dumps(response_document.hidden_fields),
+                )
+        response_document.form_id = str(form_id)
+        response_document.provider = "self"
+        return await self.upsert(response_document)
+
+    async def patch_form_response(
+        self,
+        form_id: PydanticObjectId,
+        response_id: PydanticObjectId,
+        response: StandardFormResponse,
+        workspace_id: PydanticObjectId,
+        user=User,
+    ):
+        response_document = await self.one(
+            FormResponseRow.response_id == _oid(response_id)
+        )
+        if not response_document.dataOwnerIdentifier != user.sub:
+            raise HTTPException(
+                status_code=HTTPStatus.FORBIDDEN, content=MESSAGE_FORBIDDEN
+            )
+        for k, v in response.answers.items():
+            if type(v) == StandardFormResponseAnswer:
+                response_document.answers[k] = v.model_dump(mode="json")
+            response_document.answers = crypto_service.encrypt(
+                workspace_id=workspace_id,
+                form_id=form_id,
+                data=json.dumps(response_document.answers),
+            )
+        return await self.upsert(response_document)
+
+    async def delete_form_response(self, form_id: PydanticObjectId, response_id: str):
+        await self.delete_where(
+            FormResponseRow.form_id == _oid(form_id),
+            FormResponseRow.response_id == response_id,
+        )
+        deletion_request = await self.one_of(
+            ResponseDeletionRequestRow,
+            FormResponseDeletionRequest,
+            ResponseDeletionRequestRow.form_id == _oid(form_id),
+            ResponseDeletionRequestRow.response_id == response_id,
+        )
+        if deletion_request:
+            deletion_request.status = DeletionRequestStatus.SUCCESS
+            await self.upsert(deletion_request, row=ResponseDeletionRequestRow)
+        return response_id
+
+    async def get_all_expiring_responses(self):
+        return await self.many(FormResponseRow.expiration_type.in_(["date", "days"]))
+
+    async def delete_response(self, response_id: str):
+        await self.delete_one_where(FormResponseRow.response_id == response_id)
+        return response_id
+
+    async def get_response(self, response_id: str):
+        return await self.one(FormResponseRow.response_id == response_id)
+
+    async def get_by_submission_uuid(self, submission_uuid: str):
+        return await self.one(FormResponseRow.submission_uuid == submission_uuid)
+
+    async def verify_response_exists_in_workspace(
+        self, workspace_id: PydanticObjectId, response_id: str
+    ):
+        response = await self.one(FormResponseRow.response_id == response_id)
+        workspace_form = (
+            None
+            if response is None
+            else await self._workspace_forms.find_workspace_form(
+                workspace_id, response.form_id
+            )
+        )
+        if workspace_form is None:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                content="Response not found in workspace",
+            )
+
+
+class PostgresWorkspaceRespondersRepository(PostgresRepositoryBase):
+    row = WorkspaceResponderRow
+    document = WorkspaceResponderDocument
+
+    async def create_workspace_tag(self, workspace_id: PydanticObjectId, title: str):
+        workspace_tag = await self.one_of(
+            WorkspaceTagRow,
+            WorkspaceTags,
+            WorkspaceTagRow.workspace_id == _oid(workspace_id),
+            WorkspaceTagRow.title == title,
+        )
+        if not workspace_tag:
+            workspace_tag = WorkspaceTags(workspace_id=workspace_id, title=title)
+        return await self.upsert(workspace_tag, row=WorkspaceTagRow)
+
+    async def get_workspace_tags(self, workspace_id: PydanticObjectId):
+        return await self.many(
+            WorkspaceTagRow.workspace_id == _oid(workspace_id),
+            row=WorkspaceTagRow,
+            document=WorkspaceTags,
+        )
+
+    async def get_responder_by_email_and_workspace_id(
+        self, workspace_id: PydanticObjectId, email: str
+    ):
+        workspace_responder = await self.one(
+            WorkspaceResponderRow.workspace_id == _oid(workspace_id),
+            WorkspaceResponderRow.email == email,
+        )
+        if not workspace_responder:
+            workspace_responder = WorkspaceResponderDocument(
+                workspace_id=workspace_id, email=email
+            )
+        return await self.upsert(workspace_responder)
+
+
+class PostgresResponderGroupsRepository(PostgresRepositoryBase):
+    row = ResponderGroupRow
+    document = ResponderGroupDocument
+
+    @staticmethod
+    def member(
+        group_id: PydanticObjectId, identifier: str
+    ) -> ResponderGroupMemberDocument:
+        return ResponderGroupMemberDocument(
+            id=derived_object_id("responder_group_member", group_id, identifier),
+            group_id=group_id,
+            identifier=identifier,
+        )
+
+    @staticmethod
+    def link(group_id: PydanticObjectId, form_id: str) -> ResponderGroupFormDocument:
+        return ResponderGroupFormDocument(
+            id=derived_object_id("responder_group_form", group_id, form_id),
+            group_id=group_id,
+            form_id=form_id,
+        )
+
+    async def _members(self, *where) -> List[ResponderGroupMemberDocument]:
+        return await self.many(
+            *where, row=ResponderGroupMemberRow, document=ResponderGroupMemberDocument
+        )
+
+    async def _links(self, *where) -> List[ResponderGroupFormDocument]:
+        return await self.many(
+            *where, row=ResponderGroupFormRow, document=ResponderGroupFormDocument
+        )
+
+    async def create_group(
+        self,
+        workspace_id: PydanticObjectId,
+        name: str,
+        description: Optional[str] = None,
+        regex: Optional[str] = None,
+    ):
+        if description and len(description) > 280:
+            return {"message": "description should be less than 280 characters"}
+        return await self.upsert(
+            ResponderGroupDocument(
+                name=name,
+                workspace_id=workspace_id,
+                description=description,
+                regex=regex,
+            )
+        )
+
+    async def update_group(
+        self,
+        workspace_id: PydanticObjectId,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        emails: List[EmailStr] = None,
+        group_id: PydanticObjectId = None,
+        regex: Optional[str] = None,
+    ):
+        responder_group = await self.get_group_in_workspace(workspace_id, group_id)
+        if emails and len(emails) != 0:
+            await self.delete_where(
+                ResponderGroupMemberRow.group_id == _oid(group_id),
+                row=ResponderGroupMemberRow,
+            )
+            await self.upsert_many(
+                [self.member(group_id, email) for email in set(emails)],
+                row=ResponderGroupMemberRow,
+            )
+        if responder_group:
+            if name:
+                responder_group.name = name
+            if description:
+                responder_group.description = description
+            responder_group.regex = regex
+        return await self.upsert(responder_group)
+
+    async def get_group_in_workspace(
+        self, workspace_id: PydanticObjectId, group_id: PydanticObjectId
+    ):
+        return await self.one(
+            ResponderGroupRow.workspace_id == _oid(workspace_id),
+            ResponderGroupRow.id == _oid(group_id),
+        )
+
+    async def add_emails_to_group(
+        self, group_id: PydanticObjectId, emails: List[EmailStr]
+    ):
+        emails = list(set(emails))
+        existing = {
+            member.identifier
+            for member in await self._members(
+                ResponderGroupMemberRow.group_id == _oid(group_id),
+                ResponderGroupMemberRow.identifier.in_(emails),
+            )
+        }
+        new_members = [self.member(group_id, e) for e in emails if e not in existing]
+        if new_members:
+            await self.upsert_many(new_members, row=ResponderGroupMemberRow)
+
+    async def remove_emails_from_group(
+        self, group_id: PydanticObjectId, emails: List[EmailStr]
+    ):
+        await self.delete_where(
+            ResponderGroupMemberRow.group_id == _oid(group_id),
+            ResponderGroupMemberRow.identifier.in_(list(emails)),
+            row=ResponderGroupMemberRow,
+        )
+
+    async def _projected(self, groups: List[ResponderGroupDocument]) -> List[dict]:
+        """The $project of get_emails_in_group / get_groups_in_workspace."""
+        ids = [_oid(g.id) for g in groups]
+        members = await self._members(ResponderGroupMemberRow.group_id.in_(ids))
+        links = await self._links(ResponderGroupFormRow.group_id.in_(ids))
+        out = []
+        for group in groups:
+            out.append(
+                {
+                    "_id": group.id,
+                    "name": group.name,
+                    "workspace_id": group.workspace_id,
+                    "emails": [m.identifier for m in members if m.group_id == group.id],
+                    "description": group.description,
+                    "regex": group.regex,
+                    "forms": [l.form_id for l in links if l.group_id == group.id],
+                }
+            )
+        return out
+
+    async def get_emails_in_group(self, group_id: PydanticObjectId):
+        group = await self.one(ResponderGroupRow.id == _oid(group_id))
+        if group is None:
+            return None
+        return (await self._projected([group]))[0]
+
+    async def remove_responder_group(self, group_id: PydanticObjectId):
+        await self.delete_by_id(group_id)
+        await self.delete_where(
+            ResponderGroupMemberRow.group_id == _oid(group_id),
+            row=ResponderGroupMemberRow,
+        )
+        await self.delete_where(
+            ResponderGroupFormRow.group_id == _oid(group_id), row=ResponderGroupFormRow
+        )
+
+    async def get_groups_in_workspace(self, workspace_id: PydanticObjectId):
+        groups = await self.many(ResponderGroupRow.workspace_id == _oid(workspace_id))
+        return [ResponderGroupDto(**row) for row in await self._projected(groups)]
+
+    async def get_groups_by_form_ids(
+        self, form_ids: List[str]
+    ) -> Dict[str, List[dict]]:
+        links = await self._links(ResponderGroupFormRow.form_id.in_(list(form_ids)))
+        groups = {
+            group.id: to_bson_dict(group)
+            for group in await self.many(
+                ResponderGroupRow.id.in_([_oid(l.group_id) for l in links] or ["-"])
+            )
+        }
+        by_form: Dict[str, List[dict]] = {form_id: [] for form_id in form_ids}
+        for link in links:
+            if link.group_id in groups:
+                by_form.setdefault(link.form_id, []).append(groups[link.group_id])
+        return by_form
+
+    async def get_form_ids_accessible_to(
+        self, form_ids: List[str], identifier: str
+    ) -> Set[str]:
+        links = await self._links(ResponderGroupFormRow.form_id.in_(list(form_ids)))
+        group_ids = [_oid(g) for g in {link.group_id for link in links}]
+        if not group_ids:
+            return set()
+        member_of = {
+            member.group_id
+            for member in await self._members(
+                ResponderGroupMemberRow.group_id.in_(group_ids),
+                ResponderGroupMemberRow.identifier == identifier,
+            )
+        }
+        for group in await self.many(ResponderGroupRow.id.in_(group_ids)):
+            if not group.regex:
+                continue
+            try:
+                if re.search(group.regex, identifier):
+                    member_of.add(group.id)
+            except re.error:
+                continue
+        return {link.form_id for link in links if link.group_id in member_of}
+
+    async def add_group_to_form(self, form_id: str, group_id: PydanticObjectId):
+        existing = await self._links(
+            ResponderGroupFormRow.form_id == form_id,
+            ResponderGroupFormRow.group_id == _oid(group_id),
+        )
+        if not existing:
+            return await self.upsert(
+                self.link(group_id, form_id), row=ResponderGroupFormRow
+            )
+
+    async def add_groups_to_form(self, form_id: str, group_ids: List[PydanticObjectId]):
+        ids_to_add = group_ids
+        existing_groups = await self._links(ResponderGroupFormRow.form_id == form_id)
+        ids_to_remove = [group.group_id for group in existing_groups]
+        for group_id in list(ids_to_remove):
+            if group_id in ids_to_add:
+                ids_to_remove.remove(group_id)
+                ids_to_add.remove(group_id)
+        for group_id in ids_to_remove:
+            await self.remove_group_from_form(form_id, group_id)
+        for group_id in ids_to_add:
+            await self.add_group_to_form(form_id, group_id)
+        return await self._links(ResponderGroupFormRow.form_id == form_id)
+
+    async def remove_group_from_form(self, form_id: str, group_id: PydanticObjectId):
+        await self.delete_one_where(
+            ResponderGroupFormRow.form_id == form_id,
+            ResponderGroupFormRow.group_id == _oid(group_id),
+            row=ResponderGroupFormRow,
+        )
+
+    async def delete_workspace_form_groups(self, form_id: str):
+        await self.delete_where(
+            ResponderGroupFormRow.form_id == form_id, row=ResponderGroupFormRow
+        )
+
+    async def delete_responder_groups(self, workspace_ids: List[PydanticObjectId]):
+        groups = await self.many(
+            ResponderGroupRow.workspace_id.in_([_oid(w) for w in workspace_ids])
+        )
+        group_ids = [_oid(group.id) for group in groups] or ["-"]
+        await self.delete_where(
+            ResponderGroupFormRow.group_id.in_(group_ids), row=ResponderGroupFormRow
+        )
+        await self.delete_where(
+            ResponderGroupMemberRow.group_id.in_(group_ids), row=ResponderGroupMemberRow
+        )
+        await self.delete_where(ResponderGroupRow.id.in_(group_ids))

--- a/backend/backend/app/services/form_service.py
+++ b/backend/backend/app/services/form_service.py
@@ -273,8 +273,23 @@ class FormService:
         return minified_form
 
     async def save_form(self, form: StandardForm):
-        form_document = FormDocument(**form.model_dump(mode='json'))
-        form_version_document = FormVersionsDocument(**form.model_dump(mode='json'), version=1)
+        """Persist an imported form as version 1. Re-importing a form replaces
+        its document and its version 1 rather than adding duplicates: form_id
+        is unique in the forms store (and Mongo readers use find_one on it)."""
+        form_document = FormDocument(**form.model_dump(mode="json"))
+        existing = await self._form_repo.get_form_document_by_id(form_document.form_id)
+        if existing:
+            form_document.id = existing.id
+            form_document.created_at = existing.created_at
+        form_version_document = FormVersionsDocument(
+            **form.model_dump(mode="json"), version=1
+        )
+        existing_version = await self._form_repo.get_form_by_by_version(
+            form_document.form_id, 1
+        )
+        if existing_version:
+            form_version_document.id = existing_version.id
+            form_version_document.created_at = existing_version.created_at
         await self._form_repo.save_form_version(form_version_document)
         return await self._form_repo.save_form(form_document)
 

--- a/backend/backend/app/services/workspace_form_service.py
+++ b/backend/backend/app/services/workspace_form_service.py
@@ -29,6 +29,7 @@ from backend.app.models.dtos.response_dtos import (
     StandardFormResponseCamelModel,
 )
 from backend.app.models.workspace import WorkspaceFormSettings, WorkspaceRequestDto
+from backend.app.repositories.template import FormTemplateRepository
 from backend.app.repositories.form_repository import FormRepository
 from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
 from backend.app.schedulers.form_schedular import FormSchedular
@@ -73,6 +74,7 @@ class WorkspaceFormService:
         aws_service: AWSS3Service,
         action_service: ActionService,
         crypto: Crypto,
+        form_template_repo: FormTemplateRepository,
     ):
         self.form_provider_service = form_provider_service
         self.plugin_proxy_service = plugin_proxy_service
@@ -80,6 +82,7 @@ class WorkspaceFormService:
         self.form_service = form_service
         self.workspace_form_repository = workspace_form_repository
         self._form_repo = form_repo
+        self.form_template_repo = form_template_repo
         self.form_schedular = form_schedular
         self.form_import_service = form_import_service
         self.schedular = schedular
@@ -677,7 +680,12 @@ class WorkspaceFormService:
             duplicated_form.created_by = user.id
         else:
             duplicated_form.form_id = str(PydanticObjectId())
-        duplicated_form = await self._form_repo.save_form(duplicated_form)
+        # a template is a different collection: save it through its own repository
+        duplicated_form = (
+            await self.form_template_repo.save(duplicated_form)
+            if is_template
+            else await self._form_repo.save_form(duplicated_form)
+        )
 
         if not is_template:
             workspace_form = WorkspaceFormDocument(

--- a/backend/backend/db/session.py
+++ b/backend/backend/db/session.py
@@ -36,3 +36,23 @@ def postgres_repository(
 ) -> Optional[Any]:
     """The Postgres twin of a repository, or ``None`` when Postgres is not configured."""
     return None if session_factory is None else cls(session_factory, *args, **kwargs)
+
+
+class LazyRepository:
+    """Resolve a routed repository at first use, not at construction.
+
+    The forms and responses twins compose over each other's routed repository;
+    resolving either eagerly while the container builds the other recurses.
+    Attribute access is forwarded to the resolved repository.
+    """
+
+    def __init__(self, resolve):
+        self._resolve = resolve
+        self._target = None
+
+    def __getattr__(self, name):
+        if name.startswith("_"):  # copying/pickling probes must not resolve
+            raise AttributeError(name)
+        if self._target is None:
+            self._target = self._resolve()
+        return getattr(self._target, name)

--- a/backend/tests/app/controllers/test_ai_memory.py
+++ b/backend/tests/app/controllers/test_ai_memory.py
@@ -6,6 +6,7 @@ from typing import Any, Coroutine
 import pytest
 from httpx import AsyncClient
 
+from tests.app.controllers.data import testUser
 from backend.app.container import container
 from backend.app.schemas.ai_preference_memory import UserAIPreferenceMemoryDocument
 from backend.app.schemas.workspace import WorkspaceDocument
@@ -38,7 +39,9 @@ class TestAIMemoryEndpoints:
         workspace: Coroutine[Any, Any, WorkspaceDocument],
         test_user_cookies: dict[str, str],
     ):
-        response = await client.get(f"/api/v1/workspaces/{workspace.id}/ai-memory", cookies=test_user_cookies)
+        response = await client.get(
+            f"/api/v1/workspaces/{workspace.id}/ai-memory", cookies=test_user_cookies
+        )
         assert response.status_code == 200
         assert response.json() == []
 
@@ -49,13 +52,17 @@ class TestAIMemoryEndpoints:
         test_user_cookies: dict[str, str],
     ):
         url = f"/api/v1/workspaces/{workspace.id}/ai-memory"
-        added = await client.post(url, cookies=test_user_cookies, json={"text": "Prefers short pages"})
+        added = await client.post(
+            url, cookies=test_user_cookies, json={"text": "Prefers short pages"}
+        )
         assert added.status_code == 200
         assert [e["text"] for e in added.json()] == ["Prefers short pages"]
         assert added.json()[0]["source"] == "manual"
 
         # Case-insensitive dedupe: no second copy.
-        again = await client.post(url, cookies=test_user_cookies, json={"text": "prefers SHORT pages"})
+        again = await client.post(
+            url, cookies=test_user_cookies, json={"text": "prefers SHORT pages"}
+        )
         assert len(again.json()) == 1
 
         entry_id = added.json()[0]["id"]
@@ -70,7 +77,8 @@ class TestAIMemoryEndpoints:
         test_user_cookies: dict[str, str],
     ):
         response = await client.delete(
-            f"/api/v1/workspaces/{workspace.id}/ai-memory/nope", cookies=test_user_cookies
+            f"/api/v1/workspaces/{workspace.id}/ai-memory/nope",
+            cookies=test_user_cookies,
         )
         assert response.status_code == 404
 
@@ -98,8 +106,12 @@ class TestExtractionThroughChat:
         fake_provider: FakeProvider,
     ):
         fake_provider.replies = [
-            json.dumps({"reply": "Done — no placeholders.", "ops": []}),  # the chat turn
-            json.dumps({"memories": ["Does not want placeholder text in inputs"]}),  # extraction
+            json.dumps(
+                {"reply": "Done — no placeholders.", "ops": []}
+            ),  # the chat turn
+            json.dumps(
+                {"memories": ["Does not want placeholder text in inputs"]}
+            ),  # extraction
         ]
         response = await client.post(
             f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/chat",
@@ -113,18 +125,22 @@ class TestExtractionThroughChat:
         # The extraction call must use THE extraction prompt, verbatim — a
         # substring check would let a rewired/garbled prompt pass silently.
         extraction_call = fake_provider.calls[1]
-        assert extraction_call["system"] == EXTRACTION_SYSTEM_PROMPT.format(existing="(empty)")
+        assert extraction_call["system"] == EXTRACTION_SYSTEM_PROMPT.format(
+            existing="(empty)"
+        )
         # …and it must be fed the actual turn (what the creator said and what
         # the assistant did), or extraction degrades into guessing.
         turn_payload = extraction_call["messages"][0]["content"]
         assert "never add placeholder text to my inputs" in turn_payload
         assert "Done — no placeholders." in turn_payload
 
-        document = await UserAIPreferenceMemoryDocument.find_one(
-            UserAIPreferenceMemoryDocument.workspace_id == workspace.id
+        document = await container.ai_preference_memory_repo().find(
+            workspace.id, testUser.id
         )
         assert document is not None
-        assert [e["text"] for e in document.entries] == ["Does not want placeholder text in inputs"]
+        assert [e["text"] for e in document.entries] == [
+            "Does not want placeholder text in inputs"
+        ]
         assert document.entries[0]["source"] == "extracted"
 
     async def test_extraction_failure_never_breaks_the_turn(
@@ -159,7 +175,10 @@ class TestExtractionThroughChat:
             cookies=test_user_cookies,
             json={"text": "Prefers British English"},
         )
-        fake_provider.replies = [json.dumps({"reply": "Noted.", "ops": []}), json.dumps({"memories": []})]
+        fake_provider.replies = [
+            json.dumps({"reply": "Noted.", "ops": []}),
+            json.dumps({"memories": []}),
+        ]
         await client.post(
             f"/api/v1/workspaces/{workspace.id}/forms/{workspace_form.form_id}/ai/chat",
             cookies=test_user_cookies,

--- a/backend/tests/app/controllers/test_api_keys.py
+++ b/backend/tests/app/controllers/test_api_keys.py
@@ -27,7 +27,9 @@ class TestAPIKeys:
         assert body["prefix"] == body["token"][:11]
         assert body["scopes"] == ["forms:read", "forms:write"]
 
-        listed = await client.get(f"/api/v1/workspaces/{workspace.id}/api-keys", cookies=test_user_cookies)
+        listed = await client.get(
+            f"/api/v1/workspaces/{workspace.id}/api-keys", cookies=test_user_cookies
+        )
         assert listed.status_code == 200
         assert len(listed.json()) == 1
         # The token itself never appears again.
@@ -78,7 +80,8 @@ class TestAPIKeys:
 
         # Revocation kills authentication.
         revoked = await client.delete(
-            f"/api/v1/workspaces/{workspace.id}/api-keys/{key_id}", cookies=test_user_cookies
+            f"/api/v1/workspaces/{workspace.id}/api-keys/{key_id}",
+            cookies=test_user_cookies,
         )
         assert revoked.status_code == 200
         assert revoked.json()[0]["revoked"] is True

--- a/backend/tests/app/controllers/test_form_ai_chat.py
+++ b/backend/tests/app/controllers/test_form_ai_chat.py
@@ -12,6 +12,7 @@ from common.models.standard_form import (
     StandardFormFieldType,
 )
 
+from beanie import PydanticObjectId
 from backend.app.container import container
 from backend.app.schemas.form_ai_session import FormAISessionDocument
 from backend.app.schemas.standard_form import FormDocument
@@ -121,7 +122,9 @@ class TestFormAIChat:
         assert "Work email" in _all_titles(saved)
 
         # Session recorded with the auditable ops + results
-        session = await FormAISessionDocument.get(body["sessionId"])
+        session = await container.form_ai_session_repo().get_or_404(
+            PydanticObjectId(body["sessionId"])
+        )
         assert session is not None
         assert session.messages[0]["role"] == "user"
         assert session.messages[1]["ops"][0]["op"] == "add_field"

--- a/backend/tests/app/controllers/test_form_ai_insights.py
+++ b/backend/tests/app/controllers/test_form_ai_insights.py
@@ -191,8 +191,8 @@ class TestFormAIInsights:
         assert cached.json()["summary"] == body["summary"]
         assert len(fake_insights_provider.calls) == 1
 
-        document = await FormAIInsightDocument.find_one(
-            FormAIInsightDocument.form_id == workspace_form.form_id
+        document = await container.form_ai_insight_repo().find(
+            workspace.id, workspace_form.form_id
         )
         assert document is not None and document.response_count == 3
 
@@ -243,8 +243,8 @@ class TestFormAIInsights:
         )
         assert response.status_code == 502
         assert (
-            await FormAIInsightDocument.find_one(
-                FormAIInsightDocument.form_id == workspace_form.form_id
+            await container.form_ai_insight_repo().find(
+                workspace.id, workspace_form.form_id
             )
             is None
         )

--- a/backend/tests/app/controllers/test_mcp_server.py
+++ b/backend/tests/app/controllers/test_mcp_server.py
@@ -165,9 +165,7 @@ class TestMCPServer:
         assert "Work email" in titles
 
         # Every tool call is audited against the key.
-        logs = await MCPAuditLogDocument.find(
-            MCPAuditLogDocument.workspace_id == workspace.id
-        ).to_list()
+        logs = await container.mcp_audit_log_repo().list_by_workspace(workspace.id)
         assert any(log.tool == "update_form" and log.ok for log in logs)
 
     async def test_create_form_blank_then_build_with_ops(

--- a/backend/tests/app/controllers/test_workspace.py
+++ b/backend/tests/app/controllers/test_workspace.py
@@ -29,7 +29,11 @@ class TestWorkspaces:
         )
         assert response.status_code == 200
         body = response.json()
-        assert body["about"] == "" and body["guidelines"] == "" and body["compliance"] == ""
+        assert (
+            body["about"] == ""
+            and body["guidelines"] == ""
+            and body["compliance"] == ""
+        )
 
     async def test_ai_profile_update_and_roundtrip(
         self,
@@ -66,8 +70,8 @@ class TestWorkspaces:
 
         from backend.app.schemas.workspace_ai_profile import WorkspaceAIProfileDocument
 
-        document = await WorkspaceAIProfileDocument.find_one(
-            WorkspaceAIProfileDocument.workspace_id == workspace.id
+        document = await container.workspace_ai_profile_repo().find_by_workspace(
+            workspace.id
         )
         assert len(document.revisions) == 1
         assert document.revisions[0]["guidelines"] == payload["guidelines"]
@@ -104,7 +108,9 @@ class TestWorkspaces:
             json=[theme],
         )
         assert response.status_code == 200
-        assert response.json().get("customThemes") == [{**theme, "background": None, "style": None}]
+        assert response.json().get("customThemes") == [
+            {**theme, "background": None, "style": None}
+        ]
 
         # And it round-trips on the persisted document.
         saved = await container.workspace_repo().get_or_404(workspace.id)
@@ -191,7 +197,9 @@ class TestWorkspaces:
     ):
         get_workspace_url = f"{common_url}?workspace_name={testUser.id}"
         with mock_get_workspace_by_query:
-            fetched_workspace = await client.get(get_workspace_url, cookies=test_user_cookies)
+            fetched_workspace = await client.get(
+                get_workspace_url, cookies=test_user_cookies
+            )
 
             expected_workspace_id = str(workspace.id)
             actual_workspace_id = fetched_workspace.json().get("id")
@@ -261,7 +269,9 @@ class TestWorkspaces:
         self, client: AsyncClient, test_pro_user_cookies: dict[str, str]
     ):
         get_mine_workspace_url = f"{common_url}/mine"
-        await client.post(common_url, cookies=test_pro_user_cookies, data=workspace_attribute)
+        await client.post(
+            common_url, cookies=test_pro_user_cookies, data=workspace_attribute
+        )
         await client.post(
             common_url, cookies=test_pro_user_cookies, data=workspace_attribute_1
         )
@@ -411,7 +421,9 @@ class TestWorkspaces:
     ):
         suggest_handles_url = f"{common_url}/suggest-handle/test"
 
-        suggest_handle = await client.get(suggest_handles_url, cookies=test_user_cookies)
+        suggest_handle = await client.get(
+            suggest_handles_url, cookies=test_user_cookies
+        )
 
         expected_response = ["test", "test1", "test2", "test3", "test4", "test5"]
         actual_response = suggest_handle.json()
@@ -485,7 +497,9 @@ class TestWorkspaces:
     ):
         workspace_stats_url = f"{common_url}/{workspace.id}/stats"
 
-        workspace_stats = await client.get(workspace_stats_url, cookies=test_user_cookies)
+        workspace_stats = await client.get(
+            workspace_stats_url, cookies=test_user_cookies
+        )
 
         expected_response = {
             "deletionRequests": {"pending": 0, "success": 0, "total": 0},
@@ -505,7 +519,9 @@ class TestWorkspaces:
     ):
         workspace_stats_url = f"{common_url}/{workspace.id}/stats"
 
-        workspace_stats = await client.get(workspace_stats_url, cookies=test_user_cookies_1)
+        workspace_stats = await client.get(
+            workspace_stats_url, cookies=test_user_cookies_1
+        )
 
         expected_response_message = MESSAGE_FORBIDDEN
         actual_response_message = workspace_stats.json()

--- a/backend/tests/app/controllers/test_workspace_form_submissions.py
+++ b/backend/tests/app/controllers/test_workspace_form_submissions.py
@@ -99,7 +99,9 @@ class TestWorkspaceFormSubmission:
         )
 
         form_response_deletion_request = (
-            await FormResponseDeletionRequest.find().to_list()
+            await container.form_response_repo().list_deletion_requests_for_form_ids(
+                [workspace_form_response["form_id"]]
+            )
         )
         actual_response = request_response_deletion.json()
         expected_response = {"message": "Request for deletion created successfully."}

--- a/backend/tests/app/controllers/test_workspace_forms.py
+++ b/backend/tests/app/controllers/test_workspace_forms.py
@@ -270,10 +270,10 @@ class TestWorkspaceForm:
     ):
         delete_form = await client.delete(workspace_form_url, cookies=test_user_cookies)
 
-        actual_response = await FormResponseDocument.find_one(
-            {"form_id": workspace_form.form_id}
+        actual_response = await container.form_response_repo().list_by_form_id(
+            workspace_form.form_id
         )
-        expected_response = None
+        expected_response = []
         assert actual_response == expected_response
 
     async def test_delete_workspace_form_also_deletes_request_response_deletion(
@@ -291,8 +291,10 @@ class TestWorkspaceForm:
 
         delete_form = await client.delete(workspace_form_url, cookies=test_user_cookies)
 
-        actual_request_response_deletion = await FormResponseDeletionRequest.find_one(
-            {"response_id": workspace_form_response["response_id"]}
+        actual_request_response_deletion = (
+            await container.form_response_repo().find_deletion_request_by_response_id(
+                workspace_form_response["response_id"]
+            )
         )
         expected_request_response_deletion = None
         assert actual_request_response_deletion == expected_request_response_deletion
@@ -365,7 +367,7 @@ class TestWorkspaceForm:
 
         submission_uuid = response.json()
         expected_user_id = (
-            await FormResponseDocument.find_one({"submission_uuid": submission_uuid})
+            await container.form_response_repo().get_by_submission_uuid(submission_uuid)
         ).submission_uuid
         assert submission_uuid == expected_user_id
 
@@ -427,8 +429,8 @@ class TestWorkspaceForm:
         )
 
         actual_form_response_deletion_request = (
-            await FormResponseDeletionRequest.find_one(
-                {"response_id": workspace_form_response["response_id"]}
+            await container.form_response_repo().find_deletion_request_by_response_id(
+                workspace_form_response["response_id"]
             )
         )
         expected_form_response_deletion_request = None
@@ -563,9 +565,11 @@ class TestWorkspaceForm:
             json={"group_ids": [str(workspace_group.id)]},
         )
 
-        expected_added_form = (await ResponderGroupFormDocument.find().to_list())[
-            0
-        ].form_id
+        expected_added_form = (
+            await container.responder_groups_repository().get_emails_in_group(
+                workspace_group.id
+            )
+        )["forms"][0]
         actual_added_form = group_form.json()[0]["form_id"]
         assert group_form.status_code == 200
         assert actual_added_form == expected_added_form
@@ -607,10 +611,12 @@ class TestWorkspaceForm:
             delete_form_from_group_url, cookies=test_user_cookies
         )
 
-        actual_form = await ResponderGroupFormDocument.find_one(
-            {"form_id": workspace_form.form_id, "group_id": workspace_group.id}
-        )
-        expected_form = None
+        actual_form = (
+            await container.responder_groups_repository().get_emails_in_group(
+                workspace_group.id
+            )
+        )["forms"]
+        expected_form = []
         assert group_form.status_code == 200
         assert actual_form == expected_form
 

--- a/backend/tests/app/controllers/test_workspace_members.py
+++ b/backend/tests/app/controllers/test_workspace_members.py
@@ -156,7 +156,9 @@ class TestWorkspaceMember:
     ):
         await create_invitation(workspace.id, InvitationRequest(**invitation_request))
 
-        invitations = await client.get(workspace_invitation_url, cookies=test_user_cookies)
+        invitations = await client.get(
+            workspace_invitation_url, cookies=test_user_cookies
+        )
 
         expected_invitations_number = 1
         actual_invitations_number = invitations.json().get("total")
@@ -171,7 +173,9 @@ class TestWorkspaceMember:
         test_user_cookies_1: dict[str, str],
         workspace_invitation_url: str,
     ):
-        invitations = await client.get(workspace_invitation_url, cookies=test_user_cookies_1)
+        invitations = await client.get(
+            workspace_invitation_url, cookies=test_user_cookies_1
+        )
 
         expected_response_message = MESSAGE_FORBIDDEN
         actual_response_message = invitations.json()
@@ -299,11 +303,11 @@ class TestWorkspaceMember:
     ):
         invitation = await container.workspace_invitation_repo().save(
             WorkspaceUserInvitesDocument(
-            workspace_id=workspace.id,
-            email="invited_daemon@gmail.com",
-            invitation_status="REMOVED",
-            invitation_token=secrets.token_hex(16),
-            expiry=1720156071,
+                workspace_id=workspace.id,
+                email="invited_daemon@gmail.com",
+                invitation_status="REMOVED",
+                invitation_token=secrets.token_hex(16),
+                expiry=1720156071,
             )
         )
         invitation_by_token_url = (
@@ -328,10 +332,10 @@ class TestWorkspaceMember:
     ):
         invitation = await container.workspace_invitation_repo().save(
             WorkspaceUserInvitesDocument(
-            workspace_id=workspace.id,
-            email="invited_daemon@gmail.com",
-            expiry=0,
-            invitation_token=secrets.token_hex(16),
+                workspace_id=workspace.id,
+                email="invited_daemon@gmail.com",
+                expiry=0,
+                invitation_token=secrets.token_hex(16),
             )
         )
         invitation_by_token_url = (
@@ -408,11 +412,11 @@ class TestWorkspaceMember:
     ):
         accepted_invitation = await container.workspace_invitation_repo().save(
             WorkspaceUserInvitesDocument(
-            workspace_id=workspace.id,
-            email="invited_daemon@gmail.com",
-            invitation_status="ACCEPTED",
-            invitation_token=secrets.token_hex(16),
-            expiry=1720156071,
+                workspace_id=workspace.id,
+                email="invited_daemon@gmail.com",
+                invitation_status="ACCEPTED",
+                invitation_token=secrets.token_hex(16),
+                expiry=1720156071,
             )
         )
         url = f"{workspace_invitation_url}/{accepted_invitation.invitation_token}?response_status=REJECTED"
@@ -433,10 +437,10 @@ class TestWorkspaceMember:
     ):
         accepted_invitation = await container.workspace_invitation_repo().save(
             WorkspaceUserInvitesDocument(
-            workspace_id=workspace.id,
-            email="invited_daemon@gmail.com",
-            expiry=0,
-            invitation_token=secrets.token_hex(16),
+                workspace_id=workspace.id,
+                email="invited_daemon@gmail.com",
+                expiry=0,
+                invitation_token=secrets.token_hex(16),
             )
         )
         url = f"{workspace_invitation_url}/{accepted_invitation.invitation_token}?response_status=REJECTED"

--- a/backend/tests/app/controllers/test_workspace_responders.py
+++ b/backend/tests/app/controllers/test_workspace_responders.py
@@ -101,7 +101,9 @@ class TestWorkspaceResponders:
         workspace_tag_url: str,
         test_user_cookies_1: dict[str, str],
     ):
-        unauthorized_client = await client.get(workspace_tag_url, cookies=test_user_cookies_1)
+        unauthorized_client = await client.get(
+            workspace_tag_url, cookies=test_user_cookies_1
+        )
 
         expected_response_message = MESSAGE_FORBIDDEN
         actual_response_message = unauthorized_client.json()

--- a/backend/tests/app/repositories/test_postgres_surface.py
+++ b/backend/tests/app/repositories/test_postgres_surface.py
@@ -29,6 +29,38 @@ from backend.app.repositories.postgres.forms import (
 from backend.app.repositories.template import FormTemplateRepository
 from backend.app.repositories.workspace_consent_repo import WorkspaceConsentRepo
 from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
+from backend.app.repositories.action_repository import ActionRepository
+from backend.app.repositories.ai_preference_memory_repository import (
+    AIPreferenceMemoryRepository,
+)
+from backend.app.repositories.flow_event_repository import FlowEventRepository
+from backend.app.repositories.form_ai_insight_repository import FormAIInsightRepository
+from backend.app.repositories.form_ai_session_repository import FormAISessionRepository
+from backend.app.repositories.form_response_repository import FormResponseRepository
+from backend.app.repositories.mcp_audit_log_repository import McpAuditLogRepository
+from backend.app.repositories.postgres.actions import PostgresActionRepository
+from backend.app.repositories.postgres.ai import (
+    PostgresAIPreferenceMemoryRepository,
+    PostgresFlowEventRepository,
+    PostgresFormAIInsightRepository,
+    PostgresFormAISessionRepository,
+    PostgresMcpAuditLogRepository,
+    PostgresWorkspaceAIProfileRepository,
+)
+from backend.app.repositories.postgres.responses import (
+    PostgresFormResponseRepository,
+    PostgresResponderGroupsRepository,
+    PostgresWorkspaceRespondersRepository,
+)
+from backend.app.repositories.responder_groups_repository import (
+    ResponderGroupsRepository,
+)
+from backend.app.repositories.workspace_ai_profile_repository import (
+    WorkspaceAIProfileRepository,
+)
+from backend.app.repositories.workspace_responders_repository import (
+    WorkspaceRespondersRepository,
+)
 from backend.app.repositories.postgres.identity import (
     PostgresBlacklistedRefreshTokenRepository,
     PostgresUserTagsRepository,
@@ -69,6 +101,16 @@ PAIRS = [
     (WorkspaceConsentRepo, PostgresWorkspaceConsentRepo),
     (FormTemplateRepository, PostgresFormTemplateRepository),
     (MediaLibraryRepository, PostgresMediaLibraryRepository),
+    (FormResponseRepository, PostgresFormResponseRepository),
+    (ResponderGroupsRepository, PostgresResponderGroupsRepository),
+    (WorkspaceRespondersRepository, PostgresWorkspaceRespondersRepository),
+    (ActionRepository, PostgresActionRepository),
+    (FlowEventRepository, PostgresFlowEventRepository),
+    (FormAIInsightRepository, PostgresFormAIInsightRepository),
+    (FormAISessionRepository, PostgresFormAISessionRepository),
+    (WorkspaceAIProfileRepository, PostgresWorkspaceAIProfileRepository),
+    (AIPreferenceMemoryRepository, PostgresAIPreferenceMemoryRepository),
+    (McpAuditLogRepository, PostgresMcpAuditLogRepository),
 ]
 
 

--- a/backend/tests/app/repositories/test_responses_parity.py
+++ b/backend/tests/app/repositories/test_responses_parity.py
@@ -1,0 +1,462 @@
+"""The Postgres twins of the responses, actions, ai and analytics repositories
+behave like the Mongo originals. The forms-group data the responses twin
+composes over lives in Mongo here (routed repositories are Mongo instances).
+Skipped unless DATABASE_URL points at a *_test database.
+"""
+
+import datetime as dt
+
+import pytest
+from beanie import PydanticObjectId
+from fastapi_pagination import Page, Params
+from fastapi_pagination.api import set_page, set_params
+
+from backend.app.container import container
+from backend.app.exceptions import HTTPException
+from backend.app.models.dtos.action_dto import ActionDto
+from backend.app.models.filter_queries.form_responses import FormResponseFilterQuery
+from backend.app.models.filter_queries.sort import SortOrder, SortRequest
+from backend.app.repositories.action_repository import ActionRepository
+from backend.app.repositories.ai_preference_memory_repository import (
+    AIPreferenceMemoryRepository,
+)
+from backend.app.repositories.deletion_requests_repository import (
+    DeletionRequestsRepository,
+)
+from backend.app.repositories.flow_event_repository import FlowEventRepository
+from backend.app.repositories.form_ai_insight_repository import FormAIInsightRepository
+from backend.app.repositories.form_ai_session_repository import FormAISessionRepository
+from backend.app.repositories.form_repository import FormRepository
+from backend.app.repositories.form_response_repository import FormResponseRepository
+from backend.app.repositories.mcp_audit_log_repository import McpAuditLogRepository
+from backend.app.repositories.postgres.actions import PostgresActionRepository
+from backend.app.repositories.postgres.ai import (
+    PostgresAIPreferenceMemoryRepository,
+    PostgresFlowEventRepository,
+    PostgresFormAIInsightRepository,
+    PostgresFormAISessionRepository,
+    PostgresMcpAuditLogRepository,
+    PostgresWorkspaceAIProfileRepository,
+)
+from backend.app.repositories.postgres.responses import (
+    PostgresFormResponseRepository,
+    PostgresResponderGroupsRepository,
+    PostgresWorkspaceRespondersRepository,
+)
+from backend.app.repositories.responder_groups_repository import (
+    ResponderGroupsRepository,
+)
+from backend.app.repositories.workspace_ai_profile_repository import (
+    WorkspaceAIProfileRepository,
+)
+from backend.app.repositories.workspace_form_repository import WorkspaceFormRepository
+from backend.app.repositories.workspace_responders_repository import (
+    WorkspaceRespondersRepository,
+)
+from backend.app.schemas.ai_preference_memory import UserAIPreferenceMemoryDocument
+from backend.app.schemas.form_ai_insight import FormAIInsightDocument
+from backend.app.schemas.form_ai_session import FormAISessionDocument
+from backend.app.schemas.standard_form import FormDocument
+from backend.app.schemas.standard_form_response import (
+    DeletionRequestStatus,
+    FormResponseDeletionRequest,
+    FormResponseDocument,
+)
+from backend.app.schemas.workspace_ai_profile import WorkspaceAIProfileDocument
+from backend.app.schemas.workspace_form import WorkspaceFormDocument
+from backend.app.schemas.workspace_responder import WorkspaceResponderDocument
+from common.exceptions import NotFoundError
+from common.models.standard_form import StandardFormResponse
+from common.models.user import User
+from tests.app.repositories.test_identity_parity import both_raise
+from tests.app.repositories.test_refdata_parity import parity, strip
+
+T0 = dt.datetime(2026, 1, 1, tzinfo=dt.timezone.utc)
+
+
+@pytest.fixture
+def sessions(clean_postgres):
+    return container.pg_sessionmaker()
+
+
+def at(minutes):
+    return T0 + dt.timedelta(minutes=minutes)
+
+
+def response(form_id, response_id, minutes, **extra):
+    return FormResponseDocument(
+        id=PydanticObjectId(),
+        form_id=form_id,
+        response_id=response_id,
+        created_at=at(minutes),
+        **extra,
+    )
+
+
+async def seed_both(pairs, method, *documents):
+    for repo in pairs:
+        for document in documents:
+            await getattr(repo, method)(document)
+
+
+async def pages_equal(mongo_call, postgres_call, size=10):
+    with set_page(Page), set_params(Params(page=1, size=size)):
+        m, p = await mongo_call(), await postgres_call()
+    assert (m.total, m.pages) == (p.total, p.pages)
+    assert strip(m.items) == strip(p.items)
+    return p
+
+
+# ------------------------------------------------------------------ responses
+async def test_response_listings_compose_over_forms(sessions):
+    ws = PydanticObjectId()
+    # forms-group data, in Mongo only: the twin composes over it
+    forms, workspace_forms = FormRepository(), WorkspaceFormRepository()
+    for form_id, title in (("f1", "Alpha"), ("f2", "Beta")):
+        await forms.save_form(FormDocument(form_id=form_id, title=title))
+        await workspace_forms.save(
+            WorkspaceFormDocument(workspace_id=ws, form_id=form_id, user_id="importer")
+        )
+    mongo = FormResponseRepository(crypto=container.crypto())
+    postgres = PostgresFormResponseRepository(sessions, forms, workspace_forms)
+    await seed_both(
+        (mongo, postgres),
+        "save",
+        response("f1", "r1", 1, answers={}, dataOwnerIdentifier="a@example.com"),
+        response("f1", "r2", 2, answers={}, dataOwnerIdentifier="b@example.com"),
+        response("f2", "r3", 3, answers={}, dataOwnerIdentifier="a@example.com"),
+        response("f1", "r4", 4),  # no answers: a deletion-only stub, not listed
+        response("orphan", "r5", 5, answers={}),  # its form is gone: dropped
+    )
+    for repo in (mongo, postgres):
+        for response_id in ("r1", "r3"):
+            await repo.add_deletion_request(
+                await repo.get_response(response_id), response_id
+            )
+
+    ids = ["f1", "f2", "orphan", "missing"]
+    user_a = User(id=str(PydanticObjectId()), sub="a@example.com")
+    await pages_equal(
+        lambda: mongo.get_form_responses(ids),
+        lambda: postgres.get_form_responses(ids),
+    )
+    page = await pages_equal(
+        lambda: mongo.get_form_responses(ids, data_owner_identifier="a@example.com"),
+        lambda: postgres.get_form_responses(ids, data_owner_identifier="a@example.com"),
+    )
+    assert {i["response_id"] for i in page.items} == {"r1", "r3"}
+    assert (
+        next(i for i in page.items if i["response_id"] == "r3")["status"] == "pending"
+    )
+    assert (
+        next(i for i in page.items if i["response_id"] == "r1")["form_title"] == "Alpha"
+    )
+    await pages_equal(
+        lambda: mongo.get_form_responses(
+            ids, filter_query=FormResponseFilterQuery(data_owner_identifier="^b@")
+        ),
+        lambda: postgres.get_form_responses(
+            ids, filter_query=FormResponseFilterQuery(data_owner_identifier="^b@")
+        ),
+    )
+    await pages_equal(
+        lambda: mongo.get_form_responses(
+            ids, sort=SortRequest(sort_by="created_at", sort_order=SortOrder.ASCENDING)
+        ),
+        lambda: postgres.get_form_responses(
+            ids, sort=SortRequest(sort_by="created_at", sort_order=SortOrder.ASCENDING)
+        ),
+        size=2,
+    )
+    await pages_equal(  # the Mongo original lives on the static DeletionRequestsRepository
+        lambda: DeletionRequestsRepository.get_deletion_requests(ids),
+        lambda: postgres.get_deletion_requests(ids),
+    )
+    await pages_equal(
+        lambda: mongo.get_user_submissions(ids, user_a),
+        lambda: postgres.get_user_submissions(ids, user_a),
+    )
+    await pages_equal(
+        lambda: mongo.get_user_submissions(ids, user_a, request_for_deletion=True),
+        lambda: postgres.get_user_submissions(ids, user_a, request_for_deletion=True),
+    )
+    await pages_equal(
+        lambda: mongo.list(ids, False, data_subjects=True),
+        lambda: postgres.list(ids, False, data_subjects=True),
+    )
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("count_responses_with_answers_by_form_ids", lambda: (ids,)),
+            ("count_deletion_requests_by_form_ids", lambda: (ids,)),
+            ("count_responses_for_form_ids", lambda: (ids,)),
+            ("get_deletion_requests_count_in_workspace", lambda: (ids,)),
+            ("get_deletion_requests_count_in_workspace", lambda: (["missing"],)),
+            ("list_recent_by_form_id", lambda: ("f1", 2)),
+            ("list_deletion_requests_for_form_ids", lambda: (ids,)),
+            ("list_by_form_id", lambda: ("f2",)),
+            ("find_deletion_request_by_response_id", lambda: ("r3",)),
+            ("find_deletion_request_by_response_id", lambda: ("r1",)),
+            ("get_all_expiring_responses", lambda: ()),
+            ("get_response", lambda: ("r2",)),
+            ("get_response", lambda: ("nope",)),
+            ("verify_response_exists_in_workspace", lambda: (ws, "r1")),
+        ],
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.verify_response_exists_in_workspace(PydanticObjectId(), "r1"),
+        lambda: postgres.verify_response_exists_in_workspace(PydanticObjectId(), "r1"),
+    )
+    await both_raise(
+        HTTPException,
+        lambda: mongo.verify_response_exists_in_workspace(ws, "r5"),
+        lambda: postgres.verify_response_exists_in_workspace(ws, "r5"),
+    )
+    # writes
+    submitted = []
+    for repo in (mongo, postgres):
+        saved = await repo.save_form_response(
+            PydanticObjectId(),
+            StandardFormResponse(answers={}, dataOwnerIdentifier="c@example.com"),
+            ws,
+        )
+        dumped = saved.model_dump()  # answers is an encrypted blob: not JSON, not equal
+        for key in (
+            "id",
+            "created_at",
+            "updated_at",
+            "submission_uuid",
+            "answers",
+            "form_id",
+        ):
+            dumped.pop(key, None)
+        submitted.append(dumped)
+    assert submitted[0] == submitted[1]
+    await parity(
+        mongo,
+        postgres,
+        [
+            (
+                "mark_deletion_requests_success_except",
+                lambda: ("f1", None, ["zzz"], at(9)),
+            ),
+            ("find_deletion_request_by_response_id", lambda: ("r3",)),
+            ("delete_form_response", lambda: ("f1", "r1")),
+            ("get_response", lambda: ("r1",)),
+            ("delete_by_form_id_except", lambda: ("f1", ["r2"])),
+            ("list_by_form_id", lambda: ("f1",)),
+            ("delete_response", lambda: ("r3",)),
+            ("delete_deletion_requests", lambda: ("f1",)),
+            ("list_deletion_requests_for_form_ids", lambda: (ids,)),
+            ("delete_by_form_ids", lambda: (["f2", "orphan"],)),
+            ("count_responses_for_form_ids", lambda: (ids,)),
+            ("delete_deletion_requests_by_form_ids", lambda: (ids,)),
+        ],
+    )
+
+
+async def test_workspace_responders_and_tags(sessions):
+    ws = PydanticObjectId()
+    mongo, postgres = (
+        WorkspaceRespondersRepository(),
+        PostgresWorkspaceRespondersRepository(sessions),
+    )
+    tags = [
+        strip(await repo.create_workspace_tag(ws, "vip")) for repo in (mongo, postgres)
+    ]
+    assert tags[0] == tags[1]
+    await parity(
+        mongo,
+        postgres,
+        [
+            ("create_workspace_tag", lambda: (ws, "vip")),  # idempotent on title
+            ("get_workspace_tags", lambda: (ws,)),
+            ("get_workspace_tags", lambda: (PydanticObjectId(),)),
+            ("get_responder_by_email_and_workspace_id", lambda: (ws, "a@example.com")),
+            ("get_responder_by_email_and_workspace_id", lambda: (ws, "a@example.com")),
+        ],
+    )
+
+
+async def test_responder_groups(sessions):
+    ws = PydanticObjectId()
+    mongo, postgres = ResponderGroupsRepository(), PostgresResponderGroupsRepository(
+        sessions
+    )
+    created = [
+        await repo.create_group(ws, "Team", "desc", ".*@team.com")
+        for repo in (mongo, postgres)
+    ]
+    assert strip(created[0]) == strip(created[1])
+    assert isinstance(await postgres.create_group(ws, "x", "d" * 281), dict)
+    for repo, group in zip((mongo, postgres), created):
+        await repo.add_emails_to_group(group.id, ["a@x.com", "b@x.com", "a@x.com"])
+        await repo.add_group_to_form("f1", group.id)
+        await repo.add_group_to_form("f1", group.id)  # idempotent
+        await repo.add_groups_to_form("f2", [group.id])
+    # relation documents get derived ids, so both stores hold identical rows
+    m_links = await mongo.get_emails_in_group(created[0].id)
+    p_links = await postgres.get_emails_in_group(created[1].id)
+    assert (
+        sorted(m_links["emails"]) == sorted(p_links["emails"]) == ["a@x.com", "b@x.com"]
+    )
+    assert sorted(m_links["forms"]) == sorted(p_links["forms"]) == ["f1", "f2"]
+    for repo, group in zip((mongo, postgres), created):
+        groups = await repo.get_groups_in_workspace(ws)
+        assert [g.name for g in groups] == ["Team"] and sorted(groups[0].forms) == [
+            "f1",
+            "f2",
+        ]
+        assert await repo.get_group_in_workspace(ws, group.id) is not None
+        assert await repo.get_group_in_workspace(PydanticObjectId(), group.id) is None
+        assert (await repo.get_groups_by_form_ids(["f1", "zz"]))["f1"][0][
+            "name"
+        ] == "Team"
+        assert await repo.get_form_ids_accessible_to(["f1", "f2", "f3"], "b@x.com") == {
+            "f1",
+            "f2",
+        }
+        assert await repo.get_form_ids_accessible_to(["f1"], "who@team.com") == {"f1"}
+        assert await repo.get_form_ids_accessible_to(["f1"], "who@else.com") == set()
+        await repo.remove_emails_from_group(group.id, ["a@x.com"])
+        await repo.remove_group_from_form("f2", group.id)
+        updated = await repo.update_group(
+            ws, "Team2", None, ["c@x.com"], group.id, None
+        )
+        assert updated.name == "Team2" and updated.regex is None
+        info = await repo.get_emails_in_group(group.id)
+        assert (info["emails"], info["forms"]) == (["c@x.com"], ["f1"])
+        assert await repo.get_emails_in_group(PydanticObjectId()) is None
+        await repo.delete_workspace_form_groups("f1")
+        assert (await repo.get_emails_in_group(group.id))["forms"] == []
+        await repo.remove_responder_group(group.id)
+        assert await repo.get_emails_in_group(group.id) is None
+    for repo in (mongo, postgres):
+        g = await repo.create_group(ws, "Gone")
+        await repo.add_emails_to_group(g.id, ["z@x.com"])
+        await repo.delete_responder_groups([ws])
+        assert await repo.get_groups_in_workspace(ws) == []
+
+
+# --------------------------------------------------------------------- actions
+async def test_actions(sessions):
+    ws = PydanticObjectId()
+    user = User(id=str(PydanticObjectId()), sub="u@example.com")
+    mongo = ActionRepository(crypto=container.crypto())
+    postgres = PostgresActionRepository(sessions, container.crypto())
+
+    def dto(name):
+        return ActionDto(
+            name=name, title=name, action_code="print(1)", secrets=None, parameters=None
+        )
+
+    created = [
+        await repo.create_action(ws, dto("notify"), user) for repo in (mongo, postgres)
+    ]
+    assert strip(created[0]) == strip(created[1])
+    globals_ = [
+        await repo.create_global_action(dto("global"), user)
+        for repo in (mongo, postgres)
+    ]
+    assert strip(globals_[0]) == strip(globals_[1])
+    for repo, action in zip((mongo, postgres), created):
+        assert strip(await repo.get_action_by_id(action.id)) == strip(action)
+        assert len(await repo.get_all_actions()) == 2
+        assert [a.name for a in await repo.get_actions_by_ids([action.id])] == [
+            "notify"
+        ]
+        wa = await repo.create_action_in_workspace_from_action(ws, action.id, "cred")
+        assert dict(wa.secrets[0])["value"] == "cred"  # stored as a plain dict
+        wa2 = await repo.create_action_in_workspace_from_action(ws, action.id)
+        assert wa2.id == wa.id and wa2.secrets is None
+        assert (await repo.get_workspace_action(ws, action.id)).id == wa.id
+        assert await repo.get_workspace_action(PydanticObjectId(), action.id) is None
+        assert await repo.delete_action(action.id) == action.id
+        assert await repo.get_action_by_id(action.id) is None
+
+
+# ------------------------------------------------------------ ai and analytics
+async def test_ai_and_analytics(sessions):
+    ws = PydanticObjectId()
+    await parity(
+        FlowEventRepository(),
+        PostgresFlowEventRepository(sessions),
+        [
+            ("add", lambda: ("f1", "s1", "p1", "p2")),
+            ("add", lambda: ("f1", "s1", "p2", "p3")),
+            ("list_by_form_id", lambda: ("f1",)),
+            ("list_by_form_id", lambda: ("f2",)),
+        ],
+    )
+    insight = FormAIInsightDocument(
+        id=PydanticObjectId(),
+        workspace_id=ws,
+        form_id="f1",
+        payload={"k": 1},
+        response_count=3,
+        total_responses=3,
+        generated_at=at(1),
+    )
+    await parity(
+        FormAIInsightRepository(),
+        PostgresFormAIInsightRepository(sessions),
+        [
+            ("find", lambda: (ws, "f1")),
+            ("save", lambda: (insight,)),
+            ("find", lambda: (ws, "f1")),
+            ("find", lambda: (ws, "f2")),
+        ],
+    )
+    session = FormAISessionDocument(
+        id=PydanticObjectId(), workspace_id=ws, form_id="f1", user_id="u1", messages=[]
+    )
+    mongo_s, postgres_s = FormAISessionRepository(), PostgresFormAISessionRepository(
+        sessions
+    )
+    await parity(
+        mongo_s,
+        postgres_s,
+        [("save", lambda: (session,)), ("get_or_404", lambda: (session.id,))],
+    )
+    missing = PydanticObjectId()
+    await both_raise(
+        NotFoundError,
+        lambda: mongo_s.get_or_404(missing),
+        lambda: postgres_s.get_or_404(missing),
+    )
+    profile = WorkspaceAIProfileDocument(
+        id=PydanticObjectId(), workspace_id=ws, about="us"
+    )
+    await parity(
+        WorkspaceAIProfileRepository(),
+        PostgresWorkspaceAIProfileRepository(sessions),
+        [
+            ("find_by_workspace", lambda: (ws,)),
+            ("save", lambda: (profile,)),
+            ("find_by_workspace", lambda: (ws,)),
+        ],
+    )
+    memory = UserAIPreferenceMemoryDocument(
+        id=PydanticObjectId(), workspace_id=ws, user_id="u1", entries=[{"text": "x"}]
+    )
+    await parity(
+        AIPreferenceMemoryRepository(),
+        PostgresAIPreferenceMemoryRepository(sessions),
+        [
+            ("save", lambda: (memory,)),
+            ("find", lambda: (ws, "u1")),
+            ("find", lambda: (ws, "u2")),
+        ],
+    )
+    mongo_l, postgres_l = McpAuditLogRepository(), PostgresMcpAuditLogRepository(
+        sessions
+    )
+    for repo in (mongo_l, postgres_l):
+        await repo.add(
+            workspace_id=ws, key_id="k", tool="update_form", ok=True, at=at(1)
+        )
+    assert strip(await mongo_l.list_by_workspace(ws)) == strip(
+        await postgres_l.list_by_workspace(ws)
+    )

--- a/backend/tests/app/services/test_hidden_fields.py
+++ b/backend/tests/app/services/test_hidden_fields.py
@@ -20,9 +20,7 @@ async def test_submitted_hidden_fields_are_encrypted_at_rest_and_decrypted_on_re
     assert response.hidden_fields == hidden
 
     # ...but at rest the values are an encrypted blob, like answers.
-    stored = await FormResponseDocument.find_one(
-        {"response_id": response.response_id}
-    )
+    stored = await container.form_response_repo().get_response(response.response_id)
     assert isinstance(stored.hidden_fields, (bytes, str))
     assert json.dumps(hidden) != stored.hidden_fields
 
@@ -38,9 +36,7 @@ async def test_submission_without_hidden_fields_stays_none(workspace, workspace_
         StandardFormResponse(answers={}),
         workspace.id,
     )
-    stored = await FormResponseDocument.find_one(
-        {"response_id": response.response_id}
-    )
+    stored = await container.form_response_repo().get_response(response.response_id)
     assert stored.hidden_fields is None
 
 
@@ -91,9 +87,7 @@ async def test_anonymize_is_enforced_server_side(workspace, published_form):
         testUser,
     )
 
-    stored = await FormResponseDocument.find_one(
-        {"response_id": response.response_id}
-    )
+    stored = await container.form_response_repo().get_response(response.response_id)
     # The anonymity choice must hold at rest: no owner identifier, no email —
     # only the one-way hash that lets the responder find their own submission.
     assert stored.dataOwnerIdentifier is None
@@ -113,9 +107,7 @@ async def test_identity_is_kept_when_not_anonymized(workspace, published_form):
         testUser,
     )
 
-    stored = await FormResponseDocument.find_one(
-        {"response_id": response.response_id}
-    )
+    stored = await container.form_response_repo().get_response(response.response_id)
     assert stored.dataOwnerIdentifier == testUser.sub
 
 
@@ -170,11 +162,11 @@ async def test_anonymous_owner_can_request_deletion(workspace, published_form):
         workspace.id, response.response_id, testUser2
     )
 
-    stored_response = await FormResponseDocument.find_one(
-        {"response_id": response.response_id}
+    stored_response = await container.form_response_repo().get_response(
+        response.response_id
     )
-    request = await FormResponseDeletionRequest.find_one(
-        {"response_id": response.response_id}
+    request = await container.form_response_repo().find_deletion_request_by_response_id(
+        response.response_id
     )
     assert request is not None
     # Attribution survives: the request carries the same anonymous hash the

--- a/common/common/db/pg_repository.py
+++ b/common/common/db/pg_repository.py
@@ -117,6 +117,18 @@ class PostgresRepositoryBase:
             )
         }
 
+    @staticmethod
+    def _check_collection(document: Any, row: Type[Any]) -> None:
+        """Mongo writes a document to its own collection whichever repository
+        saves it; here the twin picks the table, so refuse a mismatch loudly."""
+        get_settings = getattr(type(document), "get_settings", None)
+        collection = get_settings().name if get_settings else None
+        if collection is not None and collection != row.mongo_collection():
+            raise TypeError(
+                f"a {type(document).__name__} (collection {collection!r}) cannot be "
+                f"stored in table {row.__tablename__!r}"
+            )
+
     def _upsert_statement(
         self, values: dict[str, Any], row: Optional[Type[Any]] = None
     ):
@@ -137,6 +149,7 @@ class PostgresRepositoryBase:
     async def upsert(self, document: Any, row: Optional[Type[Any]] = None) -> Any:
         """Store ``document`` (minting an id if it has none); ``row`` selects
         another table of the group."""
+        self._check_collection(document, row or self.row)
         values = row_values(document)
         async with self._session() as session, session.begin():
             await session.execute(self._upsert_statement(values, row))
@@ -147,6 +160,7 @@ class PostgresRepositoryBase:
     ) -> None:
         async with self._session() as session, session.begin():
             for document in documents:
+                self._check_collection(document, row or self.row)
                 await session.execute(self._upsert_statement(row_values(document), row))
 
     async def replay_write(self, documents: Iterable[Any]) -> None:
@@ -165,21 +179,22 @@ class PostgresRepositoryBase:
             result = await session.execute(delete(row or self.row).where(*where))
         return result.rowcount or 0
 
-    async def delete_one_where(self, *where: Any) -> int:
+    async def delete_one_where(
+        self, *where: Any, row: Optional[Type[Any]] = None
+    ) -> int:
         """Delete the first matching row in Mongo's natural order — the twin of
         ``find_one(...).delete()``. Mongo's semantics, even where odd, are what
         verification compares against."""
+        row = row or self.row
         async with self._session() as session, session.begin():
             target = (
-                select(self.row.id)
+                select(row.id)
                 .where(*where)
-                .order_by(*self._order())
+                .order_by(row.created_at, row.id)
                 .limit(1)
                 .scalar_subquery()
             )
-            result = await session.execute(
-                delete(self.row).where(self.row.id == target)
-            )
+            result = await session.execute(delete(row).where(row.id == target))
         return result.rowcount or 0
 
     async def delete_by_id(self, document_id: Any) -> int:


### PR DESCRIPTION
Plan step 7b (`plans/postgres-consolidation.md`), on top of #676. With this **every backend repository has a Postgres twin**, and CI runs the suite three ways: default (Mongo), **every group mirrored** (`DB_WRITE_MODE=dual`), and **every group served from Postgres** (`DB_READ_SOURCE=postgres DB_WRITE_MODE=postgres`) — the first run with nothing on Mongo. 312 passed in each.

## What

- **Twins** for `FormResponseRepository` (incl. the static `DeletionRequestsRepository` listing), `ResponderGroupsRepository`, `WorkspaceRespondersRepository`, `ActionRepository`, `FlowEventRepository`, `FormAIInsightRepository`, `FormAISessionRepository`, `WorkspaceAIProfileRepository`, `AIPreferenceMemoryRepository`, `McpAuditLogRepository` (`postgres/responses.py`, `postgres/actions.py`, `postgres/ai.py`).
- **Within-group lookups → SQL.** Deletion-request status / submission uuid are correlated subqueries that select the *joined document*, so "no document" leaves the field unset and "document with null field" sets null — exactly `$arrayElemAt`'s behaviour. Responders are grouped by data owner with deletion counts (`= ANY(array_agg)`), joined to `workspace_responder` and their tags.
- **Into the forms group → composition** through the routed forms repositories, restricted to the form ids they know (the Mongo `$unwind` drops responses whose form is gone). Forms ⇄ responses twins compose over each other — a provider cycle — broken by `LazyRepository` (resolves a routed repository at first use; guarded against copy probes).
- `McpAuditLogRepository.list_by_workspace`; `$unset` of lookup scaffolding (`form`, `workspace_form`, `responder`) in the Mongo response pipelines; the base class gains `row=` on `delete_one_where`.

## Two Mongo-side bugs that only Postgres's constraints could reveal

- **`duplicate_form(is_template=True)` saved a `FormTemplateDocument` through the *forms* repository.** Mongo writes any document to its own collection whichever repository calls `.save()`; the twin picks the table, so the template landed in `forms` (the created template was then not found). The service now saves templates through the template repository, and **`PostgresRepositoryBase` refuses a document whose collection is not the target table's**, so this class of bug fails loudly rather than mis-storing.
- **`FormService.save_form` created a new form document — and a new version 1 — on every import of the same `form_id`**; `unique(forms.form_id)` rejected the second. It now replaces the existing document and version, which is what a re-import means (Mongo readers `find_one` on `form_id`, so duplicates were already latent breakage).

## Tests

- `test_responses_parity.py`: listings (with responder filter, regex filter, sort, pagination), deletion requests, data subjects, counts, all writes; responder groups end-to-end (derived-id relation rows, regex/member access); actions; ai/analytics.
- Surface test extended to all 20 pairs. Tests that touched these groups' documents directly now go through the repositories.

## Verification

Backend ×3: 312 passed, 6 skipped each. Common: 53 passed.
