### PR TITLE
feat(backend): background jobs on Postgres with procrastinate; remove the dead APScheduler

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,9 @@ DATABASE_URL=postgresql+asyncpg://bc_app:bc_app@localhost:5432/bettercollected
 #   DB_READ_SOURCE=mongo|postgres            DB_WRITE_MODE=mongo|dual|postgres_primary_dual|postgres
 #   DB_READ_SOURCE__<group>=... / DB_WRITE_MODE__<group>=...   DB_SHADOW_READ_SAMPLE=0.0..1.0
 # e.g. mirror the refdata group to Postgres:  DB_WRITE_MODE__refdata=dual
+# Background jobs: temporal (default) or postgres (procrastinate, `jobs` schema), per job kind:
+#   JOBS_BACKEND=temporal|postgres   JOBS_BACKEND__delete_user / __delete_response / __run_action
+#   JOBS_QUEUES=default JOBS_CONCURRENCY=4 (worker: `python -m backend.jobs.worker`)
 # Cutover order is enforced at boot (backend/db/groups.py): a group whose Mongo
 # repositories join into another group's collections must be served from Postgres
 # before that other group stops writing Mongo (DB_WRITE_MODE=postgres).

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -23,7 +23,8 @@ backend/
       core/           # provider plugin system: base/, factory/, loader/, plugins/{google,typeform}.py
       handlers/       # startup wiring: database.py (Beanie init), logging
       middlewares/    # DynamicCORSMiddleware, timing
-      schedulers/     # APScheduler jobs (form_schedular.py)
+      schedulers/     # form_schedular.py: re-import + expired-response deletion, called by workers via /temporal
+      jobs/           # procrastinate app, tasks, worker and schema entrypoints (JOBS_BACKEND=postgres)
       container.py    # dependency-injector AppContainer (wires repos -> services)
       router.py       # aggregates all routers into root_api_router
       asgi.py         # get_application() app factory
@@ -51,7 +52,9 @@ Routers are registered in [backend/app/router.py](backend/app/router.py) via the
 Beanie Documents are registered in [backend/app/handlers/database.py](backend/app/handlers/database.py) `init_db`'s
 `document_models` list — **a new collection must be added there or it won't be initialized.** Core domain models
 (`User`, `StandardForm`, `StandardFormResponse`, `Consent`) come from the shared `common` package, not from here.
-APScheduler uses a separate DB (`init_scheduler_db`).
+Background jobs go through `services/temporal_service.py`, which dispatches per job kind (`JOBS_BACKEND__<job>`)
+to a Temporal workflow (default) or a procrastinate job on Postgres (`backend/jobs/`; worker:
+`python -m backend.jobs.worker`, queue tables in the `jobs` schema via `python -m backend.jobs.schema`).
 
 Response `answers` **and** `hidden_fields` (captured URL parameters, see `StandardForm.hidden_fields` for the
 declared names) are encrypted at rest via `crypto_service` in `form_response_repository.save_form_response` and
@@ -121,9 +124,10 @@ and architecture.
 
 - **Auth:** `services/auth_service.py` — OAuth state + OTP, JWT via `common.services.jwt_service`; refresh-token
   blacklist in Mongo; cookies via `auth_cookie_service.py`.
-- **Temporal:** `services/temporal_service.py` connects to the Temporal server, creates **Schedules**, and starts
-  workflows (form import, CSV export, response/user deletion, action code). On startup `migrate_schedule_to_temporal()`
-  can migrate legacy APScheduler jobs (gated by settings).
+- **Jobs:** `services/temporal_service.py` starts the three background jobs — user deletion, scheduled response
+  deletion (at the response's expiration), action-code execution — on Temporal (default) or, per job kind via
+  `JOBS_BACKEND__<job>=postgres`, as procrastinate jobs (`backend/jobs/tasks.py`; `run_action` is deferred by name and
+  executed by `temporal/actions-executor`). See plans/postgres-consolidation.md §7.
 - **Provider plugins:** `core/plugins/{google,typeform}.py` behind `plugin_proxy_service.py` — forwards standardized
   requests to the external provider microservices (:8003 / :8002).
 - **Third-party services:** `aws_service.py` (S3), `stripe_service.py`, `openai_service.py` (prompts/AI form gen),

--- a/backend/backend/app/asgi.py
+++ b/backend/backend/app/asgi.py
@@ -22,6 +22,7 @@ from backend.app.exceptions import HTTPException, http_exception_handler
 from backend.app.handlers import init_logging
 from backend.app.handlers.database import close_db, init_db
 from backend.db.startup import check_postgres_at_startup, dispose_postgres
+from backend.jobs.app import app as jobs_app, postgres_jobs_enabled
 from backend.app.mcp.server import build_mcp_asgi_app, mcp
 from backend.app.middlewares import DynamicCORSMiddleware, include_middlewares
 from backend.app.router import root_api_router
@@ -48,6 +49,9 @@ async def lifespan(app: FastAPI):
         container.database_client.override(providers.Object(client))
     await init_db(settings.mongo_settings.DB, client)
     await check_postgres_at_startup(container)
+    jobs_on_postgres = postgres_jobs_enabled(container.flags())
+    if jobs_on_postgres:
+        await jobs_app.open_async()
 
     # Auto-provision the Umami website (find-or-create by UMAMI_WEBSITE_NAME)
     # when UMAMI_WEBSITE_ID isn't already set — lets self-hosters skip creating
@@ -111,6 +115,8 @@ async def lifespan(app: FastAPI):
     mcp_stop.set()
     await mcp_task
     await close_db(client)
+    if jobs_on_postgres:
+        await jobs_app.close_async()
     await dispose_postgres(container)
     await AiohttpClient.close_aiohttp_client()
     await container.http_client().aclose()

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -3,8 +3,6 @@ from pathlib import Path
 
 from concurrent.futures.thread import ThreadPoolExecutor
 
-from apscheduler.jobstores.mongodb import MongoDBJobStore
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from common.configs.crypto import Crypto
 from common.services.http_client import HttpClient
 from common.services.jwt_service import JwtService
@@ -19,6 +17,7 @@ from common.db.routing import RoutingRepository
 
 from backend.db.outbox import OutboxRecorder
 from backend.db.groups import MONGO_JOINS
+from backend.jobs.app import app as jobs_app
 from backend.db.session import (
     LazyRepository,
     build_engine,
@@ -410,6 +409,8 @@ class AppContainer(containers.DeclarativeContainer):
         server_uri=settings.temporal_settings.server_uri,
         namespace=settings.temporal_settings.namespace,
         crypto=crypto,
+        flags=flags,
+        jobs=providers.Object(jobs_app),
     )
 
     aws_service: AWSS3Service = providers.Singleton(
@@ -465,15 +466,6 @@ class AppContainer(containers.DeclarativeContainer):
         workspace_repo=workspace_repo,
     )
 
-    job_store = providers.Singleton(MongoDBJobStore, host=settings.mongo_settings.URI)
-
-    job_stores = providers.Dict(default=job_store)
-
-    schedular = providers.Singleton(
-        AsyncIOScheduler,
-        jobstores=job_stores,
-    )
-
     form_import_service: FormImportService = providers.Singleton(
         FormImportService,
         form_service=form_service,
@@ -520,7 +512,6 @@ class AppContainer(containers.DeclarativeContainer):
         form_repo=form_repo,
         form_schedular=form_schedular,
         form_import_service=form_import_service,
-        schedular=schedular,
         form_response_service=form_response_service,
         responder_groups_service=responder_groups_service,
         user_tags_service=user_tags_service,

--- a/backend/backend/app/services/temporal_service.py
+++ b/backend/backend/app/services/temporal_service.py
@@ -1,8 +1,14 @@
 import json
 from dataclasses import asdict
-from datetime import timedelta
+from datetime import timedelta, timezone
 from http import HTTPStatus
-from typing import List
+from typing import List, Optional
+
+from procrastinate import App
+from procrastinate.exceptions import AlreadyEnqueued
+
+from common.db.flags import DbFlags, JobsBackend
+from backend.jobs import tasks
 from bson import ObjectId
 
 import loguru
@@ -39,7 +45,18 @@ from backend.config import settings
 
 
 class TemporalService:
-    def __init__(self, server_uri: str, namespace: str, crypto: Crypto):
+    """Starts background jobs. Per job kind, ``JOBS_BACKEND__<job>`` picks the
+    Temporal workflow (today's default) or a procrastinate job on Postgres
+    (plans/postgres-consolidation.md §7); the callers do not know which."""
+
+    def __init__(
+        self,
+        server_uri: str,
+        namespace: str,
+        crypto: Crypto,
+        flags: Optional[DbFlags] = None,
+        jobs: Optional[App] = None,
+    ):
         self.server_uri = server_uri
         self.namespace = namespace
         self.crypto = crypto
@@ -51,6 +68,15 @@ class TemporalService:
         # cross-loop hazard (the same shape that broke the auth OTP send once
         # motor's cross-loop tolerance was dropped for pymongo).
         self.temporal_client = None
+        self.flags = flags
+        self.jobs = jobs
+
+    def _on_postgres(self, job: str) -> bool:
+        return (
+            self.flags is not None
+            and self.jobs is not None
+            and self.flags.jobs_backend(job) is JobsBackend.POSTGRES
+        )
 
     async def connect_to_temporal_server(self):
         try:
@@ -71,9 +97,20 @@ class TemporalService:
                 )
 
     async def start_user_deletion_workflow(self, user_tokens: UserTokens, user_id: str):
+        encrypted_tokens = self.crypto.encrypt(json.dumps(asdict(user_tokens)))
+        if self._on_postgres("delete_user"):
+            try:
+                await tasks.delete_user.configure(
+                    queueing_lock=f"delete_user:{user_id}"
+                ).defer_async(encrypted_tokens=encrypted_tokens, user_id=user_id)
+                return "Job Started"
+            except AlreadyEnqueued:
+                loguru.logger.error(
+                    "Deletion of user " + user_id + " has already been queued."
+                )
+                return None
         await self.check_temporal_client_and_try_to_connect_if_not_connected()
         try:
-            encrypted_tokens = self.crypto.encrypt(json.dumps(asdict(user_tokens)))
             await self.temporal_client.start_workflow(
                 "delete_user_workflow",
                 encrypted_tokens,
@@ -94,6 +131,15 @@ class TemporalService:
         self, response: StandardFormResponse
     ):
         expiration_date = get_formatted_date_from_str(response.expiration)
+        if self._on_postgres("delete_response"):
+            try:
+                await tasks.delete_response.configure(
+                    schedule_at=expiration_date.replace(tzinfo=timezone.utc),
+                    queueing_lock=f"delete_response:{response.response_id}",
+                ).defer_async(response_id=response.response_id)
+            except AlreadyEnqueued as e:
+                loguru.logger.info(e)
+            return
         try:
             await self.check_temporal_client_and_try_to_connect_if_not_connected()
             await self.temporal_client.create_schedule(
@@ -124,6 +170,15 @@ class TemporalService:
             loguru.logger.error(e)
 
     async def delete_response_delete_schedule(self, response_id: str):
+        if self._on_postgres("delete_response"):
+            pending = await self.jobs.job_manager.list_jobs_async(
+                queueing_lock=f"delete_response:{response_id}", status="todo"
+            )
+            for job in pending:
+                await self.jobs.job_manager.cancel_job_by_id_async(
+                    job.id, delete_job=True
+                )
+            return
         try:
             await self.check_temporal_client_and_try_to_connect_if_not_connected()
             schedule_id = "delete_response_" + response_id
@@ -154,6 +209,20 @@ class TemporalService:
             user_email=response.dataOwnerIdentifier if response is not None else "",
             workspace=workspace.json(),
         )
+        lock = (
+            "action_" + str(action.id) + str(form.form_id) + str(response.response_id)
+        )
+        if self._on_postgres("run_action"):
+            try:
+                await tasks.run_action_deferrer(queueing_lock=lock).defer_async(
+                    **asdict(run_action_params)
+                )
+                return "Job Started"
+            except AlreadyEnqueued:
+                raise HTTPException(
+                    status_code=HTTPStatus.CONFLICT,
+                    content="Workflow has already started.",
+                )
         try:
             await self.check_temporal_client_and_try_to_connect_if_not_connected()
             await self.temporal_client.start_workflow(

--- a/backend/backend/app/services/workspace_form_service.py
+++ b/backend/backend/app/services/workspace_form_service.py
@@ -4,7 +4,6 @@ import re
 from http import HTTPStatus
 from typing import List, Optional, Any
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from beanie import PydanticObjectId
 from common.configs.crypto import Crypto
 from common.constants import MESSAGE_NOT_FOUND, MESSAGE_FORBIDDEN
@@ -66,7 +65,6 @@ class WorkspaceFormService:
         form_repo: FormRepository,
         form_schedular: FormSchedular,
         form_import_service: FormImportService,
-        schedular: AsyncIOScheduler,
         form_response_service: FormResponseService,
         responder_groups_service: ResponderGroupsService,
         user_tags_service: UserTagsService,
@@ -85,7 +83,6 @@ class WorkspaceFormService:
         self.form_template_repo = form_template_repo
         self.form_schedular = form_schedular
         self.form_import_service = form_import_service
-        self.schedular = schedular
         self.form_response_service = form_response_service
         self.responder_groups_service = responder_groups_service
         self.user_tags_service = user_tags_service

--- a/backend/backend/jobs/__init__.py
+++ b/backend/backend/jobs/__init__.py
@@ -1,0 +1,8 @@
+"""Background jobs on Postgres (procrastinate) — plans/postgres-consolidation.md §7.
+
+Three job kinds exist today (Temporal): ``delete_user``, ``delete_response``
+(scheduled at the response's expiration) and ``run_action`` (executed by the
+actions-executor process on its own queue). ``JOBS_BACKEND`` / ``JOBS_BACKEND__<job>``
+choose, per job kind, whether TemporalService starts a Temporal workflow or
+defers a procrastinate job; the default stays ``temporal`` through R1.
+"""

--- a/backend/backend/jobs/app.py
+++ b/backend/backend/jobs/app.py
@@ -1,0 +1,45 @@
+"""The procrastinate application: one per process, connected lazily.
+
+Constructing the App does not connect; ``open_async`` does, and the backend
+only opens it when some job kind is routed to Postgres. The queue tables live
+in the ``jobs`` schema (postgres/init): the connection pins ``search_path`` to
+it so procrastinate's unqualified table names resolve there for every role.
+"""
+
+from __future__ import annotations
+
+import os
+
+from procrastinate import App, PsycopgConnector
+
+from common.db.flags import DbFlags, JobsBackend
+
+DEFAULT_QUEUE = "default"
+ACTIONS_QUEUE = "actions"
+JOB_NAMES = ("delete_user", "delete_response", "run_action")
+SEARCH_PATH_OPTIONS = "-c search_path=jobs"
+
+
+def libpq_url(url: str) -> str:
+    """``postgresql+asyncpg://…`` (SQLAlchemy) → ``postgresql://…`` (libpq/psycopg)."""
+    scheme, _, rest = url.partition("://")
+    return f"{scheme.split('+')[0]}://{rest}"
+
+
+def build_connector(database_url: str | None) -> PsycopgConnector:
+    return PsycopgConnector(
+        conninfo=libpq_url(database_url) if database_url else "",
+        kwargs={"options": SEARCH_PATH_OPTIONS},
+        min_size=int(os.environ.get("JOBS_POOL_MIN", "1")),
+        max_size=int(os.environ.get("JOBS_POOL_MAX", "4")),
+    )
+
+
+def postgres_jobs_enabled(flags: DbFlags) -> bool:
+    return any(flags.jobs_backend(job) is JobsBackend.POSTGRES for job in JOB_NAMES)
+
+
+app = App(
+    connector=build_connector(os.environ.get("DATABASE_URL")),
+    import_paths=["backend.jobs.tasks"],
+)

--- a/backend/backend/jobs/schema.py
+++ b/backend/backend/jobs/schema.py
@@ -1,0 +1,31 @@
+"""Apply procrastinate's schema into the ``jobs`` schema, once.
+
+``python -m backend.jobs.schema`` — run at deploy after Alembic (deploy.sh),
+as the backend's role (bc_app owns ``jobs``). Idempotent: a no-op when the
+queue table already exists, so it cannot hang or half-apply a second time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from backend.jobs.app import app
+
+
+async def ensure_schema() -> bool:
+    """Returns True when the schema was applied, False when it was present."""
+    async with app.open_async():
+        row = await app.connector.execute_query_one_async(
+            "SELECT to_regclass('jobs.procrastinate_jobs') AS queue_table"
+        )
+        if row["queue_table"] is not None:
+            return False
+        await app.schema_manager.apply_schema_async()
+        return True
+
+
+if __name__ == "__main__":
+    applied = asyncio.run(ensure_schema())
+    print("procrastinate schema applied" if applied else "procrastinate schema present")
+    sys.exit(0)

--- a/backend/backend/jobs/tasks.py
+++ b/backend/backend/jobs/tasks.py
@@ -1,0 +1,71 @@
+"""Job bodies. They call the same service methods the Temporal workers reach
+today over HTTP (``/auth/user``, ``/temporal/delete/submissions/…``) — in
+process, no HTTP hop, no API key. ``run_action`` is deliberately *not* defined
+here: the backend only defers it by name; the actions-executor process owns
+the body (temporal/actions-executor/procrastinate_worker.py) and is the only
+consumer of the ``actions`` queue.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+import jwt
+from procrastinate import RetryStrategy
+
+from backend.app.models.dataclasses.user_tokens import UserTokens
+from backend.app.services.user_service import get_user_from_token
+from backend.config import settings
+from backend.jobs.app import ACTIONS_QUEUE, DEFAULT_QUEUE, app
+
+RUN_ACTION = "run_action"
+
+
+def _container():
+    from backend.app.container import container  # at call time: importing app boots it
+
+    return container
+
+
+@app.task(
+    name="delete_user",
+    queue=DEFAULT_QUEUE,
+    retry=RetryStrategy(max_attempts=4, exponential_wait=2),
+)
+async def delete_user(encrypted_tokens: str, user_id: str) -> str:
+    """The user's workspaces, forms, integrations and auth record — what the
+    Temporal `delete_user` activity did via DELETE /auth/user with the user's
+    own tokens; the tokens travel encrypted exactly as before."""
+    container = _container()
+    tokens = UserTokens(**json.loads(container.crypto().decrypt(encrypted_tokens)))
+    user = get_user_from_token(tokens.access_token)
+    await container.auth_service().delete_user(user=user)
+    claims = jwt.decode(
+        tokens.refresh_token,
+        key=settings.auth_settings.JWT_SECRET,
+        algorithms=["HS256"],
+    )
+    await container.blacklisted_refresh_token_repo().add(
+        token=tokens.refresh_token, expiry=claims.get("exp")
+    )
+    return "User Deleted Successfully"
+
+
+@app.task(
+    name="delete_response",
+    queue=DEFAULT_QUEUE,
+    retry=RetryStrategy(max_attempts=4, exponential_wait=2),
+)
+async def delete_response(response_id: str) -> str:
+    """Scheduled at the response's expiration (`schedule_at`); one-shot, so
+    unlike the Temporal path there is no schedule left to delete afterwards."""
+    await _container().form_response_service().delete_response(response_id=response_id)
+    return response_id
+
+
+def run_action_deferrer(queueing_lock: str):
+    """Defer ``run_action`` to the actions queue without importing its body."""
+    return app.configure_task(
+        name=RUN_ACTION, queue=ACTIONS_QUEUE, queueing_lock=queueing_lock
+    )

--- a/backend/backend/jobs/worker.py
+++ b/backend/backend/jobs/worker.py
@@ -1,0 +1,47 @@
+"""The backend's job worker: ``python -m backend.jobs.worker``.
+
+Same image and configuration as the API; boots the container (Beanie, the
+Postgres engine, the outbox) and consumes the ``default`` queue — never
+``actions``, which belongs to the actions-executor. Concurrency is small on
+purpose (jobs are deletions).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dependency_injector import providers
+from loguru import logger
+from pymongo import AsyncMongoClient
+
+from backend.app.container import container
+from backend.app.handlers.database import close_db, init_db
+from backend.app.utils import AiohttpClient
+from backend.config import settings
+from backend.db.startup import check_postgres_at_startup, dispose_postgres
+from backend.jobs.app import DEFAULT_QUEUE, app
+
+
+async def main() -> None:
+    queues = [q for q in os.environ.get("JOBS_QUEUES", DEFAULT_QUEUE).split(",") if q]
+    concurrency = int(os.environ.get("JOBS_CONCURRENCY", "4"))
+    AiohttpClient.get_aiohttp_client()
+    client = AsyncMongoClient(settings.mongo_settings.URI)
+    container.database_client.override(providers.Object(client))
+    await init_db(settings.mongo_settings.DB, client)
+    await check_postgres_at_startup(container)
+    logger.info("jobs worker: queues={} concurrency={}", queues, concurrency)
+    try:
+        async with app.open_async():
+            await app.run_worker_async(
+                queues=queues, concurrency=concurrency, install_signal_handlers=True
+            )
+    finally:
+        await close_db(client)
+        await dispose_postgres(container)
+        await AiohttpClient.close_aiohttp_client()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "boto3>=1.43.40",
     "python-multipart>=0.0.22",
     "cryptography>=50.0.0",
-    "apscheduler>=3.11.3",
     "fastapi-pagination>=0.15.10",
     "python-whois>=0.9.6",
     "camel-converter>=5.1.0",
@@ -39,6 +38,7 @@ dependencies = [
     "pymongo>=4.17.0",
     "pydantic-settings>=2.13.0",
     "mcp>=1.28.1",
+    "procrastinate>=3.9,<4",
 ]
 
 [dependency-groups]

--- a/backend/tests/app/jobs/test_jobs.py
+++ b/backend/tests/app/jobs/test_jobs.py
@@ -1,0 +1,132 @@
+"""Jobs on Postgres: what TemporalService defers when JOBS_BACKEND routes a job
+kind to procrastinate, and what the job bodies do when a worker runs them.
+Uses procrastinate's in-memory connector — no queue database needed."""
+
+import datetime as dt
+from dataclasses import asdict
+
+import pytest
+from beanie import PydanticObjectId
+from procrastinate.testing import InMemoryConnector
+
+from backend.app.container import container
+from backend.app.models.dataclasses.user_tokens import UserTokens
+from backend.app.services.temporal_service import TemporalService
+from backend.jobs import tasks
+from backend.jobs.app import (
+    ACTIONS_QUEUE,
+    DEFAULT_QUEUE,
+    app,
+    libpq_url,
+    postgres_jobs_enabled,
+)
+from common.db import load_flags
+from common.models.standard_form import StandardFormResponse
+from tests.app.controllers.data import formResponse, testUser
+
+
+@pytest.fixture
+def memory_jobs():
+    connector = InMemoryConnector()
+    with app.replace_connector(connector):
+        yield connector
+
+
+def service(flags_env):
+    return TemporalService(
+        server_uri="unused:7233",
+        namespace="default",
+        crypto=container.crypto(),
+        flags=load_flags(flags_env),
+        jobs=app,
+    )
+
+
+def test_libpq_url_strips_the_sqlalchemy_driver():
+    assert (
+        libpq_url("postgresql+asyncpg://u:p@h:5432/db") == "postgresql://u:p@h:5432/db"
+    )
+    assert libpq_url("postgresql://u:p@h/db") == "postgresql://u:p@h/db"
+
+
+def test_jobs_app_is_opened_only_when_a_job_kind_uses_postgres():
+    assert not postgres_jobs_enabled(load_flags({}))
+    assert postgres_jobs_enabled(
+        load_flags({"JOBS_BACKEND__delete_response": "postgres"})
+    )
+    assert postgres_jobs_enabled(load_flags({"JOBS_BACKEND": "postgres"}))
+
+
+async def test_response_deletion_is_scheduled_at_expiration_and_cancellable(
+    memory_jobs,
+):
+    svc = service({"JOBS_BACKEND__delete_response": "postgres"})
+    response = StandardFormResponse(
+        response_id="r1", expiration="2031-01-02T03:04:05.000Z", answers={}
+    )
+    await svc.add_scheduled_job_for_deleting_response(response)
+    await svc.add_scheduled_job_for_deleting_response(response)  # queueing lock: once
+    jobs = list(memory_jobs.jobs.values())
+    assert len(jobs) == 1
+    job = jobs[0]
+    assert job["task_name"] == "delete_response" and job["queue_name"] == DEFAULT_QUEUE
+    assert job["args"] == {"response_id": "r1"}
+    assert job["scheduled_at"] == dt.datetime(
+        2031, 1, 2, 3, 4, 5, tzinfo=dt.timezone.utc
+    )
+    assert job["queueing_lock"] == "delete_response:r1"
+    await svc.delete_response_delete_schedule("r1")
+    assert [j for j in memory_jobs.jobs.values() if j["status"] == "todo"] == []
+    await svc.delete_response_delete_schedule("r1")  # nothing to cancel is fine
+
+
+async def test_user_deletion_is_deferred_once_with_encrypted_tokens(memory_jobs):
+    svc = service({"JOBS_BACKEND__delete_user": "postgres"})
+    tokens = UserTokens(access_token="access-token-secret", refresh_token="refresh-token-secret")
+    assert await svc.start_user_deletion_workflow(tokens, "u1") == "Job Started"
+    assert (
+        await svc.start_user_deletion_workflow(tokens, "u1") is None
+    )  # already queued
+    (job,) = memory_jobs.jobs.values()
+    assert job["task_name"] == "delete_user" and job["args"]["user_id"] == "u1"
+    assert (
+        "access-token-secret" not in job["args"]["encrypted_tokens"]
+    )  # travels encrypted, as with Temporal
+    assert container.crypto().decrypt(job["args"]["encrypted_tokens"])
+
+
+async def test_run_action_is_deferred_by_name_to_the_actions_queue(memory_jobs):
+    svc = service({"JOBS_BACKEND__run_action": "postgres"})
+    params = {
+        "action": '{"id": "x"}',
+        "form": "{}",
+        "response": "{}",
+        "user_email": "e",
+        "workspace": "{}",
+    }
+    await tasks.run_action_deferrer(queueing_lock="action_1").defer_async(**params)
+    (job,) = memory_jobs.jobs.values()
+    assert job["task_name"] == tasks.RUN_ACTION and job["queue_name"] == ACTIONS_QUEUE
+    assert job["args"] == params
+
+
+async def test_temporal_stays_the_default(memory_jobs):
+    svc = service({})
+    assert not svc._on_postgres("delete_user")
+    assert not svc._on_postgres("run_action")
+
+
+async def test_delete_response_job_deletes_the_response(
+    memory_jobs, workspace, workspace_form_response_for_test
+):
+    response_id = workspace_form_response_for_test["response_id"]
+    assert await container.form_response_repo().get_response(response_id) is not None
+    svc = service({"JOBS_BACKEND__delete_response": "postgres"})
+    await svc.add_scheduled_job_for_deleting_response(
+        StandardFormResponse(
+            response_id=response_id, expiration="2020-01-01T00:00:00.000Z", answers={}
+        )
+    )
+    await app.run_worker_async(wait=False, install_signal_handlers=False)
+    assert await container.form_response_repo().get_response(response_id) is None
+    assert [j["status"] for j in memory_jobs.jobs.values()] == ["succeeded"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -246,15 +246,15 @@ wheels = [
 ]
 
 [[package]]
-name = "apscheduler"
-version = "3.11.3"
+name = "asgiref"
+version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzlocal" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/6b/eeff360196bb20b312c9e762a820fd1b2c6d809466c755ef57863478e454/apscheduler-3.11.3.tar.gz", hash = "sha256:cd2fcc9330039a81a5893472ad49facf23a6d5604cbe1d918c835c6de7834d5a", size = 110312, upload-time = "2026-06-28T19:39:22.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/c9/8638db32514dbb9157b3d82680c6faea89283523edf9ed2415ea3884f2ae/apscheduler-3.11.3-py3-none-any.whl", hash = "sha256:bbeb2ec02d23d3c06a6c07ed7f0f3939ada6680eb121fae809a69bb42c537a30", size = 66024, upload-time = "2026-06-28T19:39:20.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
 ]
 
 [[package]]
@@ -340,7 +340,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "apscheduler" },
     { name = "base58" },
     { name = "beanie" },
     { name = "boto3" },
@@ -360,6 +359,7 @@ dependencies = [
     { name = "loguru" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "procrastinate" },
     { name = "pycryptodome" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
@@ -385,7 +385,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.3" },
-    { name = "apscheduler", specifier = ">=3.11.3" },
     { name = "base58", specifier = ">=2.1.1" },
     { name = "beanie", specifier = ">=2.1.0" },
     { name = "boto3", specifier = ">=1.43.40" },
@@ -405,6 +404,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "openai", specifier = ">=2.44.0" },
+    { name = "procrastinate", specifier = ">=3.9,<4" },
     { name = "pycryptodome", specifier = ">=3.23.0" },
     { name = "pydantic-settings", specifier = ">=2.13.0" },
     { name = "pyjwt", specifier = ">=2.11.0" },
@@ -757,6 +757,18 @@ dev = [
     { name = "black", specifier = ">=26.1.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.4.0" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
 ]
 
 [[package]]
@@ -2022,6 +2034,24 @@ wheels = [
 ]
 
 [[package]]
+name = "procrastinate"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "attrs" },
+    { name = "croniter" },
+    { name = "packaging" },
+    { name = "psycopg", extra = ["pool"] },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/bc/adfe64992725143791ea78c33e9a0778a97f67c0ca8761bb6fd269fbb0be/procrastinate-3.9.0.tar.gz", hash = "sha256:5805ab2af35eab12befa700ecd49e572c4f655d654151df9e5ce1ca07efb5e6e", size = 89448, upload-time = "2026-06-20T23:09:14.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/0c/17bfd406fe4bf85e8a0cfbb9744271df447004233da295fb6e2c10dc29e1/procrastinate-3.9.0-py3-none-any.whl", hash = "sha256:af4b9ccaeebbf2a1439e02ae1e8ce327f8436a81e9d68a0b1bd26d5e7ac697bd", size = 153597, upload-time = "2026-06-20T23:09:13.105Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2173,6 +2203,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/f5/2aa3a4acdc1e5940b59d421742356f133185667dd190b166dbcfcf5d7b43/psutil-5.9.8-cp37-abi3-win32.whl", hash = "sha256:bc56c2a1b0d15aa3eaa5a60c9f3f8e3e565303b465dbf57a1b730e7a2b9844e0", size = 251252, upload-time = "2024-01-19T20:47:52.88Z" },
     { url = "https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl", hash = "sha256:8db4c1b57507eef143a15a6884ca10f7c73876cdf5d51e713151c1236a0e68cf", size = 255090, upload-time = "2024-01-19T20:47:56.019Z" },
     { url = "https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8", size = 249898, upload-time = "2024-01-19T20:47:59.238Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -3364,18 +3424,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/deploy.sh
+++ b/deploy.sh
@@ -67,6 +67,8 @@ function dockerup() {
   "$docker_compose_cmd" -f "docker-compose.deployment.yml" pull -q backend auth $([ "$googleform_flag" = true ] && echo integrations-googleform)
   "$docker_compose_cmd" -f "docker-compose.deployment.yml" up -d --wait app-postgres
   "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps backend /api/backend/.venv/bin/alembic -c /api/backend/alembic.ini upgrade head
+  # procrastinate's queue tables (jobs schema), applied once; a no-op afterwards
+  "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps backend /api/backend/.venv/bin/python -m backend.jobs.schema
   "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps auth /api/auth/.venv/bin/alembic -c /api/auth/alembic.ini upgrade head
   if [ "$googleform_flag" = true ]; then
     "$docker_compose_cmd" -f "docker-compose.deployment.yml" run --rm --no-deps integrations-googleform alembic -c /api/integrations/google/alembic.ini upgrade head

--- a/docker-compose.deployment.yml
+++ b/docker-compose.deployment.yml
@@ -185,6 +185,26 @@ services:
       retries: 20
       start_period: 15s
 
+  # Consumes the procrastinate `default` queue (delete_user, delete_response) when
+  # JOBS_BACKEND routes those to Postgres; same image and env as the backend.
+  jobs-worker:
+    image: bettercollected/backend:nightly
+    command: ["/api/backend/.venv/bin/python", "-m", "backend.jobs.worker"]
+    environment:
+      AUTH_BASE_URL: http://auth:8000/api/v1
+      AUTH_CALLBACK_URI: http://auth:8000/api/v1/auth/callback
+      # Backend reaches Umami over the compose network; only UMAMI_USERNAME/
+      # UMAMI_PASSWORD/UMAMI_WEBSITE_ID need to come from .env.deployment.
+      UMAMI_URL: http://umami:3000
+      DATABASE_URL: postgresql+asyncpg://bc_app:${BC_APP_PASSWORD}@app-postgres:5432/bettercollected
+    env_file:
+      - .env.deployment
+    depends_on:
+      app-postgres:
+        condition: service_healthy
+      mongodb:
+        condition: service_healthy
+
   auth:
     image: bettercollected/auth:nightly
     # image: bettercollected/auth:nightly

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,8 +96,10 @@ creates **Schedules** on the Temporal server (PostgreSQL-backed). Three worker s
 | `temporal/csv-worker` | `ExportCSVWorkflow` | `export_as_csv` | Export form responses to CSV |
 | `temporal/actions-executor` | `RunActionCode` | `run_action_code` | Execute user-defined form-action / automation code |
 
-The backend can migrate legacy **APScheduler** jobs into Temporal Schedules on startup
-(`migrate_schedule_to_temporal()`, gated by temporal settings).
+Each job kind can instead run as a **procrastinate** job on Postgres (`JOBS_BACKEND__<job>=postgres`, tables in the
+`jobs` schema): the backend's `jobs-worker` consumes `delete_user` / `delete_response`, the actions-executor consumes
+`run_action` (`JOBS_BACKEND=postgres` in its entrypoint). Temporal stays the default until the cutover
+(plan: [plans/postgres-consolidation.md](../plans/postgres-consolidation.md) §7).
 
 ## Example end-to-end flows
 
@@ -106,7 +108,7 @@ The backend can migrate legacy **APScheduler** jobs into Temporal Schedules on s
 2. Backend `plugin_proxy` forwards to the google microservice (:8003), or enqueues an `ImportFormWorkflow` on Temporal.
 3. The google service (or the `import_form` activity) calls Google Forms + Drive APIs, converts the result via
    `POST /google/convert/standard_form`, and the form is stored as a `StandardForm` (`FormDocument`) under the workspace.
-4. Recurring re-imports are managed as Temporal Schedules.
+4. A re-import is triggered through the backend's `/temporal/import/{workspace_id}/form/{form_id}` callback.
 
 **Submitting a response (with consent)**
 1. Responder loads the public form (webapp `app/forms/[form_id]`), reviews the declared purpose/consent.
@@ -119,7 +121,7 @@ The backend can migrate legacy **APScheduler** jobs into Temporal Schedules on s
 
 - **MongoDB** — all application data via Beanie Documents. Backend collections are registered in
   [backend/app/handlers/database.py](../backend/backend/app/handlers/database.py) `init_db`; core models come from
-  `common/`. A separate `apscheduler` DB holds `APSchedulerDocument`.
+  `common/`.
 - **PostgreSQL (`app-postgres`)** — the application database that is replacing MongoDB and Temporal
   (plan: [plans/postgres-consolidation.md](../plans/postgres-consolidation.md)). One database, one schema per
   service (`app`, `auth`, `google`, `jobs`), one least-privilege role each — the actions-executor's role can reach

--- a/temporal/actions-executor/main.py
+++ b/temporal/actions-executor/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import random
 import string
 
@@ -36,4 +37,11 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # JOBS_BACKEND=postgres: consume the procrastinate `actions` queue instead
+    # of Temporal (plans/postgres-consolidation.md §7). Temporal stays default.
+    if os.environ.get("JOBS_BACKEND", "temporal").lower() == "postgres":
+        from procrastinate_worker import main as run_procrastinate
+
+        asyncio.run(run_procrastinate())
+    else:
+        asyncio.run(main())

--- a/temporal/actions-executor/procrastinate_worker.py
+++ b/temporal/actions-executor/procrastinate_worker.py
@@ -1,0 +1,58 @@
+"""The actions-executor as a procrastinate worker (plans/postgres-consolidation.md §7).
+
+Consumes the ``actions`` queue only, connecting as the ``bc_jobs_exec`` role
+whose search_path is the ``jobs`` schema (it can reach the queue tables and
+nothing else). The backend defers ``run_action`` by name; the body is here,
+the same ``run_action`` the Temporal activity wraps. Selected by
+``JOBS_BACKEND=postgres`` in main.py; the Temporal worker remains the default.
+"""
+
+import asyncio
+import os
+
+from procrastinate import App, PsycopgConnector, RetryStrategy
+
+from utilities.actions import run_action
+
+ACTIONS_QUEUE = "actions"
+
+
+def libpq_url(url: str) -> str:
+    scheme, _, rest = url.partition("://")
+    return f"{scheme.split('+')[0]}://{rest}"
+
+
+app = App(
+    connector=PsycopgConnector(
+        conninfo=libpq_url(os.environ.get("DATABASE_URL", "")),
+        kwargs={"options": "-c search_path=jobs"},
+        min_size=1,
+        max_size=int(os.environ.get("JOBS_POOL_MAX", "4")),
+    )
+)
+
+
+@app.task(name="run_action", queue=ACTIONS_QUEUE, retry=RetryStrategy(max_attempts=2))
+async def run_action_job(
+    action: str, form: str, response: str, user_email=None, workspace=None
+):
+    return await run_action(
+        action=action,
+        form=form,
+        response=response,
+        user_email=user_email,
+        workspace=workspace,
+    )
+
+
+async def main() -> None:
+    async with app.open_async():
+        await app.run_worker_async(
+            queues=[ACTIONS_QUEUE],
+            concurrency=int(os.environ.get("JOBS_CONCURRENCY", "4")),
+            install_signal_handlers=True,
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/temporal/actions-executor/pyproject.toml
+++ b/temporal/actions-executor/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "email-validator>=2.3.0",
     "pydantic==2.13.4",
     "protobuf==7.35.1",
+    "procrastinate>=3.9,<4",
 ]
 
 [dependency-groups]

--- a/temporal/actions-executor/uv.lock
+++ b/temporal/actions-executor/uv.lock
@@ -19,6 +19,7 @@ dependencies = [
     { name = "google-auth" },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "procrastinate" },
     { name = "protobuf" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -42,6 +43,7 @@ requires-dist = [
     { name = "google-auth", specifier = "==2.55.1" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "jinja2", specifier = "==3.1.6" },
+    { name = "procrastinate", specifier = ">=3.9,<4" },
     { name = "protobuf", specifier = "==7.35.1" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
@@ -84,6 +86,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "asgiref"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/26/3b59f2bdae5f640389becb1f673cded775287f5fc4f816309d9ca9a3f93d/asgiref-3.12.1.tar.gz", hash = "sha256:59dcb51c272ad209d59bed5708a64a333083e86017d7fcdd67498eeab7784340", size = 42378, upload-time = "2026-07-14T09:56:18.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/1b/54f4ad77cd8a584fa70746c47df988e002cf1ee1eba43364d46f87803647/asgiref-3.12.1-py3-none-any.whl", hash = "sha256:fe386d1c2bff7259ea95929266d12a8cf9a8b5a1c2598402967d8792e7a7c094", size = 25478, upload-time = "2026-07-14T09:56:16.926Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -303,6 +323,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
 ]
 
 [[package]]
@@ -692,6 +724,24 @@ wheels = [
 ]
 
 [[package]]
+name = "procrastinate"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asgiref" },
+    { name = "attrs" },
+    { name = "croniter" },
+    { name = "packaging" },
+    { name = "psycopg", extra = ["pool"] },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/bc/adfe64992725143791ea78c33e9a0778a97f67c0ca8761bb6fd269fbb0be/procrastinate-3.9.0.tar.gz", hash = "sha256:5805ab2af35eab12befa700ecd49e572c4f655d654151df9e5ce1ca07efb5e6e", size = 89448, upload-time = "2026-06-20T23:09:14.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/0c/17bfd406fe4bf85e8a0cfbb9744271df447004233da295fb6e2c10dc29e1/procrastinate-3.9.0-py3-none-any.whl", hash = "sha256:af4b9ccaeebbf2a1439e02ae1e8ce327f8436a81e9d68a0b1bd26d5e7ac697bd", size = 153597, upload-time = "2026-06-20T23:09:13.105Z" },
+]
+
+[[package]]
 name = "proto-plus"
 version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +766,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
     { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
     { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+pool = [
+    { name = "psycopg-pool" },
+]
+
+[[package]]
+name = "psycopg-pool"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/82/7a23d26039827ecd4ebe93905651029ddd307c5182ad59296dfb6f67b528/psycopg_pool-3.3.1.tar.gz", hash = "sha256:b10b10b7a175d5cc1592147dc5b7eec8a9e0834eb3ed2c4a92c858e2f51eb63c", size = 31661, upload-time = "2026-05-01T23:31:59.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/ed/89c2c620af0e1660354cd8aabf9f5b21f911597ce22acb37c805d6c86bc8/psycopg_pool-3.3.1-py3-none-any.whl", hash = "sha256:2af5b432941c4c9ad5c87b3fa410aec910ec8f7c122855897983a06c45f2e4b5", size = 40023, upload-time = "2026-05-01T23:31:53.136Z" },
 ]
 
 [[package]]
@@ -889,6 +969,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1051,6 +1143,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1110,6 +1211,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Plan step 9 (`plans/postgres-consolidation.md` §7): the Temporal replacement. **Temporal stays the default**; each of the three job kinds can be routed to Postgres independently with `JOBS_BACKEND__delete_user` / `__delete_response` / `__run_action` `=postgres` (or `JOBS_BACKEND=postgres` for all). Flips take effect on restart, like the store flags.

## What

- **`backend/jobs/`** — the procrastinate `App` (constructed at import, connects lazily; the connection pins `search_path=jobs` so the queue tables resolve in the `jobs` schema for every role), the tasks, the worker and the schema entrypoints:
  - `delete_user(encrypted_tokens, user_id)` and `delete_response(response_id)` call the same service methods the Temporal workers reach today over HTTP (`DELETE /auth/user`, `/temporal/delete/submissions/…`) — in process, no HTTP hop, no API key. Retry 4 with exponential backoff; **queueing locks** (`delete_user:<uid>`, `delete_response:<rid>`) make deferral idempotent, matching Temporal's workflow-id semantics.
  - `run_action` is **deferred by name** to the `actions` queue; its body lives in the actions-executor (below), the only consumer of that queue.
  - `python -m backend.jobs.worker` (default queue) · `python -m backend.jobs.schema` (idempotent apply of procrastinate's tables; `deploy.sh` runs it after Alembic).
- **`TemporalService` dispatches per job kind** through the flags; callers unchanged. Scheduled response deletion becomes `schedule_at=<expiration UTC>`; cancelling finds the pending job by queueing lock. The API opens the queue pool only when a job kind is routed to Postgres.
- **actions-executor**: `procrastinate_worker.py` — the `run_action` body on the `actions` queue as the `bc_jobs_exec` role (search_path `jobs`, nothing else reachable); `main.py` selects it with `JOBS_BACKEND=postgres`.
- **`jobs-worker`** compose service from the backend image.

## APScheduler removed — it was dead

Nothing in the repository ever called `add_job`. The `AsyncIOScheduler` and its Mongo `MongoDBJobStore` were instantiated and never used (the local Mongo has no `jobs` collection either), and `FormSchedular.update_form` is only reachable through the `/temporal/import/…` callback that the plan already identified as producer-less. So there is nothing to port: the dependency, the container providers and the `WorkspaceFormService` parameter go. `SchedulerFormConfigDocument`/`Row` and `APSchedulerDocument` stay for the R3 cleanup. `backend/AGENTS.md` and `docs/ARCHITECTURE.md` described the scheduler — and two functions that no longer exist (`migrate_schedule_to_temporal`, `init_scheduler_db`) — and are corrected.

## Not in this PR

- The actions-executor isn't in `docker-compose.deployment.yml` today (plan open question 3), so no deployment service is added for it here — only the entrypoint.
- Periodic housekeeping (outbox reconcile, expiration sweep) and the `procrastinate` tables' retention come with the migration CLI (PR 11).

## Verification

Backend ×3 (default / all mirrored / all served from Postgres): **319 passed**, 6 skipped each — 7 new tests on procrastinate's in-memory connector cover what gets deferred (task, queue, args, schedule, lock), lock idempotency, cancellation, and a worker actually deleting a response. The executor's worker module imports and registers `run_action`.
