### PR TITLE
ci: restore the run line of the Postgres-served auth and google test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
                   AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
                   AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
                   ELASTIC_APM_DISABLE_SEND: "true"
+              run: uv run pytest
     google-tests:
         name: Google integration tests (pytest)
         # The google unit suite has pre-existing failures from aiohttp/pydantic API

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,9 @@ jobs:
                   AUTH_JWT_SECRET: c3c66ff889b1deabc35ebb3cf07374f1fd934f0f0185eec076b5bcd874de86d5
                   AUTH_AES_HEX_KEY: L5HuSlk0ijI3xzaccuy2x1jnzHNjtTw3zW53tjGHZG0=
                   ELASTIC_APM_DISABLE_SEND: "true"
+                  MONGO_URI: mongodb://localhost:27017
+                  MONGO_DB: bettercollected_google_test
+                  MASTER_ENCRYPTION_KEYSET: "ewogICAgICAgICAgImtleSI6IFt7CiAgICAgICAgICAgICAgImtleURhdGEiOiB7CiAgICAgICAgICAgICAgICAgICJrZXlNYXRlcmlhbFR5cGUiOgogICAgICAgICAgICAgICAgICAgICAgIlNZTU1FVFJJQyIsCiAgICAgICAgICAgICAgICAgICJ0eXBlVXJsIjoKICAgICAgICAgICAgICAgICAgICAgICJ0eXBlLmdvb2dsZWFwaXMuY29tL2dvb2dsZS5jcnlwdG8udGluay5BZXNHY21LZXkiLAogICAgICAgICAgICAgICAgICAidmFsdWUiOgogICAgICAgICAgICAgICAgICAgICAgIkdpQld5VWZHZ1lrM1JUUmhqL0xJVXpTdWRJV2x5akNmdENPeXBUcjBqQ05TTGc9PSIKICAgICAgICAgICAgICB9LAogICAgICAgICAgICAgICJrZXlJZCI6IDI5NDQwNjUwNCwKICAgICAgICAgICAgICAib3V0cHV0UHJlZml4VHlwZSI6ICJUSU5LIiwKICAgICAgICAgICAgICAic3RhdHVzIjogIkVOQUJMRUQiCiAgICAgICAgICB9XSwKICAgICAgICAgICJwcmltYXJ5S2V5SWQiOiAyOTQ0MDY1MDQKICAgICAgfQ=="
 
               run: uv run pytest --ignore=tests/unit/app/utils/test_aiohttp_client.py --ignore=tests/unit/app/views --ignore=tests/unit/app/test_asgi.py
 


### PR DESCRIPTION
Two defects in the steps cloned in #678 for the Postgres-served test modes, both found once the workflow could run:

1. **`Run auth tests (served from Postgres)` had no `run:`.** A step with neither `run` nor `uses` makes the **whole workflow file invalid**, so `ci.yml` has not run on `develop` or on any PR since that merge — #680 and #681 only showed the separate *PR Checks* workflow. Found with `actionlint`; the file lints clean now.
2. **`Run google tests (served from Postgres)` was missing `MONGO_URI`, `MONGO_DB` and `MASTER_ENCRYPTION_KEYSET`**, so the google suite could not be collected in that mode (first surfaced by this PR's own run).

Merging this first lets CI run on #681 (I'll bring the fix into that branch) and on #683.