### PR TITLE
feat: the Mongo → Postgres migration CLI (preflight, backfill, verify, reconcile, status)

### DIFF
--- a/auth/auth/db/models.py
+++ b/auth/auth/db/models.py
@@ -4,6 +4,7 @@ from sqlalchemy import Index, UniqueConstraint
 
 from auth.db.base import S, Base
 from common.db import BaseRow, MirrorWriteFailureMixin
+from common.db.migrate import MigrationProgressMixin
 
 
 class UserRow(Base, BaseRow):
@@ -29,3 +30,9 @@ class ProviderRow(Base, BaseRow):
 
 class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
     __tablename__ = "mirror_write_failures"
+
+
+class MigrationProgress(Base, MigrationProgressMixin):
+    """Checkpoints of the Mongo → Postgres backfill (python -m <service>.migrate)."""
+
+    __tablename__ = "migration_progress"

--- a/auth/auth/migrate/__init__.py
+++ b/auth/auth/migrate/__init__.py
@@ -1,0 +1,1 @@
+"""`python -m auth.migrate` — this service's Mongo → Postgres migration CLI."""

--- a/auth/auth/migrate/__main__.py
+++ b/auth/auth/migrate/__main__.py
@@ -1,0 +1,38 @@
+"""python -m auth.migrate {preflight,backfill,verify,reconcile,status}
+
+Runs as this service's role against its schema and Mongo database
+(plans/postgres-consolidation.md §5).
+"""
+
+import os
+import sys
+
+from auth.config import settings
+from auth.db.base import SCHEMA, Base
+from auth.db.models import MigrationProgress
+import auth.db.models  # noqa: F401 — registers every row
+from common.db.migrate import Target
+from common.db.migrate.cli import main
+
+
+def _tables():
+    return {
+        mapper.class_.mongo_collection(): mapper.local_table
+        for mapper in Base.registry.mappers
+        if hasattr(mapper.class_, "mongo_collection")
+        and mapper.local_table.name
+        not in ("mirror_write_failures", "migration_progress")
+    }
+
+
+if __name__ == "__main__":
+    target = Target(
+        schema=SCHEMA,
+        tables=_tables(),
+        progress=MigrationProgress.__table__,
+        mongo_uri=settings.mongo_settings.URI,
+        mongo_db=settings.mongo_settings.DB,
+        database_url=os.environ["DATABASE_URL"],
+        application_name="bettercollected-migrate-" + SCHEMA,
+    )
+    sys.exit(main(sys.argv[1:], target, prog="python -m auth.migrate"))

--- a/auth/auth/migrations/versions/0002_migration_progress_checkpoints.py
+++ b/auth/auth/migrations/versions/0002_migration_progress_checkpoints.py
@@ -1,0 +1,39 @@
+"""migration progress checkpoints
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-09-06 20:17:00.457793
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "migration_progress",
+        sa.Column("collection", sa.Text(), nullable=False),
+        sa.Column("last_id", sa.Text(), nullable=True),
+        sa.Column("count", sa.BigInteger(), nullable=False),
+        sa.Column("skipped", sa.BigInteger(), nullable=False),
+        sa.Column("batch_size", sa.Integer(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("run_id", sa.Text(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("heartbeat_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("collection", name=op.f("pk_migration_progress")),
+        schema="auth",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("migration_progress", schema="auth")

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -71,6 +71,12 @@ plan and decisions in `plans/postgres-consolidation.md`. What that means when yo
 - **Mirror failures** land in the outbox (`mirror_write_failures`, Mongo doc or Postgres row — whichever store is
   primary); shadow-read diffs and counters are exposed on `GET /persistence/status` (admin) and the effective flags
   are logged at boot.
+- **Migration CLI:** `python -m backend.migrate {preflight,backfill,verify,reconcile,status,jobs-sweep}` (auth and
+  google have `python -m auth.migrate` / `python -m googleform.migrate`), the engine in `common/db/migrate/`. Raw
+  pymongo + SQLAlchemy Core, never Beanie, never decrypts. Backfill is resumable (checkpoints in `migration_progress`,
+  adaptive batches, `--max-minutes`, advisory lock) and never overwrites a row the application wrote
+  (`_bc_source = 'app'`); `verify` compares counts, per-row checksums and a sampled round-trip; `reconcile` fixes
+  drift with Mongo authoritative (`--direction postgres->mongo` for the fallback) and drains the outboxes.
 - **Tests run three ways in CI** (Mongo · everything mirrored · everything served from Postgres). Parity tests
   (`tests/app/repositories/test_*_parity.py`) run each method on both stores; test fixtures must go through
   `container.<repo>()`, never Beanie directly, or the Postgres-served mode fails.

--- a/backend/backend/db/models.py
+++ b/backend/backend/db/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import Index, UniqueConstraint, text
 
 from backend.db.base import S, Base
 from common.db import BaseRow, MirrorWriteFailureMixin
+from common.db.migrate import MigrationProgressMixin
 
 
 class WorkspaceRow(Base, BaseRow):
@@ -369,3 +370,9 @@ class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
 
 
 ROW_MODELS = [cls for cls in Base.__subclasses__() if issubclass(cls, BaseRow)]
+
+
+class MigrationProgress(Base, MigrationProgressMixin):
+    """Checkpoints of the Mongo → Postgres backfill (python -m <service>.migrate)."""
+
+    __tablename__ = "migration_progress"

--- a/backend/backend/migrate/__init__.py
+++ b/backend/backend/migrate/__init__.py
@@ -1,0 +1,1 @@
+"""`python -m backend.migrate` — the backend's Mongo → Postgres migration CLI."""

--- a/backend/backend/migrate/__main__.py
+++ b/backend/backend/migrate/__main__.py
@@ -1,0 +1,81 @@
+"""python -m backend.migrate {preflight,backfill,verify,reconcile,status,jobs-sweep}
+
+Runs as the backend's role against schema ``app`` and Mongo database
+``MONGO_DB``. ``jobs-sweep`` (re)creates the scheduled response deletions on
+the chosen jobs backend — independent of any queue's memory (plans §7, §9).
+"""
+
+import os
+import sys
+
+from bson import ObjectId
+
+from backend.config import settings
+from backend.db.base import SCHEMA, Base
+from backend.db.models import MigrationProgress
+import backend.db.models  # noqa: F401 — registers every row
+from common.db.migrate import Target
+from common.db.migrate.cli import main
+
+
+def _tables():
+    return {
+        mapper.class_.mongo_collection(): mapper.local_table
+        for mapper in Base.registry.mappers
+        if hasattr(mapper.class_, "mongo_collection")
+        and mapper.local_table.name
+        not in ("mirror_write_failures", "migration_progress")
+    }
+
+
+async def jobs_sweep(backend: str) -> dict:
+    """Every response with an expiration gets its deletion (re)scheduled on
+    ``backend``; queueing locks / schedule ids make this idempotent."""
+    from pymongo import AsyncMongoClient
+
+    from backend.app.container import container
+    from backend.app.services.temporal_service import TemporalService
+    from backend.jobs.app import app as jobs_app
+    from common.db import load_flags
+    from common.models.standard_form import StandardFormResponse
+
+    service = TemporalService(
+        server_uri=settings.temporal_settings.server_uri,
+        namespace=settings.temporal_settings.namespace,
+        crypto=container.crypto(),
+        flags=load_flags({"JOBS_BACKEND__delete_response": backend}),
+        jobs=jobs_app,
+    )
+    client = AsyncMongoClient(settings.mongo_settings.URI)
+    responses = client[settings.mongo_settings.DB]["form_responses"]
+    scheduled = 0
+    async with jobs_app.open_async():
+        async for doc in responses.find(
+            {
+                "expiration_type": {"$in": ["date", "days"]},
+                "expiration": {"$type": "string"},
+            },
+            {"response_id": 1, "expiration": 1},
+        ):
+            await service.add_scheduled_job_for_deleting_response(
+                StandardFormResponse(
+                    response_id=doc["response_id"], expiration=doc["expiration"]
+                )
+            )
+            scheduled += 1
+    await client.close()
+    return {"backend": backend, "scheduled": scheduled}
+
+
+if __name__ == "__main__":
+    target = Target(
+        schema=SCHEMA,
+        tables=_tables(),
+        progress=MigrationProgress.__table__,
+        mongo_uri=settings.mongo_settings.URI,
+        mongo_db=settings.mongo_settings.DB,
+        database_url=os.environ["DATABASE_URL"],
+        application_name="bettercollected-migrate-backend",
+        extras={"jobs_sweep": jobs_sweep},
+    )
+    sys.exit(main(sys.argv[1:], target, prog="python -m backend.migrate"))

--- a/backend/backend/migrations/versions/0003_migration_progress_checkpoints.py
+++ b/backend/backend/migrations/versions/0003_migration_progress_checkpoints.py
@@ -1,0 +1,39 @@
+"""migration progress checkpoints
+
+Revision ID: 0003
+Revises: 0002
+Create Date: 2026-09-06 20:16:59.242347
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0003"
+down_revision: Union[str, None] = "0002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "migration_progress",
+        sa.Column("collection", sa.Text(), nullable=False),
+        sa.Column("last_id", sa.Text(), nullable=True),
+        sa.Column("count", sa.BigInteger(), nullable=False),
+        sa.Column("skipped", sa.BigInteger(), nullable=False),
+        sa.Column("batch_size", sa.Integer(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("run_id", sa.Text(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("heartbeat_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("collection", name=op.f("pk_migration_progress")),
+        schema="app",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("migration_progress", schema="app")

--- a/backend/tests/app/migrate/test_engine.py
+++ b/backend/tests/app/migrate/test_engine.py
@@ -1,0 +1,147 @@
+"""The migration CLI against both real stores: backfill copies Mongo documents
+into rows it never lets clobber the application's own rows, verify sees the
+truth, reconcile restores it, and a run resumes from its checkpoint.
+Skipped unless DATABASE_URL points at a *_test database."""
+
+import os
+
+import pytest
+from beanie import PydanticObjectId
+from sqlalchemy import select, text
+
+from backend.app.container import container
+from backend.app.repositories.allowed_origins_repository import AllowedOriginsRepository
+from backend.app.repositories.postgres.refdata import PostgresAllowedOriginsRepository
+from backend.app.schemas.allowed_origin import AllowedOriginsDocument
+from backend.app.schemas.workspace import WorkspaceDocument
+from backend.config import settings
+from backend.db.base import SCHEMA
+from backend.db.models import AllowedOriginRow, MigrationProgress, WorkspaceRow
+from backend.migrate.__main__ import _tables
+from common.db.base import SOURCE_APP, SOURCE_BACKFILL
+from common.db.migrate import Runner, Target
+
+
+@pytest.fixture
+def target(clean_postgres):
+    return Target(
+        schema=SCHEMA,
+        tables=_tables(),
+        progress=MigrationProgress.__table__,
+        mongo_uri=settings.mongo_settings.URI,
+        mongo_db=settings.mongo_settings.DB,
+        database_url=os.environ["DATABASE_URL"],
+    )
+
+
+async def rows(table):
+    async with container.pg_engine().connect() as conn:
+        return {r.id: r for r in (await conn.execute(select(table))).all()}
+
+
+async def test_backfill_verify_reconcile_round_trip(target):
+    mongo = AllowedOriginsRepository()
+    for origin in ("https://a.example", "https://b.example", "https://c.example"):
+        await mongo.add(origin)
+    ws = WorkspaceDocument(title="W", workspace_name="w1", owner_id="o")
+    await ws.save()
+    # one row the application already dual-wrote: backfill must leave it alone
+    app_written = await PostgresAllowedOriginsRepository(
+        container.pg_sessionmaker()
+    ).add("https://app.example")
+    await AllowedOriginsDocument(
+        id=app_written.id, origin="https://changed-in-mongo.example"
+    ).save()
+
+    async with Runner(target) as runner:
+        pre = {
+            r.collection: r
+            for r in await runner.preflight(["allowed_origins", "workspaces"])
+        }
+        assert (pre["allowed_origins"].mongo, pre["allowed_origins"].postgres) == (4, 1)
+        assert (
+            pre["workspaces"].duplicates == 0
+            and pre["allowed_origins"].invalid_ids == 0
+        )
+
+        result = await runner.backfill(["allowed_origins", "workspaces"])
+        assert (
+            result["allowed_origins"]["state"] == "done"
+            and result["allowed_origins"]["count"] == 4
+        )
+        assert result["workspaces"]["count"] == 1
+    origins = await rows(AllowedOriginRow)
+    assert len(origins) == 4
+    assert origins[str(app_written.id)]._bc_source == SOURCE_APP
+    assert (
+        origins[str(app_written.id)].doc["origin"] == "https://app.example"
+    )  # not clobbered
+    assert all(
+        r._bc_source == SOURCE_BACKFILL
+        for oid, r in origins.items()
+        if oid != str(app_written.id)
+    )
+    assert (await rows(WorkspaceRow))[str(ws.id)].doc["workspace_name"] == "w1"
+
+    async with Runner(target) as runner:
+        reports = {
+            r.collection: r
+            for r in await runner.verify(["allowed_origins", "workspaces"])
+        }
+    assert reports["workspaces"].clean
+    assert (
+        reports["allowed_origins"].mismatched == 1
+    )  # the app row Mongo disagrees with
+    assert reports["allowed_origins"].samples["mismatched"] == [str(app_written.id)]
+
+    # Mongo is authoritative in Phase 1: reconcile brings the row in line
+    async with Runner(target) as runner:
+        fixed = await runner.reconcile(["allowed_origins"])
+        assert fixed["allowed_origins"]["fixed"] == 1
+        assert all(r.clean for r in await runner.verify(["allowed_origins"]))
+        status = await runner.status()
+    assert status["collections"]["allowed_origins"]["state"] == "done"
+    assert status["outbox"] == {"mongo": 0, "postgres": 0}
+    assert (await rows(AllowedOriginRow))[str(app_written.id)].doc[
+        "origin"
+    ] == "https://changed-in-mongo.example"
+
+
+async def test_backfill_resumes_from_its_checkpoint_and_dry_run_writes_nothing(target):
+    mongo = AllowedOriginsRepository()
+    for i in range(60):
+        await mongo.add(f"https://{i}.example")
+    async with Runner(target) as runner:
+        assert (await runner.backfill(["allowed_origins"], dry_run=True))[
+            "allowed_origins"
+        ]["count"] == 60
+        assert await rows(AllowedOriginRow) == {}
+        first = await runner.backfill(["allowed_origins"], max_batches=1, batch_size=25)
+        assert (
+            first["allowed_origins"]["state"] == "paused"
+            and 0 < first["allowed_origins"]["count"] < 60
+        )
+        checkpoint = (await runner.status())["collections"]["allowed_origins"]
+        assert checkpoint["state"] == "paused" and checkpoint["last_id"]
+        second = await runner.backfill(["allowed_origins"])
+        assert (
+            second["allowed_origins"]["state"] == "done"
+            and second["allowed_origins"]["count"] == 60
+        )
+        assert (await runner.backfill(["allowed_origins"]))["allowed_origins"][
+            "note"
+        ] == "already done"
+    assert len(await rows(AllowedOriginRow)) == 60
+
+
+async def test_verify_reports_rows_mongo_no_longer_has(target):
+    postgres = PostgresAllowedOriginsRepository(container.pg_sessionmaker())
+    orphan = await postgres.add("https://only-in-postgres.example")
+    async with Runner(target) as runner:
+        (report,) = await runner.verify(["allowed_origins"])
+        assert (
+            report.missing_in_mongo == 1 and report.postgres == 1 and report.mongo == 0
+        )
+        # postgres->mongo puts it back (the R2/R3 fallback direction)
+        await runner.reconcile(["allowed_origins"], direction="postgres->mongo")
+    assert await AllowedOriginsDocument.get(orphan.id) is not None

--- a/common/common/db/migrate/__init__.py
+++ b/common/common/db/migrate/__init__.py
@@ -1,0 +1,15 @@
+"""The Mongo → Postgres migration engine (plans/postgres-consolidation.md §5).
+
+``preflight`` · ``backfill`` · ``verify`` · ``reconcile`` · ``status`` (and a
+service-provided ``jobs-sweep``). Runs as a one-off process per service —
+``python -m backend.migrate``, ``python -m auth.migrate``,
+``python -m googleform.migrate`` — each with its own rows, schema, Mongo
+database and least-privilege role. Raw pymongo and SQLAlchemy Core only: no
+Beanie, nothing is ever decrypted, every batch is a fresh short query and one
+short transaction, every run is idempotent and resumable.
+"""
+
+from common.db.migrate.engine import Runner, Target
+from common.db.migrate.progress import MigrationProgressMixin
+
+__all__ = ["Runner", "Target", "MigrationProgressMixin"]

--- a/common/common/db/migrate/cli.py
+++ b/common/common/db/migrate/cli.py
@@ -1,0 +1,122 @@
+"""Command line for the migration engine; each service wraps it with its Target."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+from typing import Callable, Sequence
+
+from common.db.migrate.engine import Runner, Target
+
+
+def build_parser(prog: str) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        description="Mongo → Postgres migration for one service: preflight, backfill, verify, reconcile, status.",
+    )
+    parser.add_argument("--collections", help="comma-separated subset (default: all)")
+    parser.add_argument("--verbose", action="store_true")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("preflight", help="counts, invalid ids, duplicate unique keys")
+    backfill = sub.add_parser("backfill", help="copy Mongo → Postgres, resumable")
+    backfill.add_argument("--dry-run", action="store_true")
+    backfill.add_argument(
+        "--max-minutes",
+        type=float,
+        help="stop at the next checkpoint after this budget",
+    )
+    backfill.add_argument(
+        "--max-batches", type=int, help="stop after N batches (tests, smoke runs)"
+    )
+    backfill.add_argument(
+        "--restart", action="store_true", help="ignore checkpoints and start over"
+    )
+    backfill.add_argument(
+        "--batch-size",
+        type=int,
+        default=200,
+        help="initial batch size (adapts while running)",
+    )
+    verify = sub.add_parser(
+        "verify", help="counts + checksum merge-join + sampled deep compare"
+    )
+    verify.add_argument(
+        "--sample-every", type=int, default=1, help="check every k-th batch"
+    )
+    reconcile = sub.add_parser(
+        "reconcile", help="fix what verify finds; drain outboxes"
+    )
+    reconcile.add_argument(
+        "--direction",
+        choices=["mongo->postgres", "postgres->mongo"],
+        default="mongo->postgres",
+    )
+    reconcile.add_argument("--dry-run", action="store_true")
+    sub.add_parser("status", help="checkpoints, stalls, outbox backlog")
+    sweep = sub.add_parser(
+        "jobs-sweep", help="(re)create scheduled deletions on a jobs backend"
+    )
+    sweep.add_argument(
+        "--backend", choices=["postgres", "temporal"], default="postgres"
+    )
+    return parser
+
+
+def _print(value) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True, default=str))
+
+
+async def run(args: argparse.Namespace, target: Target) -> int:
+    collections = [c for c in (args.collections or "").split(",") if c] or None
+    async with Runner(target) as runner:
+        if args.command == "preflight":
+            reports = await runner.preflight(collections)
+            _print([r.as_dict() for r in reports])
+            return 1 if any(r.invalid_ids or r.duplicates for r in reports) else 0
+        if args.command == "backfill":
+            _print(
+                await runner.backfill(
+                    collections,
+                    dry_run=args.dry_run,
+                    max_minutes=args.max_minutes,
+                    max_batches=args.max_batches,
+                    restart=args.restart,
+                    batch_size=args.batch_size,
+                )
+            )
+            return 0
+        if args.command == "verify":
+            reports = await runner.verify(collections, sample_every=args.sample_every)
+            _print([r.as_dict() for r in reports])
+            return 0 if all(r.clean for r in reports) else 1
+        if args.command == "reconcile":
+            _print(
+                await runner.reconcile(
+                    collections, direction=args.direction, dry_run=args.dry_run
+                )
+            )
+            return 0
+        if args.command == "status":
+            _print(await runner.status())
+            return 0
+        if args.command == "jobs-sweep":
+            sweep: Callable | None = target.extras.get("jobs_sweep")
+            if sweep is None:
+                print("this service has no scheduled jobs to sweep", file=sys.stderr)
+                return 2
+            _print(await sweep(args.backend))
+            return 0
+    return 2
+
+
+def main(argv: Sequence[str], target: Target, prog: str) -> int:
+    args = build_parser(prog).parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    return asyncio.run(run(args, target))

--- a/common/common/db/migrate/engine.py
+++ b/common/common/db/migrate/engine.py
@@ -1,0 +1,759 @@
+"""Backfill, verify, reconcile, status — the engine behind the per-service CLIs.
+
+No-hang guarantees (plans/postgres-consolidation.md §5): each Mongo batch is a
+fresh ``find({_id: {$gt: last}}).sort(_id).limit(n)``; each Postgres batch is
+one short transaction on a connection with statement/lock/idle timeouts; the
+batch size adapts (halve when a batch is slow, grow when fast); a time budget
+stops at the next checkpoint; the checkpoint is written after the batch
+commits; a heartbeat line per batch; an advisory lock plus the checkpoint's
+heartbeat refuse a second concurrent run.
+
+Idempotency: ``INSERT … ON CONFLICT (id) DO UPDATE … WHERE _bc_source =
+'backfill'`` — a row the application wrote is never overwritten by backfill.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Mapping, Optional
+
+from bson import ObjectId
+from pymongo import AsyncMongoClient
+from sqlalchemy import Table, and_, func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from common.db.base import SOURCE_APP, SOURCE_BACKFILL
+from common.db.canonical import canonical_document, checksum, from_canonical_document
+from common.db.engine import DatabaseSettings, make_engine
+from common.db.migrate.progress import (
+    STATE_DONE,
+    STATE_ERROR,
+    STATE_PAUSED,
+    STATE_RUNNING,
+)
+
+logger = logging.getLogger("bettercollected.migrate")
+
+OBJECT_ID = re.compile(r"^[0-9a-f]{24}$")
+SPINE_PATH = re.compile(r"doc\s*->\s*'([^']+)'((?:\s*->\s*'[^']+')*)")
+STALLED_AFTER_S = 300
+MIN_BATCH, MAX_BATCH = 25, 2000
+SLOW_BATCH_S, FAST_BATCH_S = 20.0, 2.0
+
+
+@dataclass
+class Target:
+    """What one service's CLI migrates."""
+
+    schema: str
+    tables: Mapping[str, Table]  # mongo collection -> its table
+    progress: Table
+    mongo_uri: str
+    mongo_db: str
+    database_url: str
+    application_name: str = "bettercollected-migrate"
+    extras: Mapping[str, Callable[..., Any]] = field(default_factory=dict)
+
+
+@dataclass
+class CollectionReport:
+    collection: str
+    mongo: int = 0
+    postgres: int = 0
+    missing_in_postgres: int = 0
+    missing_in_mongo: int = 0
+    mismatched: int = 0
+    drifted: int = 0  # tier 3: row → document round-trip differs from Mongo
+    invalid_ids: int = 0
+    duplicates: int = 0
+    samples: dict = field(
+        default_factory=lambda: {
+            "missing_in_postgres": [],
+            "missing_in_mongo": [],
+            "mismatched": [],
+            "drifted": [],
+        }
+    )
+
+    @property
+    def clean(self) -> bool:
+        return not (
+            self.missing_in_postgres
+            or self.missing_in_mongo
+            or self.mismatched
+            or self.drifted
+        )
+
+    def as_dict(self) -> dict:
+        return {k: v for k, v in self.__dict__.items()}
+
+
+def is_object_id(value: Any) -> bool:
+    return isinstance(value, ObjectId) or (
+        isinstance(value, str) and bool(OBJECT_ID.match(value))
+    )
+
+
+def timestamp_of(value: Any) -> Optional[datetime]:
+    """created_at/updated_at as stored by Beanie: a datetime or an ISO string."""
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+    return None
+
+
+def row_from_document(document: Mapping[str, Any]) -> dict[str, Any]:
+    """Column values for a Mongo document, as a backfilled row."""
+    doc = canonical_document(document)
+    now = datetime.now(timezone.utc)
+    return {
+        "id": str(document["_id"]),
+        "doc": doc,
+        "created_at": timestamp_of(document.get("created_at")) or now,
+        "updated_at": timestamp_of(document.get("updated_at")) or now,
+        "_bc_source": SOURCE_BACKFILL,
+        "_bc_checksum": checksum(doc),
+    }
+
+
+def spine_paths(table: Table) -> dict[str, list[str]]:
+    """column name -> document path, parsed from the GENERATED expression."""
+    paths: dict[str, list[str]] = {}
+    for column in table.columns:
+        computed = getattr(column, "computed", None)
+        if computed is None:
+            continue
+        m = SPINE_PATH.search(str(computed.sqltext))
+        if m:
+            paths[column.name] = [m.group(1), *re.findall(r"'([^']+)'", m.group(2))]
+    return paths
+
+
+def unique_key_paths(table: Table) -> list[list[list[str]]]:
+    """For every UNIQUE constraint: the document paths of its columns."""
+    paths = spine_paths(table)
+    keys = []
+    for constraint in table.constraints:
+        cols = [c.name for c in getattr(constraint, "columns", [])]
+        if (
+            type(constraint).__name__ == "UniqueConstraint"
+            and cols
+            and all(c in paths for c in cols)
+        ):
+            keys.append([paths[c] for c in cols])
+    return keys
+
+
+def adapt_batch(size: int, seconds: float) -> int:
+    if seconds > SLOW_BATCH_S:
+        return max(MIN_BATCH, size // 2)
+    if seconds < FAST_BATCH_S:
+        return min(MAX_BATCH, size * 2)
+    return size
+
+
+class Runner:
+    def __init__(self, target: Target):
+        self.target = target
+        self.run_id = uuid.uuid4().hex[:12]
+        self._engine: Optional[AsyncEngine] = None
+        self._mongo: Optional[AsyncMongoClient] = None
+
+    # -- lifecycle ----------------------------------------------------------
+    async def __aenter__(self) -> "Runner":
+        settings = DatabaseSettings.from_env()
+        settings = DatabaseSettings(
+            url=self.target.database_url,
+            pool_size=2,
+            max_overflow=0,
+            statement_timeout_ms=settings.statement_timeout_ms,
+            lock_timeout_ms=settings.lock_timeout_ms,
+            idle_in_transaction_ms=settings.idle_in_transaction_ms,
+        )
+        self._engine = make_engine(
+            settings, application_name=self.target.application_name
+        )
+        self._mongo = AsyncMongoClient(
+            self.target.mongo_uri, tz_aware=True, readPreference="secondaryPreferred"
+        )
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        if self._engine is not None:
+            await self._engine.dispose()
+        if self._mongo is not None:
+            await self._mongo.close()
+
+    @property
+    def engine(self) -> AsyncEngine:
+        assert self._engine is not None
+        return self._engine
+
+    def collection(self, name: str):
+        assert self._mongo is not None
+        return self._mongo[self.target.mongo_db][name]
+
+    def tables_for(self, collections: Optional[Iterable[str]]) -> dict[str, Table]:
+        if not collections:
+            return dict(self.target.tables)
+        unknown = [c for c in collections if c not in self.target.tables]
+        if unknown:
+            raise SystemExit(f"unknown collection(s): {', '.join(unknown)}")
+        return {c: self.target.tables[c] for c in collections}
+
+    # -- progress -------------------------------------------------------------
+    async def _progress_rows(self) -> dict[str, dict]:
+        async with self.engine.connect() as conn:
+            rows = (await conn.execute(select(self.target.progress))).mappings().all()
+        return {r["collection"]: dict(r) for r in rows}
+
+    async def _checkpoint(self, collection: str, **values: Any) -> None:
+        now = datetime.now(timezone.utc)
+        values = {
+            **values,
+            "collection": collection,
+            "updated_at": now,
+            "heartbeat_at": now,
+            "run_id": self.run_id,
+        }
+        stmt = pg_insert(self.target.progress).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["collection"],
+            set_={k: v for k, v in values.items() if k != "collection"},
+        )
+        async with self.engine.begin() as conn:
+            await conn.execute(stmt)
+
+    async def _refuse_if_running(
+        self, collection: str, progress: dict[str, dict]
+    ) -> None:
+        row = progress.get(collection)
+        if row and row["state"] == STATE_RUNNING and row.get("heartbeat_at"):
+            age = (datetime.now(timezone.utc) - row["heartbeat_at"]).total_seconds()
+            if age < STALLED_AFTER_S and row.get("run_id") != self.run_id:
+                raise SystemExit(
+                    f"{collection}: another run ({row['run_id']}) heartbeated {int(age)}s ago; "
+                    f"refusing to start. If it is dead, wait {STALLED_AFTER_S}s or run `status`."
+                )
+
+    async def _advisory_lock(self, conn) -> bool:
+        key = f"bc_migrate:{self.target.schema}"
+        return bool(
+            (
+                await conn.execute(
+                    text("SELECT pg_try_advisory_lock(hashtext(:k))"), {"k": key}
+                )
+            ).scalar()
+        )
+
+    # -- preflight ------------------------------------------------------------
+    async def preflight(
+        self, collections: Optional[Iterable[str]] = None
+    ) -> list[CollectionReport]:
+        reports = []
+        for name, table in self.tables_for(collections).items():
+            report = CollectionReport(name)
+            coll = self.collection(name)
+            report.mongo = await coll.count_documents({})
+            report.invalid_ids = await coll.count_documents(
+                {"_id": {"$not": {"$type": "objectId"}}}
+            )
+            for key in unique_key_paths(table):
+                group = {"_".join(p): "$" + ".".join(p) for p in key}
+                pipeline = [
+                    {"$group": {"_id": group, "n": {"$sum": 1}}},
+                    {"$match": {"n": {"$gt": 1}}},
+                    {"$count": "groups"},
+                ]
+                dupes = await (await coll.aggregate(pipeline)).to_list()
+                report.duplicates += dupes[0]["groups"] if dupes else 0
+            async with self.engine.connect() as conn:
+                report.postgres = (
+                    await conn.execute(select(func.count()).select_from(table))
+                ).scalar_one()
+            reports.append(report)
+            logger.info(
+                "preflight %s: mongo=%d postgres=%d invalid_ids=%d duplicate_keys=%d",
+                name,
+                report.mongo,
+                report.postgres,
+                report.invalid_ids,
+                report.duplicates,
+            )
+        return reports
+
+    # -- backfill ---------------------------------------------------------------
+    async def backfill(
+        self,
+        collections: Optional[Iterable[str]] = None,
+        *,
+        dry_run: bool = False,
+        max_minutes: Optional[float] = None,
+        max_batches: Optional[int] = None,
+        restart: bool = False,
+        batch_size: int = 200,
+    ) -> dict[str, dict]:
+        deadline = time.monotonic() + max_minutes * 60 if max_minutes else None
+        progress = await self._progress_rows()
+        results: dict[str, dict] = {}
+        async with self.engine.connect() as lock_conn:
+            if not dry_run and not await self._advisory_lock(lock_conn):
+                raise SystemExit(
+                    "another migration run holds the advisory lock for this schema"
+                )
+            for name, table in self.tables_for(collections).items():
+                await self._refuse_if_running(name, progress)
+                state = progress.get(name) or {}
+                if restart or not state:
+                    last_id, copied, skipped, size = None, 0, 0, batch_size
+                else:
+                    if state["state"] == STATE_DONE and not restart:
+                        results[name] = {
+                            "state": STATE_DONE,
+                            "count": state["count"],
+                            "note": "already done",
+                        }
+                        continue
+                    last_id, copied, skipped, size = (
+                        state["last_id"],
+                        state["count"],
+                        state["skipped"],
+                        state["batch_size"],
+                    )
+                results[name] = await self._backfill_collection(
+                    name,
+                    table,
+                    last_id,
+                    copied,
+                    skipped,
+                    size,
+                    dry_run=dry_run,
+                    deadline=deadline,
+                    max_batches=max_batches,
+                )
+                if (
+                    results[name]["state"] == STATE_PAUSED
+                    and deadline
+                    and time.monotonic() >= deadline
+                ):
+                    logger.info("time budget reached; stopping at a checkpoint")
+                    break
+        return results
+
+    async def _backfill_collection(
+        self,
+        name,
+        table,
+        last_id,
+        copied,
+        skipped,
+        size,
+        *,
+        dry_run,
+        deadline,
+        max_batches,
+    ) -> dict:
+        coll = self.collection(name)
+        batches = 0
+        if not dry_run:
+            await self._checkpoint(
+                name,
+                state=STATE_RUNNING,
+                last_id=last_id,
+                count=copied,
+                skipped=skipped,
+                batch_size=size,
+            )
+        try:
+            while True:
+                if deadline and time.monotonic() >= deadline:
+                    state = STATE_PAUSED
+                    break
+                if max_batches is not None and batches >= max_batches:
+                    state = STATE_PAUSED
+                    break
+                query = {"_id": {"$gt": ObjectId(last_id)}} if last_id else {}
+                started = time.monotonic()
+                documents = await coll.find(query).sort("_id", 1).limit(size).to_list()
+                if not documents:
+                    state = STATE_DONE
+                    break
+                rows, bad = [], 0
+                for document in documents:
+                    if not is_object_id(document.get("_id")):
+                        bad += 1
+                        continue
+                    rows.append(row_from_document(document))
+                if rows and not dry_run:
+                    stmt = pg_insert(table).values(rows)
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["id"],
+                        set_={
+                            "doc": stmt.excluded.doc,
+                            "created_at": stmt.excluded.created_at,
+                            "updated_at": stmt.excluded.updated_at,
+                            "_bc_checksum": stmt.excluded._bc_checksum,
+                        },
+                        where=table.c._bc_source == SOURCE_BACKFILL,  # never an app row
+                    )
+                    async with self.engine.begin() as conn:
+                        await conn.execute(stmt)
+                # only ObjectId _ids can be checkpointed (the sort is by _id)
+                object_ids = [
+                    d["_id"] for d in documents if isinstance(d["_id"], ObjectId)
+                ]
+                if not object_ids:
+                    state = STATE_DONE
+                    break
+                last_id = str(max(object_ids))
+                copied += len(rows)
+                skipped += bad
+                elapsed = time.monotonic() - started
+                batches += 1
+                if not dry_run:
+                    await self._checkpoint(
+                        name,
+                        state=STATE_RUNNING,
+                        last_id=last_id,
+                        count=copied,
+                        skipped=skipped,
+                        batch_size=size,
+                    )
+                logger.info(
+                    "backfill %s: batch=%d rows=%d skipped=%d copied=%d last_id=%s %.0f rows/s",
+                    name,
+                    batches,
+                    len(rows),
+                    bad,
+                    copied,
+                    last_id,
+                    len(rows) / max(elapsed, 1e-3),
+                )
+                size = adapt_batch(size, elapsed)
+                if len(documents) < size and len(documents) < MIN_BATCH:
+                    state = STATE_DONE
+                    break
+        except (
+            Exception
+        ) as exc:  # noqa: BLE001 — record, then re-raise: the checkpoint survives
+            if not dry_run:
+                await self._checkpoint(
+                    name,
+                    state=STATE_ERROR,
+                    last_id=last_id,
+                    count=copied,
+                    skipped=skipped,
+                    batch_size=size,
+                    note=f"{type(exc).__name__}: {str(exc)[:200]}",
+                )
+            raise
+        if not dry_run:
+            await self._checkpoint(
+                name,
+                state=state,
+                last_id=last_id,
+                count=copied,
+                skipped=skipped,
+                batch_size=size,
+                note=None,
+            )
+        return {
+            "state": state,
+            "count": copied,
+            "skipped": skipped,
+            "last_id": last_id,
+            "batches": batches,
+        }
+
+    # -- verify -------------------------------------------------------------
+    async def verify(
+        self,
+        collections: Optional[Iterable[str]] = None,
+        *,
+        sample_every: int = 1,
+        deep_per_batch: int = 5,
+    ) -> list[CollectionReport]:
+        """Tier 1 counts; tier 2 checksum merge-join over ids in batches; tier 3 a
+        round-trip deep compare of the first ``deep_per_batch`` rows of each
+        batch. ``sample_every=k`` checks every k-th batch (large collections)."""
+        reports = []
+        for name, table in self.tables_for(collections).items():
+            report = CollectionReport(name)
+            coll = self.collection(name)
+            report.mongo = await coll.count_documents({})
+            async with self.engine.connect() as conn:
+                report.postgres = (
+                    await conn.execute(select(func.count()).select_from(table))
+                ).scalar_one()
+            last_id, batch_no, size = None, 0, 500
+            seen_pg_ids: set[str] = set()
+            while True:
+                query = {"_id": {"$gt": ObjectId(last_id)}} if last_id else {}
+                documents = await coll.find(query).sort("_id", 1).limit(size).to_list()
+                if not documents:
+                    break
+                batch_no += 1
+                ids = [
+                    str(d["_id"]) for d in documents if isinstance(d["_id"], ObjectId)
+                ]
+                if not ids:
+                    break
+                last_id = ids[-1]
+                if (batch_no - 1) % sample_every:
+                    continue
+                mongo_side = {
+                    str(d["_id"]): d
+                    for d in documents
+                    if isinstance(d["_id"], ObjectId)
+                }
+                async with self.engine.connect() as conn:
+                    rows = (
+                        await conn.execute(
+                            select(table.c.id, table.c._bc_checksum, table.c.doc).where(
+                                and_(table.c.id >= ids[0], table.c.id <= ids[-1])
+                            )
+                        )
+                    ).all()
+                pg_side = {r[0]: (r[1], r[2]) for r in rows}
+                for oid, document in mongo_side.items():
+                    if oid not in pg_side:
+                        report.missing_in_postgres += 1
+                        report.samples["missing_in_postgres"][:5] = report.samples[
+                            "missing_in_postgres"
+                        ][:4] + [oid]
+                        continue
+                    if pg_side[oid][0] != checksum(canonical_document(document)):
+                        report.mismatched += 1
+                        if len(report.samples["mismatched"]) < 5:
+                            report.samples["mismatched"].append(oid)
+                for oid in pg_side:
+                    if oid not in mongo_side:
+                        report.missing_in_mongo += 1
+                        if len(report.samples["missing_in_mongo"]) < 5:
+                            report.samples["missing_in_mongo"].append(oid)
+                for oid in list(mongo_side)[:deep_per_batch]:  # tier 3
+                    if (
+                        oid in pg_side
+                        and from_canonical_document(pg_side[oid][1]) != mongo_side[oid]
+                    ):
+                        report.drifted += 1
+                        if len(report.samples["drifted"]) < 5:
+                            report.samples["drifted"].append(oid)
+            # Postgres rows beyond Mongo's id range (ids sort the same in both)
+            async with self.engine.connect() as conn:
+                extra = select(func.count()).select_from(table)
+                if last_id:
+                    extra = extra.where(table.c.id > last_id)
+                if sample_every == 1:
+                    report.missing_in_mongo += (await conn.execute(extra)).scalar_one()
+            reports.append(report)
+            logger.info(
+                "verify %s: mongo=%d postgres=%d missing_in_postgres=%d missing_in_mongo=%d mismatched=%d drifted=%d",
+                name,
+                report.mongo,
+                report.postgres,
+                report.missing_in_postgres,
+                report.missing_in_mongo,
+                report.mismatched,
+                report.drifted,
+            )
+        return reports
+
+    # -- reconcile ----------------------------------------------------------
+    async def reconcile(
+        self,
+        collections: Optional[Iterable[str]] = None,
+        *,
+        direction: str = "mongo->postgres",
+        dry_run: bool = False,
+    ) -> dict[str, dict]:
+        """Fix what ``verify`` finds. ``mongo->postgres`` (Phase 1, Mongo is
+        authoritative): copy missing/mismatched documents, overwriting even
+        ``app`` rows when the Mongo document is at least as new.
+        ``postgres->mongo``: replace Mongo documents from rows (R2/R3 fallback)."""
+        results = {}
+        for name, table in self.tables_for(collections).items():
+            report = (await self.verify([name]))[0]
+            fixed = 0
+            ids = report.samples["missing_in_postgres"] + report.samples["mismatched"]
+            # samples are capped; walk the collection for the full set when anything differs
+            if not report.clean:
+                fixed = await self._reconcile_collection(
+                    name, table, direction, dry_run
+                )
+            results[name] = {
+                "fixed": fixed,
+                "before": report.as_dict(),
+                "direction": direction,
+            }
+            del ids
+        await self._drain_outbox(direction, dry_run)
+        return results
+
+    async def _reconcile_collection(self, name, table, direction, dry_run) -> int:
+        coll = self.collection(name)
+        fixed, last_id, size = 0, None, 500
+        while True:
+            query = {"_id": {"$gt": ObjectId(last_id)}} if last_id else {}
+            documents = await coll.find(query).sort("_id", 1).limit(size).to_list()
+            documents = [d for d in documents if isinstance(d["_id"], ObjectId)]
+            if not documents:
+                break
+            last_id = str(documents[-1]["_id"])
+            async with self.engine.connect() as conn:
+                rows = (
+                    await conn.execute(
+                        select(
+                            table.c.id,
+                            table.c._bc_checksum,
+                            table.c.updated_at,
+                            table.c.doc,
+                            table.c._bc_source,
+                        ).where(
+                            and_(
+                                table.c.id >= str(documents[0]["_id"]),
+                                table.c.id <= last_id,
+                            )
+                        )
+                    )
+                ).all()
+            pg = {r[0]: r for r in rows}
+            if direction == "mongo->postgres":
+                to_write = []
+                for document in documents:
+                    oid = str(document["_id"])
+                    row = row_from_document(document)
+                    current = pg.get(oid)
+                    if current is None or current[1] != row["_bc_checksum"]:
+                        mongo_updated = timestamp_of(document.get("updated_at"))
+                        if (
+                            current is not None
+                            and current[4] == SOURCE_APP
+                            and current[2]
+                            and mongo_updated
+                            and mongo_updated < current[2]
+                        ):
+                            continue  # the application wrote this row after Mongo's copy: keep it
+                        to_write.append(row)
+                if to_write and not dry_run:
+                    stmt = pg_insert(table).values(to_write)
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["id"],
+                        set_={
+                            "doc": stmt.excluded.doc,
+                            "created_at": stmt.excluded.created_at,
+                            "updated_at": stmt.excluded.updated_at,
+                            "_bc_checksum": stmt.excluded._bc_checksum,
+                            "_bc_source": stmt.excluded._bc_source,
+                        },
+                    )
+                    async with self.engine.begin() as conn:
+                        await conn.execute(stmt)
+                fixed += len(to_write)
+                for oid in pg:  # rows Mongo no longer has
+                    if oid not in {str(d["_id"]) for d in documents}:
+                        pass  # reported by verify; deleting is a human decision (R3)
+            else:  # postgres->mongo
+                for oid, r in pg.items():
+                    document = from_canonical_document(r[3])
+                    mongo_doc = next(
+                        (d for d in documents if str(d["_id"]) == oid), None
+                    )
+                    if (
+                        mongo_doc is None
+                        or checksum(canonical_document(mongo_doc)) != r[1]
+                    ):
+                        if not dry_run:
+                            await coll.replace_one(
+                                {"_id": document["_id"]}, document, upsert=True
+                            )
+                        fixed += 1
+        if direction == "postgres->mongo":  # rows beyond Mongo's range
+            async with self.engine.connect() as conn:
+                extra = select(table.c.doc)
+                if last_id:
+                    extra = extra.where(table.c.id > last_id)
+                for (doc,) in (await conn.execute(extra)).all():
+                    document = from_canonical_document(doc)
+                    if not dry_run:
+                        await coll.replace_one(
+                            {"_id": document["_id"]}, document, upsert=True
+                        )
+                    fixed += 1
+        logger.info("reconcile %s (%s): fixed=%d", name, direction, fixed)
+        return fixed
+
+    async def _drain_outbox(self, direction: str, dry_run: bool) -> None:
+        """Mirror-write failures name a repository and ids; after a full pass
+        the affected rows agree, so mark them resolved (both stores)."""
+        now = datetime.now(timezone.utc)
+        async with self.engine.begin() as conn:
+            table = f'"{self.target.schema}"."mirror_write_failures"'
+            exists = (
+                await conn.execute(text(f"SELECT to_regclass('{table}')"))
+            ).scalar()
+            if exists is not None and not dry_run:
+                result = await conn.execute(
+                    text(
+                        f"UPDATE {table} SET resolved_at = :now WHERE resolved_at IS NULL"
+                    ),
+                    {"now": now},
+                )
+                logger.info("outbox (postgres): resolved %d", result.rowcount)
+        if not dry_run:
+            result = await self.collection("mirror_write_failures").update_many(
+                {"resolved_at": None}, {"$set": {"resolved_at": now}}
+            )
+            logger.info("outbox (mongo): resolved %d", result.modified_count)
+
+    # -- status -------------------------------------------------------------
+    async def status(self) -> dict:
+        progress = await self._progress_rows()
+        now = datetime.now(timezone.utc)
+        for row in progress.values():
+            hb = row.get("heartbeat_at")
+            row["stalled"] = bool(
+                row["state"] == STATE_RUNNING
+                and hb
+                and (now - hb).total_seconds() > STALLED_AFTER_S
+            )
+            for k in ("heartbeat_at", "updated_at"):
+                if row.get(k):
+                    row[k] = row[k].isoformat()
+        outbox = {
+            "mongo": await self.collection("mirror_write_failures").count_documents(
+                {"resolved_at": None}
+            )
+        }
+        async with self.engine.connect() as conn:
+            table = f'"{self.target.schema}"."mirror_write_failures"'
+            exists = (
+                await conn.execute(text(f"SELECT to_regclass('{table}')"))
+            ).scalar()
+            outbox["postgres"] = (
+                (
+                    await conn.execute(
+                        text(f"SELECT count(*) FROM {table} WHERE resolved_at IS NULL")
+                    )
+                ).scalar()
+                if exists
+                else None
+            )
+        return {
+            "run_id": self.run_id,
+            "schema": self.target.schema,
+            "collections": progress,
+            "outbox": outbox,
+        }

--- a/common/common/db/migrate/progress.py
+++ b/common/common/db/migrate/progress.py
@@ -1,0 +1,34 @@
+"""Checkpoints for the migration engine (one row per collection).
+
+Concrete class per service, beside its outbox row::
+
+    class MigrationProgress(Base, MigrationProgressMixin):
+        __tablename__ = "migration_progress"
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import BigInteger, Integer, Text
+from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+
+STATE_RUNNING = "running"
+STATE_PAUSED = "paused"  # stopped at a checkpoint (budget, signal); re-run continues
+STATE_DONE = "done"
+STATE_ERROR = "error"
+
+
+class MigrationProgressMixin:
+    collection: Mapped[str] = mapped_column(Text, primary_key=True)
+    last_id: Mapped[Optional[str]] = mapped_column(Text)  # highest _id copied so far
+    count: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    skipped: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    batch_size: Mapped[int] = mapped_column(Integer, nullable=False, default=200)
+    state: Mapped[str] = mapped_column(Text, nullable=False, default=STATE_PAUSED)
+    run_id: Mapped[Optional[str]] = mapped_column(Text)
+    note: Mapped[Optional[str]] = mapped_column(Text)
+    heartbeat_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))

--- a/common/tests/test_migrate_engine.py
+++ b/common/tests/test_migrate_engine.py
@@ -1,0 +1,87 @@
+"""Pure pieces of the migration engine (the database-driven parts are exercised
+by the backend suite against both stores)."""
+
+from datetime import datetime, timezone
+
+from bson import ObjectId
+from sqlalchemy import Column, MetaData, Table, Text, UniqueConstraint, Computed
+
+from common.db.base import SOURCE_BACKFILL
+from common.db.canonical import checksum, canonical_document
+from common.db.migrate.engine import (
+    MAX_BATCH,
+    MIN_BATCH,
+    adapt_batch,
+    is_object_id,
+    row_from_document,
+    spine_paths,
+    timestamp_of,
+    unique_key_paths,
+)
+
+
+def test_object_ids_are_recognised_in_both_shapes():
+    oid = ObjectId()
+    assert is_object_id(oid) and is_object_id(str(oid))
+    assert not is_object_id("not-an-id") and not is_object_id(42)
+
+
+def test_timestamps_are_read_as_beanie_stores_them():
+    aware = datetime(2026, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    assert timestamp_of(aware) == aware
+    assert timestamp_of(datetime(2026, 1, 2, 3, 4, 5)) == aware  # naive → UTC
+    assert timestamp_of("2026-01-02T03:04:05Z") == aware
+    assert timestamp_of("2026-01-02T03:04:05") == aware
+    assert timestamp_of("garbage") is None and timestamp_of(None) is None
+
+
+def test_backfilled_row_carries_the_document_checksum_and_source():
+    document = {
+        "_id": ObjectId(),
+        "title": "t",
+        "created_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+    }
+    row = row_from_document(document)
+    assert row["id"] == str(document["_id"]) and row["_bc_source"] == SOURCE_BACKFILL
+    assert row["_bc_checksum"] == checksum(canonical_document(document))
+    assert row["created_at"] == document["created_at"] and row["updated_at"] is not None
+
+
+def test_unique_keys_are_read_off_the_spine_columns():
+    metadata = MetaData(schema="app")
+    table = Table(
+        "workspace_forms",
+        metadata,
+        Column("id", Text, primary_key=True),
+        Column(
+            "workspace_id",
+            Text,
+            Computed("app.bc_text(doc -> 'workspace_id')", persisted=True),
+        ),
+        Column(
+            "form_id", Text, Computed("app.bc_text(doc -> 'form_id')", persisted=True)
+        ),
+        Column(
+            "custom_url",
+            Text,
+            Computed("app.bc_text(doc -> 'settings' -> 'custom_url')", persisted=True),
+        ),
+        UniqueConstraint("workspace_id", "form_id"),
+    )
+    assert spine_paths(table) == {
+        "workspace_id": ["workspace_id"],
+        "form_id": ["form_id"],
+        "custom_url": ["settings", "custom_url"],
+    }
+    assert unique_key_paths(table) == [[["workspace_id"], ["form_id"]]]
+
+
+def test_batch_size_adapts_within_bounds():
+    assert (
+        adapt_batch(200, seconds=25) == 100 and adapt_batch(30, seconds=25) == MIN_BATCH
+    )
+    assert (
+        adapt_batch(200, seconds=1) == 400
+        and adapt_batch(MAX_BATCH, seconds=1) == MAX_BATCH
+    )
+    assert adapt_batch(200, seconds=10) == 200

--- a/integrations/google/googleform/db/models.py
+++ b/integrations/google/googleform/db/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import Index
 
 from common.db import BaseRow, MirrorWriteFailureMixin
 from googleform.db.base import S, Base
+from common.db.migrate import MigrationProgressMixin
 
 
 class GoogleFormRow(Base, BaseRow):
@@ -45,3 +46,9 @@ class OAuthCredentialRow(Base, BaseRow):
 
 class MirrorWriteFailure(Base, MirrorWriteFailureMixin):
     __tablename__ = "mirror_write_failures"
+
+
+class MigrationProgress(Base, MigrationProgressMixin):
+    """Checkpoints of the Mongo → Postgres backfill (python -m <service>.migrate)."""
+
+    __tablename__ = "migration_progress"

--- a/integrations/google/googleform/migrate/__init__.py
+++ b/integrations/google/googleform/migrate/__init__.py
@@ -1,0 +1,1 @@
+"""`python -m googleform.migrate` — this service's Mongo → Postgres migration CLI."""

--- a/integrations/google/googleform/migrate/__main__.py
+++ b/integrations/google/googleform/migrate/__main__.py
@@ -1,0 +1,38 @@
+"""python -m googleform.migrate {preflight,backfill,verify,reconcile,status}
+
+Runs as this service's role against its schema and Mongo database
+(plans/postgres-consolidation.md §5).
+"""
+
+import os
+import sys
+
+from googleform.config import settings
+from googleform.db.base import SCHEMA, Base
+from googleform.db.models import MigrationProgress
+import googleform.db.models  # noqa: F401 — registers every row
+from common.db.migrate import Target
+from common.db.migrate.cli import main
+
+
+def _tables():
+    return {
+        mapper.class_.mongo_collection(): mapper.local_table
+        for mapper in Base.registry.mappers
+        if hasattr(mapper.class_, "mongo_collection")
+        and mapper.local_table.name
+        not in ("mirror_write_failures", "migration_progress")
+    }
+
+
+if __name__ == "__main__":
+    target = Target(
+        schema=SCHEMA,
+        tables=_tables(),
+        progress=MigrationProgress.__table__,
+        mongo_uri=settings.mongo_settings.URI,
+        mongo_db=settings.mongo_settings.DB,
+        database_url=os.environ["DATABASE_URL"],
+        application_name="bettercollected-migrate-" + SCHEMA,
+    )
+    sys.exit(main(sys.argv[1:], target, prog="python -m googleform.migrate"))

--- a/integrations/google/googleform/migrations/versions/0002_migration_progress_checkpoints.py
+++ b/integrations/google/googleform/migrations/versions/0002_migration_progress_checkpoints.py
@@ -1,0 +1,39 @@
+"""migration progress checkpoints
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-09-06 20:17:01.683211
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "migration_progress",
+        sa.Column("collection", sa.Text(), nullable=False),
+        sa.Column("last_id", sa.Text(), nullable=True),
+        sa.Column("count", sa.BigInteger(), nullable=False),
+        sa.Column("skipped", sa.BigInteger(), nullable=False),
+        sa.Column("batch_size", sa.Integer(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("run_id", sa.Text(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("heartbeat_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", postgresql.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("collection", name=op.f("pk_migration_progress")),
+        schema="google",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("migration_progress", schema="google")


### PR DESCRIPTION
Plan step 11 (`plans/postgres-consolidation.md` §5), stacked on #681. Retarget to `develop` once #681 merges. This is the last piece of R1: with it, the release can ship dual-write and the operator can backfill, verify and reconcile out of band.

## Shape

- **Engine** in `common/db/migrate/` (`Runner`, `Target`); **per-service shims** `python -m backend.migrate`, `python -m auth.migrate`, `python -m googleform.migrate`, each with its own rows, schema, Mongo database and least-privilege role. Raw pymongo + SQLAlchemy Core: **never Beanie, never decrypts**.
- Subcommands: `preflight` · `backfill` · `verify` · `reconcile` · `status` · `jobs-sweep` (backend). All idempotent, all resumable. Output is JSON; `verify`/`preflight` exit non-zero when something differs.

## No-hang guarantees (§5 table, each implemented)

| hazard | mechanism |
|---|---|
| long-lived Mongo cursor | each batch is a fresh `find({_id: {$gt: last}}).sort(_id).limit(n)` |
| long transaction / locks | one short transaction per batch; connection carries statement/lock/idle timeouts |
| slow batch | > 20 s → halve (floor 25); < 2 s → double (cap 2000) |
| whole run | `--max-minutes` → clean stop at the next checkpoint; re-run continues |
| crash mid-batch | checkpoint (`<schema>.migration_progress`) written after the batch commits |
| silent stall | heartbeat line per batch; `status` flags `stalled` after 5 min without one |
| operator error | `--dry-run`, `--collections`, refuses to start while another run heartbeats; advisory lock per schema |

## Correctness rules

- **Backfill never overwrites an application row**: `ON CONFLICT (id) DO UPDATE … WHERE _bc_source = 'backfill'`.
- **verify**: counts; per-row checksum merge-join over id ranges in *both* directions (missing-in-postgres, missing-in-mongo, mismatched); sampled round-trip row → document compared with Mongo's (type drift).
- **reconcile** `mongo->postgres` (Phase 1, Mongo authoritative) copies what differs, keeping an `app` row only when Mongo's `updated_at` is older; `postgres->mongo` is the R2/R3 fallback. After a full pass both outboxes are marked resolved (the outbox names repositories, not tables, so ids alone can't be re-copied selectively — a full pass is what makes them consistent).
- **preflight** reports duplicate unique keys (e.g. `workspace_forms(workspace_id, form_id)`) by parsing the spine columns' `GENERATED` expressions back to document paths and grouping in Mongo — the §3 "verify no dupes" gate.
- **jobs-sweep --backend postgres|temporal** re-creates every scheduled response deletion from `form_responses.expiration`; queueing locks / schedule ids make it idempotent (the §9 rollback step for jobs).

## Schema

Alembic backend `0003`, auth `0002`, google `0002`: `migration_progress` (collection PK, last_id, count, skipped, batch_size, state, run_id, note, heartbeat_at, updated_at). Applied as each service role; no autogenerate drift.

## Verification

- common: 61 passed (5 new unit tests: id shapes, Beanie timestamp forms, backfilled row values, spine → path → unique keys, batch adaptation).
- backend ×3: 322 / 322 / 324 passed — 3 new tests drive backfill → verify → reconcile against both real stores (the app-written row survives backfill and is reconciled only because Mongo is authoritative), resume from a checkpoint after `--max-batches 1` with `--batch-size 25`, dry-run writes nothing, and `postgres->mongo` restores a row Mongo lost.
- auth 7 / google 8 passed with their new row.
