### PR TITLE
feat: persistence observability, outbox redaction, and the Persistence docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Public site: https://bettercollected.com · License: see [LICENSE](LICENSE).
 | Path | Stack | Port | Role |
 |---|---|---|---|
 | [webapp/](webapp/) | Next.js 14 + TS, Redux Toolkit / RTK Query | 3000 | All UI: builder, dashboards, responder portal, billing |
-| [backend/](backend/) | FastAPI + Beanie (MongoDB) | 8000 | Core API — the hub everything routes through |
+| [backend/](backend/) | FastAPI + Beanie (MongoDB) + SQLAlchemy (PostgreSQL) | 8000 | Core API — the hub everything routes through |
 | [auth/](auth/) | FastAPI + fastapi-users + Stripe | 8001 | Identity (OAuth / email-OTP / JWT) + Stripe billing |
 | [integrations/google/](integrations/google/) | FastAPI + Google APIs | 8003 | Google Forms/Drive/Sheets provider microservice |
 | `integrations/typeform/` | FastAPI (Typeform APIs) | 8002 | Typeform provider microservice — **not checked out in this clone** |
@@ -57,8 +57,11 @@ See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for request-level data flow.
 ## Layering conventions
 
 - **Python (FastAPI) services** follow `fastapi-mvc`: **Controllers** (class-based via `classy-fastapi`) →
-  **Services** (business logic, wired by `dependency-injector`) → **Repositories** → **Beanie Documents** (MongoDB).
-  Put business logic in services, DB access in repositories, HTTP shape in controllers. Do not query Mongo from a controller.
+  **Services** (business logic, wired by `dependency-injector`) → **Repositories** (routed: a Mongo implementation and
+  its Postgres twin behind one `RoutingRepository`, chosen per group by `DB_*` flags — see `backend/AGENTS.md`
+  "Persistence") → **Beanie Documents** (MongoDB) / **rows** (PostgreSQL, `<service>/db/models.py`).
+  Put business logic in services, DB access in repositories, HTTP shape in controllers. Never query a store from a
+  controller or service.
 - **Frontend** is Redux Toolkit + **RTK Query** for all server state (~16 API slices, all against `/api/v1`), plain
   slices + Jotai for client state. Add server calls as RTK Query endpoints, not ad-hoc `fetch`.
 

--- a/auth/auth/app/asgi.py
+++ b/auth/auth/app/asgi.py
@@ -1,5 +1,6 @@
 """Application implementation - ASGI."""
 
+import json
 import logging
 
 import auth
@@ -35,6 +36,10 @@ async def on_startup():
     log.debug("Execute FastAPI startup event handler.")
     database_client = container.database_client()
     await init_db(database_client)
+    log.info(
+        "persistence flags: %s",
+        json.dumps(container.flags().describe(["auth"]), sort_keys=True),
+    )
     await check_postgres_at_startup(container.flags(), container.pg_engine())
 
 

--- a/auth/auth/app/container.py
+++ b/auth/auth/app/container.py
@@ -18,6 +18,7 @@ from auth.db.models import MirrorWriteFailure
 from common.db import (
     DatabaseSettings,
     OutboxRecorder,
+    RoutingMetrics,
     RoutingRepository,
     build_engine,
     build_sessionmaker,
@@ -50,6 +51,7 @@ class AppContainer(containers.DeclarativeContainer):
     mirror_timeout_s = providers.Callable(
         lambda s: s.mirror_timeout_ms / 1000, db_settings
     )
+    routing_metrics = providers.Singleton(RoutingMetrics)
 
     provider_repository: ProviderRepository = providers.Singleton(
         RoutingRepository,
@@ -57,6 +59,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(ProviderRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresProviderRepository, pg_sessionmaker
@@ -68,6 +71,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(UserRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresUserRepository, pg_sessionmaker

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -47,11 +47,38 @@ Routers are registered in [backend/app/router.py](backend/app/router.py) via the
 (classy-fastapi Routables) or `register_plugin_class` (the plugin proxy). Follow an existing controller
 (e.g. `workspace_forms.py`) as a template — constructor injection, `self.router` methods, camelCase response models.
 
-## Data / MongoDB
+## Persistence (MongoDB → PostgreSQL, in progress)
+
+Application data lives in MongoDB (Beanie Documents) **and** is moving to PostgreSQL (`app-postgres`, schema `app`);
+plan and decisions in `plans/postgres-consolidation.md`. What that means when you touch data code:
+
+- **Every repository is routed.** The container hands out `RoutingRepository` proxies over a Mongo implementation and
+  its Postgres *twin* (`app/repositories/postgres/*.py`, one class per Mongo repository, same public methods —
+  `tests/app/repositories/test_postgres_surface.py` enforces it). Repositories are grouped (`refdata`, `identity`,
+  `forms`, `responses`, `actions`, `ai`, `analytics`); `DB_READ_SOURCE__<group>` / `DB_WRITE_MODE__<group>`
+  (`mongo|dual|postgres_primary_dual|postgres`) choose the store per group, flips are restarts, and
+  `backend/db/groups.py` declares the cutover order the flags enforce at boot.
+- **Adding or changing a repository method:** implement it on both the Mongo class and the twin, mark writes
+  `@write_op` (`tests/app/repositories/test_write_markers.py` checks the AST), and `@write_op(replay=True)` for a write
+  that mints state the caller didn't pass in (a new document's id, a token) — the mirror then stores the returned
+  document instead of re-running the call. Return the *document* from such writes, not a DTO (`WriteResult` when the
+  return value must differ from what was stored). Relation documents get `derived_object_id` so both stores agree.
+- **Joins:** SQL joins only within a group; a `$lookup` into another group's collection is *composed* through that
+  group's routed repository (see `postgres/forms.py`). Never query Mongo or Postgres from a service or controller.
+- **Rows:** `backend/db/models.py` — one table per collection, typed spine columns `GENERATED` from the `doc` JSONB
+  (query only spine columns; add one + an Alembic revision under `backend/migrations/` when a query needs a new
+  field). Migrations run as the service role (`bc_app`), never as the superuser.
+- **Mirror failures** land in the outbox (`mirror_write_failures`, Mongo doc or Postgres row — whichever store is
+  primary); shadow-read diffs and counters are exposed on `GET /persistence/status` (admin) and the effective flags
+  are logged at boot.
+- **Tests run three ways in CI** (Mongo · everything mirrored · everything served from Postgres). Parity tests
+  (`tests/app/repositories/test_*_parity.py`) run each method on both stores; test fixtures must go through
+  `container.<repo>()`, never Beanie directly, or the Postgres-served mode fails.
 
 Beanie Documents are registered in [backend/app/handlers/database.py](backend/app/handlers/database.py) `init_db`'s
-`document_models` list — **a new collection must be added there or it won't be initialized.** Core domain models
-(`User`, `StandardForm`, `StandardFormResponse`, `Consent`) come from the shared `common` package, not from here.
+`document_models` list — **a new collection must be added there or it won't be initialized** (and needs a row +
+twin as above). Core domain models (`User`, `StandardForm`, `StandardFormResponse`, `Consent`) come from the shared
+`common` package, not from here.
 Background jobs go through `services/temporal_service.py`, which dispatches per job kind (`JOBS_BACKEND__<job>`)
 to a Temporal workflow (default) or a procrastinate job on Postgres (`backend/jobs/`; worker:
 `python -m backend.jobs.worker`, queue tables in the `jobs` schema via `python -m backend.jobs.schema`).
@@ -137,11 +164,13 @@ and architecture.
 
 ```bash
 ./run.sh                 # uvicorn backend.app:get_application --reload :8000  (needs Mongo up first)
-make install             # poetry install
-make test                # unit + integration
-make unit-test | make integration-test | make coverage
-make format              # black
-poetry run flake8 .      # lint
+uv sync                  # install (uv, never pip/poetry)
+DATABASE_URL=postgresql+asyncpg://bettercollected:bettercollected@localhost:5432/bettercollected_test uv run pytest
+# the same suite mirrored / served from Postgres (what CI runs):
+DB_WRITE_MODE=dual ... uv run pytest
+DB_READ_SOURCE=postgres DB_WRITE_MODE=postgres ... uv run pytest
+uv run alembic -c alembic.ini upgrade head   # as the service role (bc_app), see backend/.env.example
+python -m backend.jobs.worker                # procrastinate worker (JOBS_BACKEND=postgres)
 ```
 Prod entry: `backend serve` CLI → gunicorn with uvicorn workers.
 

--- a/backend/backend/app/container.py
+++ b/backend/backend/app/container.py
@@ -12,7 +12,7 @@ from pymongo import AsyncMongoClient
 from backend.app.repositories.ai_preference_memory_repository import (
     AIPreferenceMemoryRepository,
 )
-from common.db import DatabaseSettings, load_flags
+from common.db import DatabaseSettings, RoutingMetrics, load_flags
 from common.db.routing import RoutingRepository
 
 from backend.db.outbox import OutboxRecorder
@@ -157,6 +157,9 @@ class AppContainer(containers.DeclarativeContainer):
     mirror_timeout_s = providers.Callable(
         lambda s: s.mirror_timeout_ms / 1000, db_settings
     )
+    routing_metrics = providers.Singleton(
+        RoutingMetrics
+    )  # shared: counters keyed by group
 
     user_tags_repo = providers.Singleton(
         RoutingRepository,
@@ -164,6 +167,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(UserTagsRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresUserTagsRepository, pg_sessionmaker
@@ -180,6 +184,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(ActionRepository, crypto=crypto),
         postgres=providers.Singleton(
             postgres_repository, PostgresActionRepository, pg_sessionmaker, crypto
@@ -194,6 +199,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         postgres=providers.Singleton(
             postgres_repository, PostgresCouponRepository, pg_sessionmaker
         ),
@@ -205,6 +211,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceUserRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceUserRepository, pg_sessionmaker
@@ -216,6 +223,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceRepository),
         postgres=providers.Singleton(
             postgres_repository,
@@ -230,6 +238,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         postgres=providers.Singleton(
             postgres_repository, PostgresAllowedOriginsRepository, pg_sessionmaker
         ),
@@ -242,6 +251,7 @@ class AppContainer(containers.DeclarativeContainer):
             flags=flags,
             on_mirror_failure=outbox_recorder,
             mirror_timeout_s=mirror_timeout_s,
+            metrics=routing_metrics,
             mongo=providers.Singleton(BlacklistedRefreshTokenRepository),
             postgres=providers.Singleton(
                 postgres_repository,
@@ -257,6 +267,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FlowEventRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresFlowEventRepository, pg_sessionmaker
@@ -268,6 +279,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormAIInsightRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresFormAIInsightRepository, pg_sessionmaker
@@ -279,6 +291,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormAISessionRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresFormAISessionRepository, pg_sessionmaker
@@ -290,6 +303,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceAIProfileRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceAIProfileRepository, pg_sessionmaker
@@ -301,6 +315,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceAPIKeyRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceAPIKeyRepository, pg_sessionmaker
@@ -312,6 +327,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(AIPreferenceMemoryRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresAIPreferenceMemoryRepository, pg_sessionmaker
@@ -324,6 +340,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         postgres=providers.Singleton(
             postgres_repository, PostgresFormPluginProviderRepository, pg_sessionmaker
         ),
@@ -337,6 +354,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormResponseRepository, crypto=crypto),
         postgres=providers.Singleton(
             postgres_repository,
@@ -353,6 +371,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(ResponderGroupsRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresResponderGroupsRepository, pg_sessionmaker
@@ -365,6 +384,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormRepository),
         postgres=providers.Singleton(
             postgres_repository,
@@ -380,6 +400,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceFormRepository),
         postgres=providers.Singleton(
             postgres_repository,
@@ -398,6 +419,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(McpAuditLogRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresMcpAuditLogRepository, pg_sessionmaker
@@ -609,6 +631,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceInvitationRepo),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceInvitationRepo, pg_sessionmaker
@@ -639,6 +662,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceRespondersRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceRespondersRepository, pg_sessionmaker
@@ -656,6 +680,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(WorkspaceConsentRepo),
         postgres=providers.Singleton(
             postgres_repository, PostgresWorkspaceConsentRepo, pg_sessionmaker
@@ -674,6 +699,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormTemplateRepository),
         postgres=providers.Singleton(
             postgres_repository,
@@ -698,6 +724,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         postgres=providers.Singleton(
             postgres_repository, PostgresUserFeedbackRepo, pg_sessionmaker
         ),
@@ -727,6 +754,7 @@ class AppContainer(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(MediaLibraryRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresMediaLibraryRepository, pg_sessionmaker

--- a/backend/backend/app/controllers/persistence_router.py
+++ b/backend/backend/app/controllers/persistence_router.py
@@ -1,0 +1,45 @@
+"""Operator view of the Mongo → Postgres cutover (plans/postgres-consolidation.md §8).
+
+Admin-only. What the flags route where, the routing counters since boot
+(calls, mirror failures, shadow reads/diffs/errors, per group and method),
+the outbox backlog in both stores and whether Postgres answers. The migration
+CLI's `status` prints the same picture; this is the live one.
+"""
+
+from classy_fastapi import get
+from fastapi import Depends
+
+from backend.app.container import container
+from backend.app.router import router
+from backend.app.services.user_service import get_logged_admin
+from backend.app.utils.custom_routable import CustomRoutable
+from backend.db.models import MirrorWriteFailure
+from backend.db.startup import GROUPS
+from backend.jobs.app import JOB_NAMES, postgres_jobs_enabled
+from common.db import metrics_snapshot, outbox_backlog, ping
+from common.models.user import User
+
+
+@router(prefix="/persistence", tags=["Persistence"])
+class PersistenceRouter(CustomRoutable):
+    @get("/status")
+    async def status(self, user: User = Depends(get_logged_admin)):
+        flags = container.flags()
+        engine = container.pg_engine()
+        postgres = {"configured": engine is not None, "reachable": None}
+        if engine is not None:
+            try:
+                await ping(engine)
+                postgres["reachable"] = True
+            except Exception as exc:  # noqa: BLE001 — reported, never raised
+                postgres["reachable"] = False
+                postgres["error"] = type(exc).__name__
+        return {
+            "flags": flags.describe(GROUPS, JOB_NAMES),
+            "jobs_on_postgres": postgres_jobs_enabled(flags),
+            "postgres": postgres,
+            "metrics": metrics_snapshot(container.routing_metrics()),
+            "outbox": await outbox_backlog(
+                container.pg_sessionmaker(), MirrorWriteFailure
+            ),
+        }

--- a/backend/backend/db/outbox.py
+++ b/backend/backend/db/outbox.py
@@ -1,77 +1,16 @@
-"""Record mirror-write failures in the *primary* store (plans/postgres-consolidation.md §6).
-
-The routing layer calls this when replaying a write on the mirror store fails.
-While Mongo is primary the record is a ``MirrorWriteFailureDocument``; once
-Postgres is primary it is a row in ``app.mirror_write_failures``. The
-reconciler (migration CLI) drains both.
-"""
+"""The backend's outbox recorder: :class:`common.db.OutboxRecorder` bound to
+the ``app.mirror_write_failures`` row (plans/postgres-consolidation.md §6)."""
 
 from __future__ import annotations
 
 from typing import Optional
 
-from beanie import Document
-from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from backend.db.models import MirrorWriteFailure
-from common.db import MirrorFailure, MirrorWriteFailureDocument, ReadSource
-
-MAX_IDS = 20
+from common.db import OutboxRecorder as _OutboxRecorder
 
 
-def _ids(args: tuple, kwargs: dict) -> str:
-    """Best-effort: the ids a call touched, from document / id-like arguments."""
-    found: list[str] = []
-    for value in list(args) + list(kwargs.values()):
-        if isinstance(value, Document):
-            if value.id is not None:
-                found.append(str(value.id))
-        elif type(value).__name__ in ("ObjectId", "PydanticObjectId"):
-            found.append(str(value))
-        elif isinstance(value, str) and len(value) <= 64:
-            found.append(value)
-        elif isinstance(value, (list, tuple)):
-            for item in list(value)[:MAX_IDS]:
-                if isinstance(item, Document) and item.id is not None:
-                    found.append(str(item.id))
-                elif isinstance(item, str) and len(item) <= 64:
-                    found.append(item)
-    return ",".join(found[:MAX_IDS]) or "-"
-
-
-def _error(exc: BaseException) -> str:
-    return f"{type(exc).__name__}: {str(exc)[:200]}"
-
-
-class OutboxRecorder:
+class OutboxRecorder(_OutboxRecorder):
     def __init__(self, session_factory: Optional[async_sessionmaker[AsyncSession]]):
-        self._sessions = session_factory
-
-    async def __call__(self, failure: MirrorFailure) -> None:
-        row_id = _ids(failure.args + tuple(failure.documents), failure.kwargs)
-        if failure.store is ReadSource.POSTGRES:
-            # the mirror was Postgres, so Mongo is primary: record there
-            await MirrorWriteFailureDocument(
-                table_name=failure.repository,
-                row_id=row_id,
-                op=failure.method,
-                error=_error(failure.error),
-            ).insert()
-            return
-        if self._sessions is None:
-            logger.error(
-                "mirror to Mongo failed and Postgres is not configured to record it: {} {}",
-                failure.repository,
-                failure.method,
-            )
-            return
-        async with self._sessions() as session, session.begin():
-            session.add(
-                MirrorWriteFailure(
-                    table_name=failure.repository,
-                    row_id=row_id,
-                    op=failure.method,
-                    error=_error(failure.error),
-                )
-            )
+        super().__init__(session_factory, MirrorWriteFailure)

--- a/backend/backend/db/session.py
+++ b/backend/backend/db/session.py
@@ -1,58 +1,24 @@
-"""Postgres engine/session providers for the backend container.
-
-Everything here is a no-op when ``DATABASE_URL`` is unset: the engine provider
-yields ``None``, Postgres repositories are not registered, and the routing
-layer treats the store as absent (plans/postgres-consolidation.md §6).
+"""Postgres engine/session providers for the backend container — thin wrappers
+over :mod:`common.db.runtime`, which every service shares (the backend grew
+them first). Everything is a no-op when ``DATABASE_URL`` is unset.
 """
 
 from __future__ import annotations
 
-from typing import Any, Optional, Type
+from typing import Optional
 
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.ext.asyncio import AsyncEngine
 
-from common.db import DatabaseSettings, make_engine, make_sessionmaker
+from common.db import (
+    DatabaseSettings,
+    LazyRepository,
+    postgres_repository,
+)  # noqa: F401
+from common.db import build_engine as _build_engine
+from common.db import build_sessionmaker  # noqa: F401
 
 APPLICATION_NAME = "bettercollected-backend"
 
 
 def build_engine(settings: DatabaseSettings) -> Optional[AsyncEngine]:
-    if not settings.configured:
-        return None
-    return make_engine(settings, application_name=APPLICATION_NAME)
-
-
-def build_sessionmaker(
-    engine: Optional[AsyncEngine],
-) -> Optional[async_sessionmaker[AsyncSession]]:
-    return None if engine is None else make_sessionmaker(engine)
-
-
-def postgres_repository(
-    cls: Type[Any],
-    session_factory: Optional[async_sessionmaker[AsyncSession]],
-    *args: Any,
-    **kwargs: Any,
-) -> Optional[Any]:
-    """The Postgres twin of a repository, or ``None`` when Postgres is not configured."""
-    return None if session_factory is None else cls(session_factory, *args, **kwargs)
-
-
-class LazyRepository:
-    """Resolve a routed repository at first use, not at construction.
-
-    The forms and responses twins compose over each other's routed repository;
-    resolving either eagerly while the container builds the other recurses.
-    Attribute access is forwarded to the resolved repository.
-    """
-
-    def __init__(self, resolve):
-        self._resolve = resolve
-        self._target = None
-
-    def __getattr__(self, name):
-        if name.startswith("_"):  # copying/pickling probes must not resolve
-            raise AttributeError(name)
-        if self._target is None:
-            self._target = self._resolve()
-        return getattr(self._target, name)
+    return _build_engine(settings, APPLICATION_NAME)

--- a/backend/backend/db/startup.py
+++ b/backend/backend/db/startup.py
@@ -1,42 +1,32 @@
-"""Postgres startup/shutdown for the backend (plans/postgres-consolidation.md §4, R1).
+"""Postgres startup/shutdown for the backend, over :mod:`common.db.runtime`.
 
-Reachability is checked at boot only when the flags involve Postgres at all,
-and it is fatal only when a group *serves* from Postgres. A mirror-only
-configuration logs and continues: the mirror failing must never take the
-application down.
+Reachability is fatal only when a group *serves* from Postgres; a mirror-only
+configuration logs and continues. The effective flags are logged at boot so a
+flip is auditable in the deploy history.
 """
 
 from __future__ import annotations
 
+import json
+
 from loguru import logger
 
-from common.db import ping
+from backend.db.groups import MONGO_JOINS
+from backend.jobs.app import JOB_NAMES
+from common.db import check_postgres_at_startup as _check
+from common.db import dispose_engine
+
+GROUPS = ("refdata", "identity", "forms", "responses", "actions", "ai", "analytics")
 
 
 async def check_postgres_at_startup(container) -> None:
     flags = container.flags()
-    if not flags.requires_postgres():
-        return
-    engine = container.pg_engine()
-    if engine is None:
-        raise RuntimeError(
-            "DB_*/JOBS_* flags require Postgres but DATABASE_URL is not set"
-        )
-    try:
-        await ping(engine)
-        logger.info("Postgres reachable (application database)")
-    except Exception as exc:  # noqa: BLE001
-        if flags.serves_from_postgres():
-            raise RuntimeError(
-                "Postgres is unreachable and a repository group serves from it"
-            ) from exc
-        logger.error(
-            "Postgres unreachable at startup; it is only a mirror, continuing: {}",
-            type(exc).__name__,
-        )
+    logger.info(
+        "persistence flags: {}",
+        json.dumps(flags.describe(GROUPS, JOB_NAMES), sort_keys=True),
+    )
+    await _check(flags, container.pg_engine())
 
 
 async def dispose_postgres(container) -> None:
-    engine = container.pg_engine()
-    if engine is not None:
-        await engine.dispose()
+    await dispose_engine(container.pg_engine())

--- a/backend/tests/app/controllers/test_persistence_status.py
+++ b/backend/tests/app/controllers/test_persistence_status.py
@@ -1,0 +1,36 @@
+"""The operator status endpoint: admin-only, and it reflects the flags in effect,
+the shared routing counters and the outbox backlog."""
+
+import pytest
+from httpx import AsyncClient
+
+from backend.app.container import container
+from tests.app.controllers.data import testUser
+
+
+async def test_status_is_admin_only(client: AsyncClient, test_user_cookies_1):
+    response = await client.get(
+        "/api/v1/persistence/status", cookies=test_user_cookies_1
+    )
+    assert response.status_code == 403
+
+
+async def test_status_reports_flags_counters_and_outbox(
+    client: AsyncClient, test_user_cookies, workspace
+):
+    assert testUser.is_admin()
+    response = await client.get("/api/v1/persistence/status", cookies=test_user_cookies)
+    assert response.status_code == 200
+    body = response.json()
+    flags = container.flags()
+    assert (
+        body["flags"]["groups"]["identity"]["read_source"]
+        == flags.read_source("identity").value
+    )
+    assert (
+        body["flags"]["jobs"]["delete_user"] == flags.jobs_backend("delete_user").value
+    )
+    # the workspace fixture wrote through the routed identity repositories
+    assert body["metrics"]["identity"]["calls"]
+    assert set(body["outbox"]) == {"mongo", "postgres"} and body["outbox"]["mongo"] == 0
+    assert body["postgres"]["configured"] == (container.pg_engine() is not None)

--- a/common/common/db/__init__.py
+++ b/common/common/db/__init__.py
@@ -49,7 +49,10 @@ from common.db.runtime import (
     build_sessionmaker,
     check_postgres_at_startup,
     dispose_engine,
+    metrics_snapshot,
+    outbox_backlog,
     postgres_repository,
+    redact,
 )
 from common.db.spine import SpineColumns
 from common.db.pg_repository import PostgresNotConfigured, PostgresRepositoryBase

--- a/common/common/db/flags.py
+++ b/common/common/db/flags.py
@@ -120,6 +120,28 @@ class DbFlags:
     def jobs_backend(self, job: str) -> JobsBackend:
         return self.jobs_overrides.get(job.lower(), self.jobs_default)
 
+    def describe(self, groups: Iterable[str] = (), jobs: Iterable[str] = ()) -> dict:
+        """What is in effect, per group and job kind — logged at boot and served
+        by the status endpoints so a flip is auditable after the fact."""
+        names = sorted({*groups, *self.read_overrides, *self.write_overrides})
+        job_names = sorted({*jobs, *self.jobs_overrides})
+        return {
+            "defaults": {
+                "read_source": self.default_read.value,
+                "write_mode": self.default_write.value,
+                "jobs_backend": self.jobs_default.value,
+            },
+            "groups": {
+                g: {
+                    "read_source": self.read_source(g).value,
+                    "write_mode": self.write_mode(g).value,
+                }
+                for g in names
+            },
+            "jobs": {j: self.jobs_backend(j).value for j in job_names},
+            "shadow_read_sample": self.shadow_read_sample,
+        }
+
     # -- whole process -----------------------------------------------------
     def should_shadow_read(self, rng: random.Random | None = None) -> bool:
         if self.shadow_read_sample <= 0:

--- a/common/common/db/runtime.py
+++ b/common/common/db/runtime.py
@@ -9,6 +9,7 @@ first (backend/db); auth and the google integration use them from here.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from typing import Any, Callable, Optional, Type
 
@@ -97,9 +98,16 @@ async def dispose_engine(engine: Optional[AsyncEngine]) -> None:
 MAX_IDS = 20
 
 
+def redact(value: str) -> str:
+    """Outbox rows are read by operators: an address becomes a stable hash."""
+    if "@" in value:
+        return "email:" + hashlib.sha256(value.encode()).hexdigest()[:12]
+    return value
+
+
 def failure_ids(failure: MirrorFailure) -> str:
     """Best-effort: the ids a failed mirror write touched, from its arguments
-    and the documents a replay tried to store."""
+    and the documents a replay tried to store. Strings are redacted."""
     found: list[str] = []
     values = (
         list(failure.args) + list(failure.documents) + list(failure.kwargs.values())
@@ -110,13 +118,13 @@ def failure_ids(failure: MirrorFailure) -> str:
         elif type(value).__name__ in ("ObjectId", "PydanticObjectId"):
             found.append(str(value))
         elif isinstance(value, str) and len(value) <= 64:
-            found.append(value)
+            found.append(redact(value))
         elif isinstance(value, (list, tuple)):
             for item in list(value)[:MAX_IDS]:
                 if getattr(item, "id", None) is not None and hasattr(item, "save"):
                     found.append(str(item.id))
                 elif isinstance(item, str) and len(item) <= 64:
-                    found.append(item)
+                    found.append(redact(item))
     return ",".join(found[:MAX_IDS]) or "-"
 
 
@@ -164,3 +172,41 @@ class OutboxRecorder:
                     error=failure_error(failure.error),
                 )
             )
+
+
+def metrics_snapshot(metrics) -> dict:
+    """``RoutingMetrics`` counters as plain JSON, grouped by repository group."""
+    out: dict = {}
+    for name in (
+        "calls",
+        "mirror_failures",
+        "shadow_reads",
+        "shadow_diffs",
+        "shadow_errors",
+    ):
+        for (group, method), count in getattr(metrics, name).items():
+            out.setdefault(group, {}).setdefault(name, {})[method] = count
+    return out
+
+
+async def outbox_backlog(session_factory, row_cls) -> dict:
+    """Unresolved mirror-write failures in both stores (the outbox to drain)."""
+    from sqlalchemy import func, select
+
+    backlog = {
+        "mongo": await MirrorWriteFailureDocument.find(
+            MirrorWriteFailureDocument.resolved_at == None  # noqa: E711 — Beanie query
+        ).count()
+    }
+    if session_factory is None:
+        backlog["postgres"] = None
+        return backlog
+    async with session_factory() as session:
+        backlog["postgres"] = (
+            await session.execute(
+                select(func.count())
+                .select_from(row_cls)
+                .where(row_cls.resolved_at.is_(None))
+            )
+        ).scalar_one()
+    return backlog

--- a/common/tests/test_flags.py
+++ b/common/tests/test_flags.py
@@ -154,3 +154,26 @@ def test_mongo_joins_enforce_cutover_order():
         joins,
     )
     load_flags({"DB_READ_SOURCE": "postgres", "DB_WRITE_MODE": "postgres"}, joins)
+
+
+def test_describe_reports_what_is_in_effect():
+    flags = load_flags(
+        {"DB_WRITE_MODE__forms": "dual", "JOBS_BACKEND__delete_user": "postgres"}
+    )
+    described = flags.describe(
+        groups=["forms", "identity"], jobs=["delete_user", "run_action"]
+    )
+    assert described["defaults"] == {
+        "read_source": "mongo",
+        "write_mode": "mongo",
+        "jobs_backend": "temporal",
+    }
+    assert described["groups"]["forms"] == {
+        "read_source": "mongo",
+        "write_mode": "dual",
+    }
+    assert described["groups"]["identity"] == {
+        "read_source": "mongo",
+        "write_mode": "mongo",
+    }
+    assert described["jobs"] == {"delete_user": "postgres", "run_action": "temporal"}

--- a/common/tests/test_routing.py
+++ b/common/tests/test_routing.py
@@ -286,3 +286,24 @@ async def test_write_result_replays_the_persisted_documents_and_returns_the_valu
     assert await r.rotate("k") == {"plain": "k"}  # the caller never sees the wrapper
     assert p.replayed == [["mongo-enc"]]  # the mirror stores the encrypted copy
     assert [c[0] for c in p.calls] == []
+
+
+def test_outbox_row_ids_redact_addresses_and_keep_ids():
+    from common.db import MirrorFailure, ReadSource, redact
+    from common.db.runtime import failure_ids
+
+    assert redact("6a9d7c30c3a01cadfd948543") == "6a9d7c30c3a01cadfd948543"
+    assert redact("someone@example.com").startswith("email:") and "@" not in redact(
+        "a@b.c"
+    )
+    failure = MirrorFailure(
+        "responses",
+        "ResponderGroupsRepository",
+        "add_emails_to_group",
+        ReadSource.POSTGRES,
+        ("6a9d7c30c3a01cadfd948543", ["a@x.com", "b@x.com"]),
+        {},
+        RuntimeError("down"),
+    )
+    ids = failure_ids(failure)
+    assert ids.startswith("6a9d7c30c3a01cadfd948543,email:") and "@" not in ids

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -119,13 +119,17 @@ Each job kind can instead run as a **procrastinate** job on Postgres (`JOBS_BACK
 
 ## Data stores
 
-- **MongoDB** — all application data via Beanie Documents. Backend collections are registered in
-  [backend/app/handlers/database.py](../backend/backend/app/handlers/database.py) `init_db`; core models come from
-  `common/`.
+- **MongoDB** — application data via Beanie Documents, today's authoritative store. Backend collections are
+  registered in [backend/app/handlers/database.py](../backend/backend/app/handlers/database.py) `init_db`; core
+  models come from `common/`.
 - **PostgreSQL (`app-postgres`)** — the application database that is replacing MongoDB and Temporal
   (plan: [plans/postgres-consolidation.md](../plans/postgres-consolidation.md)). One database, one schema per
   service (`app`, `auth`, `google`, `jobs`), one least-privilege role each — the actions-executor's role can reach
-  `jobs` only, because it runs user-authored code. Introduced empty; populated by dual-write and backfill.
+  `jobs` only, because it runs user-authored code. Every repository in backend, auth and the google integration has
+  a Postgres twin behind a `RoutingRepository`; per-group flags (`DB_READ_SOURCE__<g>`, `DB_WRITE_MODE__<g>`) move
+  a group from Mongo to mirrored (`dual`) to served-from-Postgres, with Mongo kept current by a reverse mirror until
+  removal. Mirror failures go to an outbox; shadow reads compare the stores on live traffic; the flags in effect
+  are logged at boot and served on `GET /persistence/status`.
 - **PostgreSQL (Temporal)** — used only by the Temporal server (auto-setup image), not by application code;
   goes away with Temporal.
 - **Redis** — caching (notably in `integrations/google`).

--- a/integrations/google/googleform/app/asgi.py
+++ b/integrations/google/googleform/app/asgi.py
@@ -1,5 +1,6 @@
 """Application implementation - ASGI."""
 
+import json
 import logging
 
 from elasticapm.contrib.starlette import make_apm_client, ElasticAPM
@@ -37,6 +38,10 @@ async def on_startup():
     log.debug("Execute FastAPI startup event handler.")
 
     AiohttpClient.get_aiohttp_client()
+    log.info(
+        "persistence flags: %s",
+        json.dumps(Container.flags().describe(["google"]), sort_keys=True),
+    )
     await check_postgres_at_startup(Container.flags(), Container.pg_engine())
 
 

--- a/integrations/google/googleform/app/containers/__init__.py
+++ b/integrations/google/googleform/app/containers/__init__.py
@@ -21,6 +21,7 @@ from googleform.db.models import MirrorWriteFailure
 from common.db import (
     DatabaseSettings,
     OutboxRecorder,
+    RoutingMetrics,
     RoutingRepository,
     build_engine,
     build_sessionmaker,
@@ -53,6 +54,7 @@ class Container(containers.DeclarativeContainer):
     mirror_timeout_s = providers.Callable(
         lambda s: s.mirror_timeout_ms / 1000, db_settings
     )
+    routing_metrics = providers.Singleton(RoutingMetrics)
 
     # Google form repository and service
     form_repo = providers.Singleton(
@@ -61,6 +63,7 @@ class Container(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresFormRepository, pg_sessionmaker
@@ -77,6 +80,7 @@ class Container(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(FormResponseRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresFormResponseRepository, pg_sessionmaker
@@ -96,6 +100,7 @@ class Container(containers.DeclarativeContainer):
         flags=flags,
         on_mirror_failure=outbox_recorder,
         mirror_timeout_s=mirror_timeout_s,
+        metrics=routing_metrics,
         mongo=providers.Singleton(OauthCredentialRepository),
         postgres=providers.Singleton(
             postgres_repository, PostgresOauthCredentialRepository, pg_sessionmaker


### PR DESCRIPTION
Plan step 10 (`plans/postgres-consolidation.md` §8 "Verification and gates", §10.11 "Redaction"), stacked on #680. Retarget to `develop` once #680 merges. This closes the R1 code work: what's left before the first release is the migration CLI (PR 11), then the soak.

## Observability

- **One `RoutingMetrics` per service**, shared by every routed repository (backend: all 25 providers; auth; google), so the counters — calls, mirror failures, shadow reads / diffs / errors — aggregate by group and method instead of living in 25 separate proxies.
- **`DbFlags.describe()`**: the flags in effect per group and job kind. All three services log it at boot (`persistence flags: {...}`) — flips are restarts, so this is the audit trail.
- **`GET /persistence/status`** (admin only, backend): flags in effect, whether any job kind runs on Postgres, Postgres configured/reachable, the counters, and the **outbox backlog in both stores** (unresolved `mirror_write_failures`). This is the live view the soak gates in §8 read from; the migration CLI's `status` (PR 11) prints the same picture.

## Redaction

Outbox `row_id`s are built from a failed mirror write's arguments; a write like `add_emails_to_group(group_id, emails)` would have put addresses into a table operators read. Strings that look like addresses become `email:<sha256[:12]>` — stable, joinable, not PII. Audit of the routing layer's other log lines: they carry group / repository / method / store / exception *type* only, never payloads.

## Consolidation

`backend/db/{session,outbox,startup}` become thin shims over `common.db.runtime` (introduced in #678 for auth and google); every importer is unchanged.

## Docs

- `backend/AGENTS.md` gains a **Persistence** section: routed repositories and twins, groups and the flags (with the cutover-order rule), `@write_op` / `replay=True` / `WriteResult` / derived ids, SQL joins within a group vs composition across groups, rows + spine columns + Alembic as the service role, the outbox, and the three-mode test matrix (fixtures through `container.<repo>()`). The run/test block there was still poetry-based; it now shows the `uv` commands CI uses.
- Root `AGENTS.md` layering note and `docs/ARCHITECTURE.md` data-stores section updated to match.

## Verification

Backend ×3: **321 passed** each (2 new tests: the endpoint is admin-only; it reflects flags, counters and outbox). Common: 56 passed (describe, redaction). Auth ×2 and google ×2: 7 / 8 passed.
